### PR TITLE
fix: update LiveKit Agents install_command with both pip and npm

### DIFF
--- a/tools/agent-frameworks/livekit-agents.yaml
+++ b/tools/agent-frameworks/livekit-agents.yaml
@@ -5,7 +5,7 @@ tagline: Build voice, video, and physical AI agents with realtime communication
 github_url: https://github.com/livekit/agents
 website_url: https://livekit.io
 docs_url: https://docs.livekit.io/agents/
-install_command: pip install "livekit-agents[openai,silero,deepgram,cartesia,turn-detector]~=1.4"
+install_command: pip install "livekit-agents[openai,silero,deepgram,cartesia,turn-detector]~=1.4" && npm install livekit-server-sdk
 
 category: Agents
 tags: [voice-ai, realtime, webrtc, multimodal, agents, stt, tts, llm, telephony]


### PR DESCRIPTION
## Change

Per the catalog convention: use whatever the primary install method is. If both npm and pip packages exist, include both.

- **LiveKit Agents**: added both `pip install` (Python SDK) and `npm install` (JS/TS SDK)

No changes to Hermes Agent (curl script is correct) or Pipecat (pip only is correct).