### PR TITLE
Add PydanticAI, smolagents, DSPy, and Agno to catalog

### DIFF
--- a/tools/agent-frameworks/agno.yaml
+++ b/tools/agent-frameworks/agno.yaml
@@ -1,0 +1,27 @@
+name: Agno
+description: "Agno is a full-stack agent platform that lets you build, run, and manage agentic software at scale. It provides a framework for creating agents with memory, knowledge, tools, and guardrails, a stateless runtime for serving them as production APIs via FastAPI, and a control plane (AgentOS) for monitoring and management."
+tagline: "Build, run, and manage agentic software at scale"
+github_url: https://github.com/agno-agi/agno
+website_url: https://agno.com
+docs_url: https://docs.agno.com
+install_command: "pip install agno"
+category: Agents
+tags:
+  - agent-framework
+  - multi-agent
+  - llm
+  - ai-agents
+  - python
+  - production
+  - tools
+  - memory
+  - knowledge
+  - rag
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Building production-grade AI agent systems is complex, requiring memory, tool integration, guardrails, and scalable serving. Agno solves this by providing a unified framework to build stateful agents with memory and knowledge, serve them as production APIs via a FastAPI runtime, and monitor them through AgentOS."
+use_cases:
+  - "Build autonomous AI agents with memory, knowledge, and tool use"
+  - "Create multi-agent teams that collaborate to solve complex tasks"
+  - "Serve agents as production-ready APIs with stateless FastAPI runtime"

--- a/tools/agent-frameworks/dspy.yaml
+++ b/tools/agent-frameworks/dspy.yaml
@@ -1,0 +1,23 @@
+name: DSPy
+description: "DSPy is a declarative framework for building modular AI software. It allows you to iterate fast on structured code rather than brittle strings, and offers algorithms that compile AI programs into effective prompts and weights for your language models."
+tagline: "Programming, not prompting, language models"
+github_url: https://github.com/stanfordnlp/dspy
+website_url: https://dspy.ai
+docs_url: https://dspy.ai/learn/
+install_command: "pip install -U dspy"
+category: Agents
+tags:
+  - llm-programming
+  - prompt-optimization
+  - rag
+  - agents
+  - declarative-ai
+  - nlp
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Building reliable AI systems with LLMs typically requires tedious manual prompt engineering that breaks when models or tasks change. DSPy replaces brittle prompt strings with structured, declarative modules that can be automatically optimized and compiled, making AI software more maintainable, portable, and effective across different models."
+use_cases:
+  - "Building optimized RAG pipelines with automatic prompt tuning"
+  - "Creating multi-step agent loops with typed input/output signatures"
+  - "Compiling and optimizing LM programs across different model providers"

--- a/tools/agent-frameworks/pydantic-ai.yaml
+++ b/tools/agent-frameworks/pydantic-ai.yaml
@@ -1,0 +1,24 @@
+name: PydanticAI
+description: "Python agent framework by the Pydantic team that brings type-safe, production-grade GenAI application development with model-agnostic support, powerful evals, seamless Logfire observability, and composable capabilities."
+tagline: "AI Agent Framework, the Pydantic way"
+github_url: https://github.com/pydantic/pydantic-ai
+website_url: https://pydantic.dev/docs/ai/overview/
+docs_url: https://pydantic.dev/docs/ai/overview/install/
+install_command: "pip install pydantic-ai"
+category: Agents
+tags:
+  - ai-agent
+  - python
+  - pydantic
+  - llm
+  - type-safe
+  - model-agnostic
+  - observability
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Building production-grade GenAI agent applications is complex and error-prone; existing Python agent frameworks lack the type safety, composability, and observability needed for reliable deployment at scale."
+use_cases:
+  - "Building multi-model AI agents with type-safe tool calling and dependency injection"
+  - "Creating production agent workflows with built-in evals and Logfire observability"
+  - "Developing model-agnostic agent systems that seamlessly swap between OpenAI, Anthropic, Gemini, and other LLM providers"

--- a/tools/agent-frameworks/smolagents.yaml
+++ b/tools/agent-frameworks/smolagents.yaml
@@ -1,0 +1,23 @@
+name: smolagents
+description: "A barebones open-source Python library by Hugging Face for building and running AI agents that think in code. It provides first-class CodeAgent support, multi-agent orchestration, tool integrations, and works with any LLM backend in just a few lines of code."
+tagline: "Build agents that think in code with a few lines of Python"
+github_url: https://github.com/huggingface/smolagents
+website_url: https://huggingface.co/docs/smolagents
+docs_url: https://huggingface.co/docs/smolagents/en/index
+install_command: "pip install smolagents"
+category: Agents
+tags:
+  - agents
+  - code-agent
+  - multi-agent
+  - llm
+  - huggingface
+  - rag
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Building AI agents requires complex orchestration code and heavy abstractions; smolagents provides a minimal, simple framework with a core of roughly 1,000 lines to create agents that reason and act via code execution with any LLM, lowering the barrier to building capable autonomous systems."
+use_cases:
+  - "Building autonomous code agents for task automation and data analysis"
+  - "Orchestrating multi-agent systems for complex workflow coordination"
+  - "Implementing agentic RAG pipelines for intelligent knowledge retrieval"


### PR DESCRIPTION
## Tools Added\n\n### 1. PydanticAI\n- **Category:** Agents\n- **Repo:** github.com/pydantic/pydantic-ai\n- **License:** MIT | **Pricing:** Free | **Open Source:** Yes\n- Python agent framework by the Pydantic team with type-safe, model-agnostic support, built-in evals, and Logfire observability.\n\n### 2. smolagents\n- **Category:** Agents\n- **Repo:** github.com/huggingface/smolagents\n- **License:** Apache-2.0 | **Pricing:** Free | **Open Source:** Yes\n- Barebones Python library by Hugging Face for building AI agents that think in code, with CodeAgent support and multi-agent orchestration.\n\n### 3. DSPy\n- **Category:** Agents\n- **Repo:** github.com/stanfordnlp/dspy\n- **License:** MIT | **Pricing:** Free | **Open Source:** Yes\n- Declarative framework for building modular AI software. Replaces brittle prompt strings with structured, optimizable modules.\n\n### 4. Agno\n- **Category:** Agents\n- **Repo:** github.com/agno-agi/agno\n- **License:** Apache-2.0 | **Pricing:** Freemium | **Open Source:** Yes\n- Full-stack agent platform to build, run, and manage agentic software at scale. Formerly PhiData.\n\n## Validation\n\n- [x] All four YAML files pass `npx tsx scripts/validate-tool.ts`\n- [x] Required fields: name, description, problem_solved (>50 chars), use_cases (>3 items), github_url\n- [x] Install commands follow convention\n- [x] Only `tools/` files modified\n