### PR TITLE
fix: display multiline install commands properly

### DIFF
--- a/src/views/ToolDetail.tsx
+++ b/src/views/ToolDetail.tsx
@@ -180,7 +180,7 @@ export default function ToolDetail({ tool }: ToolDetailProps) {
                 {copied ? 'Copied' : 'Copy'}
               </button>
             </div>
-            <code className="font-mono text-sm text-[#D4754E] break-all">
+            <code className="font-mono text-sm text-[#D4754E] whitespace-pre-wrap break-all">
               {tool.install_command}
             </code>
           </div>

--- a/tools/agent-frameworks/livekit-agents.yaml
+++ b/tools/agent-frameworks/livekit-agents.yaml
@@ -5,7 +5,9 @@ tagline: Build voice, video, and physical AI agents with realtime communication
 github_url: https://github.com/livekit/agents
 website_url: https://livekit.io
 docs_url: https://docs.livekit.io/agents/
-install_command: pip install "livekit-agents[openai,silero,deepgram,cartesia,turn-detector]~=1.4" && npm install livekit-server-sdk
+install_command: |
+  pip install "livekit-agents[openai,silero,deepgram,cartesia,turn-detector]~=1.4"
+  npm install livekit-server-sdk
 
 category: Agents
 tags: [voice-ai, realtime, webrtc, multimodal, agents, stt, tts, llm, telephony]


### PR DESCRIPTION
## Changes

Two fixes:

1. **LiveKit Agents YAML**: Split pip and npm install onto separate lines instead of joining with `&&`
2. **ToolDetail.tsx**: Added `whitespace-pre-wrap` so newlines in `install_command` render as separate lines on the tool detail page

Before: `pip install ... && npm install ...` (looked like one combined command)
After: Each install command on its own line