### PR TITLE
Add Langfuse, AgentOps, and Ollama to catalog

### DIFF
--- a/tools/llm/ollama.yaml
+++ b/tools/llm/ollama.yaml
@@ -1,0 +1,24 @@
+name: Ollama
+description: "Ollama is the easiest way to run large language models locally. It provides a simple CLI and API to download, run, and interact with open-source models like Llama, Gemma, DeepSeek, Qwen, and Mistral on your own machine with full data privacy and no cloud dependency."
+tagline: "Run open-source LLMs locally with one command"
+github_url: https://github.com/ollama/ollama
+website_url: https://ollama.com
+docs_url: https://docs.ollama.com
+install_command: "curl -fsSL https://ollama.com/install.sh | sh"
+category: LLM
+tags:
+  - llm
+  - local-ai
+  - inference
+  - open-source
+  - dev-tools
+  - privacy
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Running large language models often requires cloud services that raise privacy, cost, and dependency concerns. Ollama eliminates these barriers by letting users run powerful open models entirely on their own hardware with a single install command and a simple API."
+use_cases:
+  - "Run open-source LLMs locally for private, offline AI applications"
+  - "Prototype and develop AI-powered features without cloud API costs"
+  - "Deploy LLM inference in air-gapped or data-sensitive environments"
+  - "Integrate local model serving into developer workflows and coding assistants"

--- a/tools/monitoring/agentops.yaml
+++ b/tools/monitoring/agentops.yaml
@@ -1,0 +1,23 @@
+name: AgentOps
+description: "Python SDK and developer platform for AI agent monitoring, observability, and debugging. Provides session replay, time-travel debugging, LLM cost tracking across 400+ models, multi-agent interaction visualization, and comprehensive audit trails from prototype to production."
+tagline: "Trace, debug, and deploy reliable AI agents"
+github_url: https://github.com/AgentOps-AI/agentops
+website_url: https://www.agentops.ai
+docs_url: https://docs.agentops.ai
+install_command: "pip install agentops"
+category: Monitoring
+tags:
+  - observability
+  - agent-monitoring
+  - llm-cost-tracking
+  - debugging
+  - session-replay
+  - multi-agent
+pricing: freemium
+is_open_source: true
+license: MIT
+problem_solved: "AI agents are notoriously difficult to debug and monitor in production. Developers lack visibility into agent decision-making, LLM costs spiral out of control, and multi-agent interactions become opaque black boxes that are impossible to audit or troubleshoot."
+use_cases:
+  - "Debug agent failures with session replay and time-travel debugging"
+  - "Track and optimize LLM spending across multiple agents and models"
+  - "Monitor multi-agent interactions and detect prompt injection attacks in production"

--- a/tools/monitoring/langfuse.yaml
+++ b/tools/monitoring/langfuse.yaml
@@ -1,0 +1,23 @@
+name: Langfuse
+description: "Langfuse is an open-source LLM engineering platform that provides comprehensive observability, evaluation, and prompt management for LLM applications and AI agents. It offers hierarchical tracing for every LLM call and tool invocation, cost and latency tracking, LLM-as-a-judge evaluation, human annotation workflows, prompt versioning, and structured experiments."
+tagline: "Open-source LLM observability and engineering platform"
+github_url: https://github.com/langfuse/langfuse
+website_url: https://langfuse.com
+docs_url: https://langfuse.com/docs
+install_command: "pip install langfuse"
+category: Monitoring
+tags:
+  - observability
+  - llm
+  - tracing
+  - evaluation
+  - prompt-management
+  - opentelemetry
+pricing: freemium
+is_open_source: true
+license: MIT
+problem_solved: "LLM applications and AI agents are complex, non-deterministic, and difficult to debug in production. Teams lack visibility into agent behavior, cannot track costs and latency across models, and have no systematic way to evaluate output quality or safely iterate on prompts."
+use_cases:
+  - "Trace and debug LLM agent workflows with hierarchical spans and OpenTelemetry support"
+  - "Track token usage, cost, and latency across models and providers in production"
+  - "Evaluate LLM outputs using automated LLM-as-a-judge, heuristic, or human annotation workflows"


### PR DESCRIPTION
## Tools Added\n\n### 1. Langfuse\n- **Category:** Monitoring\n- **Repo:** github.com/langfuse/langfuse\n- **License:** MIT | **Pricing:** Freemium | **Open Source:** Yes\n- Open-source LLM engineering platform for observability, evaluation, and prompt management. Supports OpenTelemetry and 50+ framework integrations.\n\n### 2. AgentOps\n- **Category:** Monitoring\n- **Repo:** github.com/AgentOps-AI/agentops\n- **License:** MIT | **Pricing:** Freemium | **Open Source:** Yes\n- Python SDK for AI agent monitoring with session replay, time-travel debugging, and LLM cost tracking across 400+ models.\n\n### 3. Ollama\n- **Category:** LLM\n- **Repo:** github.com/ollama/ollama\n- **License:** MIT | **Pricing:** Free | **Open Source:** Yes\n- Run open-source LLMs locally with one command. Supports Llama, Gemma, DeepSeek, Qwen, Mistral, and more.\n\n## Validation\n\n- [x] All three YAML files pass `npx tsx scripts/validate-tool.ts`\n- [x] Required fields present and valid\n- [x] Install commands follow convention\n- [x] Only `tools/` files modified\n