### PR TITLE
feat: hosted MCP server at /api/mcp (no install required)

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,0 +1,291 @@
+/**
+ * Hosted MCP Server — agenticaiforgood.com/api/mcp
+ *
+ * Runs the Agentic AI For Good tool catalog as an MCP endpoint over
+ * HTTP Streamable transport (Web Standard). Stateless — one transport per request.
+ *
+ * Claude Desktop (~/.config/claude/claude_desktop_config.json):
+ *   {
+ *     "mcpServers": {
+ *       "agenticaiforgood": {
+ *         "type": "http",
+ *         "url": "https://agenticaiforgood.com/api/mcp"
+ *       }
+ *     }
+ *   }
+ *
+ * Claude Code (.mcp.json):
+ *   {
+ *     "mcpServers": {
+ *       "agenticaiforgood": {
+ *         "type": "http",
+ *         "url": "https://agenticaiforgood.com/api/mcp"
+ *       }
+ *     }
+ *   }
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js'
+import { createServerSupabaseClient } from '@/lib/supabase-server'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+// ─── Tool definitions ──────────────────────────────────────────────────────
+
+const TOOLS = [
+  {
+    name: 'search_tools',
+    description:
+      'Search for AI tools by use case, keyword, or technology. Finds tools matching your requirements from the Agentic AI For Good catalog.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        query: {
+          type: 'string',
+          description: 'What you want to build or what problem you need to solve',
+        },
+        category: {
+          type: 'string',
+          description:
+            'Filter by category: LLM, Vector DB, RAG, Agents, Fine-tuning, Monitoring, Data, Dev Tools',
+        },
+        limit: { type: 'number', description: 'Max results (default 10)' },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'get_tool_detail',
+    description:
+      'Get full details about a specific AI tool including description, install command, use cases, and links.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        slug: {
+          type: 'string',
+          description: 'Tool slug (e.g. "langchain", "qdrant")',
+        },
+      },
+      required: ['slug'],
+    },
+  },
+  {
+    name: 'suggest_for_stack',
+    description:
+      'Get AI tool recommendations based on your current tech stack. Paste your package.json dependencies or requirements.txt.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        stack: {
+          type: 'string',
+          description: 'Your current dependencies or tech stack description',
+        },
+        goal: {
+          type: 'string',
+          description: 'What you want to achieve (optional)',
+        },
+      },
+      required: ['stack'],
+    },
+  },
+  {
+    name: 'whats_new',
+    description: 'See AI tools recently added to the catalog.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        days: {
+          type: 'number',
+          description: 'How many days back to look (default 7)',
+        },
+      },
+    },
+  },
+]
+
+// ─── Tool handlers ─────────────────────────────────────────────────────────
+
+const SITE = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://agenticaiforgood.com'
+
+async function handleSearchTools(args: {
+  query: string
+  category?: string
+  limit?: number
+}): Promise<string> {
+  const res = await fetch(`${SITE}/api/tools/search`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      query: args.query,
+      useSemantic: true,
+      threshold: 0.2,
+      limit: args.limit ?? 10,
+      category: args.category,
+    }),
+  })
+  const data = await res.json()
+  const tools = data.results ?? []
+
+  if (tools.length === 0) {
+    return `No tools found for "${args.query}". Try broader terms or a different category.`
+  }
+
+  return tools
+    .map(
+      (t: any, i: number) =>
+        `${i + 1}. **${t.name}** (${t.category} · ${t.pricing})\n   ${t.tagline ?? t.description}${t.install_command ? `\n   Install: \`${t.install_command}\`` : ''}\n   ${SITE}/tools/${t.slug}`
+    )
+    .join('\n\n')
+}
+
+async function handleGetToolDetail(args: { slug: string }): Promise<string> {
+  const supabase = createServerSupabaseClient()
+  const { data: tool } = await supabase
+    .from('tools')
+    .select('*')
+    .eq('slug', args.slug)
+    .eq('approved', true)
+    .single()
+
+  if (!tool) {
+    return `Tool "${args.slug}" not found. Use search_tools to find the correct slug.`
+  }
+
+  const lines = [
+    `# ${tool.name}`,
+    tool.tagline ? `\n${tool.tagline}` : '',
+    `\n**Category:** ${tool.category}`,
+    `**Pricing:** ${tool.pricing}`,
+    tool.is_open_source ? '**License:** Open Source' : '',
+    tool.github_stars != null
+      ? `**GitHub Stars:** ${tool.github_stars >= 1000 ? `${(tool.github_stars / 1000).toFixed(1)}k` : tool.github_stars}`
+      : '',
+    `\n## Description\n${tool.description}`,
+    tool.install_command
+      ? `\n## Install\n\`\`\`\n${tool.install_command}\n\`\`\``
+      : '',
+    tool.github_url ? `\n**GitHub:** ${tool.github_url}` : '',
+    tool.url || tool.website_url
+      ? `**Website:** ${tool.url ?? tool.website_url}`
+      : '',
+    tool.docs_url ? `**Docs:** ${tool.docs_url}` : '',
+    `\n**Catalog page:** ${SITE}/tools/${tool.slug}`,
+  ]
+
+  return lines.filter(Boolean).join('\n')
+}
+
+async function handleSuggestForStack(args: {
+  stack: string
+  goal?: string
+}): Promise<string> {
+  const query = args.goal
+    ? `AI tools for a project using ${args.stack} with goal: ${args.goal}`
+    : `AI tools that integrate well with ${args.stack}`
+  return handleSearchTools({ query, limit: 8 })
+}
+
+async function handleWhatsNew(args: { days?: number }): Promise<string> {
+  const days = args.days ?? 7
+  const supabase = createServerSupabaseClient()
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+
+  const { data: tools } = await supabase
+    .from('tools')
+    .select('name, slug, tagline, description, category, pricing, created_at')
+    .eq('approved', true)
+    .gte('created_at', since)
+    .order('created_at', { ascending: false })
+
+  if (!tools || tools.length === 0) {
+    return `No new tools added in the last ${days} days. Check back soon!`
+  }
+
+  return [
+    `**${tools.length} tool${tools.length > 1 ? 's' : ''} added in the last ${days} days:**\n`,
+    ...tools.map(
+      (t) =>
+        `• **${t.name}** (${t.category} · ${t.pricing})\n  ${t.tagline ?? t.description}\n  ${SITE}/tools/${t.slug}`
+    ),
+  ].join('\n')
+}
+
+// ─── MCP Server factory ────────────────────────────────────────────────────
+
+function createMcpServer() {
+  const server = new Server(
+    { name: 'agentic-ai-for-good', version: '1.0.0' },
+    { capabilities: { tools: {} } }
+  )
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }))
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params
+
+    try {
+      let result: string
+
+      switch (name) {
+        case 'search_tools':
+          result = await handleSearchTools(args as any)
+          break
+        case 'get_tool_detail':
+          result = await handleGetToolDetail(args as any)
+          break
+        case 'suggest_for_stack':
+          result = await handleSuggestForStack(args as any)
+          break
+        case 'whats_new':
+          result = await handleWhatsNew(args as any)
+          break
+        default:
+          result = `Unknown tool: ${name}`
+      }
+
+      return { content: [{ type: 'text', text: result }] }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error(`[mcp] Tool ${name} error:`, msg)
+      return {
+        content: [{ type: 'text', text: `Error running ${name}: ${msg}` }],
+        isError: true,
+      }
+    }
+  })
+
+  return server
+}
+
+// ─── Route handlers ────────────────────────────────────────────────────────
+
+async function handleMcpRequest(req: Request): Promise<Response> {
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    // Stateless: no sessionIdGenerator — fresh transport per request
+    enableJsonResponse: false,
+  })
+
+  const server = createMcpServer()
+  await server.connect(transport)
+
+  const response = await transport.handleRequest(req)
+  return response
+}
+
+export async function GET(req: Request) {
+  return handleMcpRequest(req)
+}
+
+export async function POST(req: Request) {
+  return handleMcpRequest(req)
+}
+
+export async function DELETE(req: Request) {
+  return handleMcpRequest(req)
+}

--- a/src/views/MCPPage.tsx
+++ b/src/views/MCPPage.tsx
@@ -2,6 +2,15 @@
 import { useState } from 'react'
 import { Terminal, Search, Package, Zap, Clock, Copy, Check, Layers, GitBranch, Rss } from 'lucide-react'
 
+const HTTP_CONFIG = `{
+  "mcpServers": {
+    "agenticaiforgood": {
+      "type": "http",
+      "url": "https://agenticaiforgood.com/api/mcp"
+    }
+  }
+}`
+
 const CLAUDE_DESKTOP_CONFIG = `{
   "mcpServers": {
     "agenticaiforgood": {
@@ -80,7 +89,7 @@ function CopyButton({ text, className = '' }: { text: string; className?: string
 }
 
 export default function MCPPage() {
-  const [activeTab, setActiveTab] = useState<'desktop' | 'code'>('desktop')
+  const [activeTab, setActiveTab] = useState<'http' | 'desktop' | 'code'>('http')
 
   return (
     <section className="min-h-screen bg-[#F5F1EB] pt-28 pb-20 px-6 lg:px-[6vw]">
@@ -110,8 +119,18 @@ export default function MCPPage() {
           {/* Tab switcher */}
           <div className="flex border-b border-[#1A1A1A]/8">
             <button
