### PR TITLE
chore(tools): switch install_command to npm; drop for Python-only tools

### DIFF
--- a/tools/agent-frameworks/autogen.yaml
+++ b/tools/agent-frameworks/autogen.yaml
@@ -6,8 +6,6 @@ github_url: https://github.com/microsoft/autogen
 website_url: https://microsoft.github.io/autogen
 docs_url: https://microsoft.github.io/autogen/docs/Getting-Started
 
-install_command: pip install pyautogen
-
 category: Agents
 tags: [python, multi-agent, code-execution, microsoft, autonomous, llm]
 pricing: free

--- a/tools/agent-frameworks/crewai.yaml
+++ b/tools/agent-frameworks/crewai.yaml
@@ -6,8 +6,6 @@ github_url: https://github.com/crewAIInc/crewAI
 website_url: https://crewai.com
 docs_url: https://docs.crewai.com
 
-install_command: pip install crewai
-
 category: Agents
 tags: [python, agents, multi-agent, role-playing, orchestration, autonomous]
 pricing: freemium

--- a/tools/agent-frameworks/langchain.yaml
+++ b/tools/agent-frameworks/langchain.yaml
@@ -6,7 +6,7 @@ github_url: https://github.com/langchain-ai/langchain
 website_url: https://langchain.com
 docs_url: https://python.langchain.com/docs
 
-install_command: pip install langchain
+install_command: npm install langchain
 
 category: Agents
 tags: [python, javascript, llm, agents, rag, chains, memory]

--- a/tools/fine-tuning/axolotl.yaml
+++ b/tools/fine-tuning/axolotl.yaml
@@ -6,8 +6,6 @@ github_url: https://github.com/OpenAccess-AI-Collective/axolotl
 website_url: https://axolotl.ai
 docs_url: https://axolotl-ai-cloud.github.io/axolotl
 
-install_command: pip install axolotl
-
 category: Fine-tuning
 tags: [python, llama, mistral, qlora, lora, training, gpu, huggingface]
 pricing: free

--- a/tools/llm/groq.yaml
+++ b/tools/llm/groq.yaml
@@ -6,7 +6,7 @@ github_url: https://github.com/groq/groq-python
 website_url: https://groq.com
 docs_url: https://console.groq.com/docs
 
-install_command: pip install groq
+install_command: npm install groq-sdk
 
 category: LLM
 tags: [api, inference, llama, mixtral, fast, low-latency, openai-compatible]

--- a/tools/monitoring/helicone.yaml
+++ b/tools/monitoring/helicone.yaml
@@ -6,7 +6,7 @@ github_url: https://github.com/Helicone/helicone
 website_url: https://helicone.ai
 docs_url: https://docs.helicone.ai
 
-install_command: pip install helicone
+install_command: npm install @helicone/helicone
 
 category: Monitoring
 tags: [python, typescript, observability, caching, cost-tracking, openai-compatible, self-hostable]

--- a/tools/monitoring/langsmith.yaml
+++ b/tools/monitoring/langsmith.yaml
@@ -6,7 +6,7 @@ github_url: https://github.com/langchain-ai/langsmith-sdk
 website_url: https://smith.langchain.com
 docs_url: https://docs.smith.langchain.com
 
-install_command: pip install langsmith
+install_command: npm install langsmith
 
 category: Monitoring
 tags: [python, typescript, observability, tracing, evaluation, llm-ops, debugging]

--- a/tools/rag/llamaindex.yaml
+++ b/tools/rag/llamaindex.yaml
@@ -6,7 +6,7 @@ github_url: https://github.com/run-llama/llama_index
 website_url: https://www.llamaindex.ai
 docs_url: https://docs.llamaindex.ai
 
-install_command: pip install llama-index
+install_command: npm install llamaindex
 
 category: RAG
 tags: [python, typescript, rag, knowledge-base, data-ingestion, embeddings, agents]

--- a/tools/vector-databases/pinecone.yaml
+++ b/tools/vector-databases/pinecone.yaml
@@ -5,7 +5,7 @@ tagline: The vector database built for production
 website_url: https://pinecone.io
 docs_url: https://docs.pinecone.io
 
-install_command: pip install pinecone-client
+install_command: npm install @pinecone-database/pinecone
 
 category: Vector DB
 tags: [vector-database, embeddings, semantic-search, rag, similarity-search]

--- a/tools/vector-databases/qdrant.yaml
+++ b/tools/vector-databases/qdrant.yaml
@@ -6,7 +6,7 @@ github_url: https://github.com/qdrant/qdrant
 website_url: https://qdrant.tech
 docs_url: https://qdrant.tech/documentation
 
-install_command: pip install qdrant-client
+install_command: npm install @qdrant/js-client-rest
 
 category: Vector DB
 tags: [rust, python, typescript, vector-search, embeddings, rag, hybrid-search]

--- a/tools/vector-databases/weaviate.yaml
+++ b/tools/vector-databases/weaviate.yaml
@@ -6,7 +6,7 @@ github_url: https://github.com/weaviate/weaviate
 website_url: https://weaviate.io
 docs_url: https://weaviate.io/developers/weaviate
 
-install_command: pip install weaviate-client
+install_command: npm install weaviate-client
 
 category: Vector DB
 tags: [python, typescript, graphql, multi-modal, embeddings, rag, hybrid-search]


### PR DESCRIPTION
## Summary

Updated tool catalog install commands from `pip install ...` to `npm install ...` for tools with official npm packages. Removed `install_command` entirely for Python-only tools without npm support.

## Changes

### npm install (8 tools)
- LangChain → `npm install langchain`
- LlamaIndex → `npm install llamaindex`
- Pinecone → `npm install @pinecone-database/pinecone`
- Qdrant → `npm install @qdrant/js-client-rest`
- Weaviate → `npm install weaviate-client`
- Groq → `npm install groq-sdk`
- LangSmith → `npm install langsmith`
- Helicone → `npm install @helicone/helicone`

### install_command removed (3 tools)
- AutoGen — Python-only, no npm package
- CrewAI — Python-only, no npm package
- Axolotl — Python-only, no npm package

## Verification

- [x] All 11 tools synced to Supabase with fresh embeddings
- [x] 74 tests passing
- [x] TypeScript compilation clean


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installation instructions for LangChain, Groq, Helicone, LangSmith, LlamaIndex, Pinecone, Qdrant, and Weaviate to support JavaScript/Node.js environments
  * Removed explicit installation commands for AutoGen, CrewAI, and Axolotl

<!-- end of auto-generated comment: release notes by coderabbit.ai -->