### PR TITLE
Fix sync-to-supabase path resolution for CI

### DIFF
--- a/scripts/sync-to-supabase.ts
+++ b/scripts/sync-to-supabase.ts
@@ -87,8 +87,15 @@ async function syncTool(filePath: string): Promise<void> {
   const slug = getSlugFromPath(filePath)
   console.log(`\n→ Syncing: ${slug}`)
 
+  // Resolve path — script may run from scripts/ dir or repo root
+  let resolvedPath = path.resolve(filePath)
+  if (!fs.existsSync(resolvedPath)) {
+    // Running from scripts/ working directory — go up one level to repo root
+    resolvedPath = path.resolve('..', filePath)
+  }
+
   // Parse YAML
-  const content = fs.readFileSync(filePath, 'utf-8')
+  const content = fs.readFileSync(resolvedPath, 'utf-8')
   const tool = yaml.load(content) as ToolYaml
 
   // Build embedding text and generate embedding


### PR DESCRIPTION
## Bug

The `sync-to-supabase.ts` script has the same path resolution issue that `validate-tool.ts` had. It runs from the `scripts/` working directory in CI but receives repo-root-relative paths like `tools/agent-frameworks/hermes-agent.yaml`, causing `fs.readFileSync` to fail with ENOENT.

## Fix

Same approach as the validate-tool fix: try the path as-is first, then fall back to resolving from the parent directory (repo root).

This was the cause of the `Sync Tools to Supabase` workflow failing on merge with "Failed to sync" after PR #42 was merged.

## Test plan

- [ ] Merge this PR
- [ ] Re-run the failed Sync Tools to Supabase workflow
- [ ] Confirm Hermes Agent appears on the live site