### PR TITLE
feat: newsletter subscribe widget on /tools and /mcp

### DIFF
--- a/src/components/SubscribeWidget.tsx
+++ b/src/components/SubscribeWidget.tsx
@@ -1,0 +1,97 @@
+'use client'
+import { useState } from 'react'
+import { Mail, ArrowRight, Check, Loader2 } from 'lucide-react'
+
+interface SubscribeWidgetProps {
+  source?: string
+  className?: string
+  compact?: boolean
+}
+
+export default function SubscribeWidget({
+  source = 'website',
+  className = '',
+  compact = false,
+}: SubscribeWidgetProps) {
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error' | 'duplicate'>('idle')
+  const [errorMsg, setErrorMsg] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!email.trim()) return
+    setStatus('loading')
+
+    try {
+      const res = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: email.trim(), source }),
+      })
+      const data = await res.json()
+
+      if (res.ok) {
+        setStatus(data.message === 'Already subscribed' ? 'duplicate' : 'success')
+        setEmail('')
+      } else {
+        setStatus('error')
+        setErrorMsg(data.error ?? 'Something went wrong')
+      }
+    } catch {
+      setStatus('error')
+      setErrorMsg('Network error — please try again')
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className={`flex items-center gap-3 ${className}`}>
+        <div className="w-8 h-8 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">
+          <Check size={16} className="text-emerald-600" />
+        </div>
+        <p className="text-sm text-[#1A1A1A] font-medium">You&apos;re in. We&apos;ll send updates on new tools.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={className}>
+      {!compact && (
+        <div className="flex items-center gap-2 mb-3">
+          <Mail size={15} className="text-[#D4754E]" />
+          <span className="micro-label text-[#D4754E]">STAY UPDATED</span>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="your@email.com"
+          required
+          className="flex-1 min-w-0 bg-white border border-[#1A1A1A]/10 rounded-xl px-4 py-2.5 text-sm text-[#1A1A1A] placeholder:text-[#6B6560]/50 outline-none focus:border-[#D4754E] transition-colors"
+        />
+        <button
+          type="submit"
+          disabled={status === 'loading'}
+          className="flex items-center gap-1.5 px-4 py-2.5 bg-[#D4754E] hover:bg-[#C0653E] disabled:opacity-60 text-white rounded-xl text-sm font-medium transition-colors flex-shrink-0"
+        >
+          {status === 'loading' ? (
+            <Loader2 size={15} className="animate-spin" />
+          ) : (
+            <ArrowRight size={15} />
+          )}
+          {!compact && <span>Subscribe</span>}
+        </button>
+      </form>
+
+      {status === 'duplicate' && (
+        <p className="text-xs text-[#6B6560] mt-2">Already subscribed — you&apos;re good.</p>
+      )}
+      {status === 'error' && (
+        <p className="text-xs text-red-600 mt-2">{errorMsg}</p>
+      )}
+    </div>
+  )
+}

--- a/src/tests/components/SubscribeWidget.test.tsx
+++ b/src/tests/components/SubscribeWidget.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+import SubscribeWidget from '@/components/SubscribeWidget'
+
+describe('SubscribeWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders email input and subscribe button', () => {
+    render(<SubscribeWidget />)
+    expect(screen.getByPlaceholderText('your@email.com')).toBeInTheDocument()
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('shows success state after successful subscribe', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: 'Subscribed successfully' }),
+    })
+
+    render(<SubscribeWidget />)
+    await userEvent.type(screen.getByPlaceholderText('your@email.com'), 'nimit@example.com')
+    await userEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => {
+      expect(screen.getByText(/you're in/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows already-subscribed message on duplicate', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: 'Already subscribed' }),
+    })
+
+    render(<SubscribeWidget />)
+    await userEvent.type(screen.getByPlaceholderText('your@email.com'), 'existing@example.com')
+    await userEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => {
+      expect(screen.getByText(/already subscribed/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error message on API failure', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Internal server error' }),
+    })
+
+    render(<SubscribeWidget />)
+    await userEvent.type(screen.getByPlaceholderText('your@email.com'), 'test@example.com')
+    await userEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => {
+      expect(screen.getByText(/internal server error/i)).toBeInTheDocument()
+    })
+  })
+
+  it('sends correct source in request body', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: 'Subscribed successfully' }),
+    })
+
+    render(<SubscribeWidget source="mcp_page" />)
+    await userEvent.type(screen.getByPlaceholderText('your@email.com'), 'dev@example.com')
+    await userEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => {
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(body.source).toBe('mcp_page')
+      expect(body.email).toBe('dev@example.com')
+    })
+  })
+
+  it('does not submit with empty email', async () => {
+    render(<SubscribeWidget />)
+    await userEvent.click(screen.getByRole('button'))
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/views/MCPPage.tsx
+++ b/src/views/MCPPage.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useState } from 'react'
-import { Terminal, Search, Package, Zap, Clock, Copy, Check, Layers, GitBranch, Rss } from 'lucide-react'
+import { Terminal, Search, Package, Zap, Clock, Copy, Check, GitBranch, Rss } from 'lucide-react'
+import SubscribeWidget from '@/components/SubscribeWidget'
 
 const CLAUDE_DESKTOP_CONFIG = `{
   "mcpServers": {
@@ -302,7 +303,17 @@ export default function MCPPage() {
           </div>
         </div>
 
-        {/* Section 5 — Contribute CTA */}
+        {/* Section 5 — Subscribe */}
+        <div className="mb-6 p-8 bg-white rounded-2xl border border-[#1A1A1A]/5">
+          <span className="micro-label text-[#D4754E] block mb-3">STAY IN THE LOOP</span>
+          <h3 className="display-heading text-xl text-[#1A1A1A] mb-2">NEW TOOLS, WEEKLY</h3>
+          <p className="text-[#6B6560] text-sm mb-5 max-w-sm">
+            Get notified when new AI tools land in the catalog. One email per week, no noise.
+          </p>
+          <SubscribeWidget source="mcp_page" className="max-w-sm" />
+        </div>
+
+        {/* Section 6 — Contribute CTA */}
         <div className="p-8 bg-white rounded-2xl border border-[#1A1A1A]/5 text-center">
           <span className="micro-label text-[#D4754E] block mb-3">Missing a tool?</span>
           <h3 className="display-heading text-xl text-[#1A1A1A] mb-3">ADD IT VIA GITHUB PR</h3>

--- a/src/views/Tools.tsx
+++ b/src/views/Tools.tsx
@@ -7,6 +7,7 @@ import gsap from 'gsap'
 import { useTools, useToolSearch } from '@/hooks/use-tools'
 import ToolCard from '@/components/ToolCard'
 import ToolSearchBar from '@/components/ToolSearchBar'
+import SubscribeWidget from '@/components/SubscribeWidget'
 
 const categories = [
   'All',
@@ -238,6 +239,13 @@ export default function Tools() {
           >
             Open Contribution Guide
           </a>
+        </div>
+
+        {/* Subscribe */}
+        <div className="max-w-[1200px] mx-auto mt-6 p-8 bg-white rounded-2xl border border-[#1A1A1A]/5">
+          <h3 className="display-heading text-lg text-[#1A1A1A] mb-1">NEW TOOLS, WEEKLY</h3>
+          <p className="text-[#6B6560] text-sm mb-4">Get notified when new tools are added to the catalog.</p>
+          <SubscribeWidget source="tools_page" className="max-w-md" />
         </div>
       )}
     </section>


### PR DESCRIPTION
## Summary
- New `SubscribeWidget` component with email input, loading spinner, success/duplicate/error states
- Wired to existing `POST /api/subscribe` endpoint
- Added to /tools page (source: `tools_page`) and /mcp page (source: `mcp_page`)
- 6 unit tests covering all states

## Test plan
- [ ] `npm test` passes (6 new tests)
- [ ] Submit email on /tools → success message appears
- [ ] Submit same email again → "Already subscribed" message
- [ ] Invalid network → error message

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a subscription widget allowing users to subscribe for email updates on the MCP and Tools pages.
  * Widget provides real-time feedback for subscription attempts, including success, error, and duplicate subscription states.

* **Tests**
  * Added comprehensive test coverage for the subscription widget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->