### PR TITLE
Add OpenHarness to catalog

### DIFF
--- a/tools/agent-frameworks/openharness.yaml
+++ b/tools/agent-frameworks/openharness.yaml
@@ -1,0 +1,26 @@
+name: OpenHarness
+description: "Open-source Python agent infrastructure providing tool-use, skills, memory, permissions, and multi-agent coordination. Includes 43+ built-in tools, a plugin ecosystem compatible with claude-code plugins, MCP protocol support, and ohmo, a personal AI agent that operates through Feishu, Slack, Telegram, and Discord channels."
+tagline: "Open agent harness with built-in personal agent ohmo"
+github_url: https://github.com/HKUDS/OpenHarness
+website_url: https://github.com/HKUDS/OpenHarness
+docs_url: https://github.com/HKUDS/OpenHarness/tree/main/docs
+install_command: "pip install openharness-ai"
+category: Agents
+tags:
+  - agent-framework
+  - multi-agent
+  - tool-use
+  - mcp
+  - cli
+  - llm-agent
+  - personal-assistant
+  - plugin-system
+  - python
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Building production-ready AI agents requires complex infrastructure: tool execution, permission management, memory, multi-agent coordination, and provider integration that most projects rebuild from scratch. OpenHarness provides this complete agent harness layer so developers can focus on their domain rather than reinventing agent infrastructure."
+use_cases:
+  - "Coding assistant that reads code, patches files, and runs tests locally via CLI"
+  - "Personal AI agent operating through chat platforms like Slack, Telegram, Discord, and Feishu"
+  - "Multi-agent task delegation with subagent spawning and background execution"


### PR DESCRIPTION
## Tool Added\n\n### OpenHarness\n- **Category:** Agents\n- **Repo:** github.com/HKUDS/OpenHarness\n- **License:** MIT | **Pricing:** Free | **Open Source:** Yes\n- Open-source Python agent infrastructure with tool-use, skills, memory, permissions, multi-agent coordination, MCP support, and 43+ built-in tools. Includes ohmo, a personal AI agent for Feishu/Slack/Telegram/Discord.\n\n## Validation\n\n- [x] YAML file passes `npx tsx scripts/validate-tool.ts`\n- [x] Required fields: name, description, problem_solved (>50 chars), use_cases (>3 items), github_url\n- [x] Install command follows convention (`pip install openharness-ai`)\n- [x] Only `tools/` files modified\n