+              onClick={() => setActiveTab('http')}
+              className={`flex-1 px-4 py-3 text-sm font-medium transition-all duration-200 ${
+                activeTab === 'http'
+                  ? 'text-[#1A1A1A] border-b-2 border-[#D4754E] bg-[#F5F1EB]/50'
+                  : 'text-[#6B6560] hover:text-[#1A1A1A] hover:bg-[#F5F1EB]/30'
+              }`}
+            >
+              HTTP ✦ Recommended
+            </button>
+            <button
               onClick={() => setActiveTab('desktop')}
-              className={`flex-1 px-6 py-3 text-sm font-medium transition-all duration-200 ${
+              className={`flex-1 px-4 py-3 text-sm font-medium transition-all duration-200 ${
                 activeTab === 'desktop'
                   ? 'text-[#1A1A1A] border-b-2 border-[#D4754E] bg-[#F5F1EB]/50'
                   : 'text-[#6B6560] hover:text-[#1A1A1A] hover:bg-[#F5F1EB]/30'
@@ -121,7 +140,7 @@ export default function MCPPage() {
             </button>
             <button
               onClick={() => setActiveTab('code')}
-              className={`flex-1 px-6 py-3 text-sm font-medium transition-all duration-200 ${
+              className={`flex-1 px-4 py-3 text-sm font-medium transition-all duration-200 ${
                 activeTab === 'code'
                   ? 'text-[#1A1A1A] border-b-2 border-[#D4754E] bg-[#F5F1EB]/50'
                   : 'text-[#6B6560] hover:text-[#1A1A1A] hover:bg-[#F5F1EB]/30'
@@ -132,7 +151,49 @@ export default function MCPPage() {
           </div>
 
           <div className="p-6">
-            {activeTab === 'desktop' ? (
+            {activeTab === 'http' ? (
+              <div className="space-y-8">
+                {/* Step 1 */}
+                <div>
+                  <div className="flex items-center gap-3 mb-3">
+                    <span className="w-6 h-6 rounded-full bg-[#D4754E] text-white text-xs font-bold flex items-center justify-center flex-shrink-0">
+                      1
+                    </span>
+                    <p className="text-sm font-medium text-[#1A1A1A]">Add the hosted server — no install required</p>
+                  </div>
+                  <p className="text-xs text-[#6B6560] mb-3 pl-9">
+                    Works in Claude Desktop, Claude Code, and any MCP client that supports HTTP transport.
+                  </p>
+                  <div className="relative rounded-xl overflow-hidden">
+                    <div className="bg-[#1A1A1A] p-4 pr-16">
+                      <pre className="text-sm text-[#E8E2D9] font-mono leading-relaxed overflow-x-auto whitespace-pre">
+                        {HTTP_CONFIG}
+                      </pre>
+                    </div>
+                    <div className="absolute top-3 right-3">
+                      <CopyButton text={HTTP_CONFIG} />
+                    </div>
+                  </div>
+                  <p className="text-xs text-[#6B6560] mt-3 pl-0">
+                    For Claude Desktop: <span className="font-mono">~/Library/Application Support/Claude/claude_desktop_config.json</span><br />
+                    For Claude Code: add to your project&apos;s <span className="font-mono">.mcp.json</span>
+                  </p>
+                </div>
+
+                {/* Step 2 */}
+                <div>
+                  <div className="flex items-center gap-3">
+                    <span className="w-6 h-6 rounded-full bg-[#D4754E] text-white text-xs font-bold flex items-center justify-center flex-shrink-0">
+                      2
+                    </span>
+                    <p className="text-sm font-medium text-[#1A1A1A]">Restart your client</p>
+                  </div>
+                  <p className="text-xs text-[#6B6560] pl-9 mt-1">
+                    The server runs on our infrastructure — always up-to-date with the latest catalog, zero maintenance on your end.
+                  </p>
+                </div>
+              </div>
+            ) : activeTab === 'desktop' ? (
               <div className="space-y-8">
                 {/* Step 1 */}
                 <div>


### PR DESCRIPTION
## Summary

- Adds `src/app/api/mcp/route.ts` — a hosted MCP server at `agenticaiforgood.com/api/mcp` using `WebStandardStreamableHTTPServerTransport` (stateless, Web Standard API compatible with Next.js App Router)
- Implements all 4 MCP tools: `search_tools`, `get_tool_detail`, `suggest_for_stack`, `whats_new`
- Updates `/mcp` install card with an **HTTP (Recommended)** tab as the first/primary option — no `npx` install needed

## Connection config (HTTP)
```json
{
  "mcpServers": {
    "agenticaiforgood": {
      "type": "http",
      "url": "https://agenticaiforgood.com/api/mcp"
    }
  }
}
```
Works in Claude Desktop, Claude Code, and any MCP client supporting HTTP transport.

## Test plan
- [ ] All 49 existing tests pass (`npm test`)
- [ ] Deploy to Vercel, confirm GET/POST to `/api/mcp` returns valid MCP JSON responses
- [ ] Add to Claude Code `.mcp.json` locally and verify `search_tools` returns results

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a hosted MCP server with four integrated tools: catalog search, tool detail retrieval, stack-based recommendations, and new tool discovery.
  * Added HTTP-based MCP configuration option accessible via new "HTTP ✦ Recommended" interface tab with step-by-step setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->