### PR TITLE
Add Marvin, Atomic Agents, and PocketFlow to catalog

### DIFF
--- a/tools/agent-frameworks/atomic-agents.yaml
+++ b/tools/agent-frameworks/atomic-agents.yaml
@@ -1,0 +1,30 @@
+name: Atomic Agents
+description: A lightweight, modular AI agent framework built around the concept of atomicity, enabling developers to compose agentic AI pipelines from single-purpose, reusable, and predictable components using Pydantic and Instructor for structured outputs.
+tagline: Build AI applications like LEGO blocks — atomic, composable, predictable
+
+github_url: https://github.com/BrainBlend-AI/atomic-agents
+website_url: https://brainblend-ai.github.io/atomic-agents/
+docs_url: https://brainblend-ai.github.io/atomic-agents/
+
+category: Agents
+tags: [python, ai-agents, modular, pydantic, instructor, structured-output, agentic-workflows, composability, lightweight]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install atomic-agents
+
+problem_solved: |
+  Most AI agent frameworks are monolithic and opinionated, forcing developers into specific
+  patterns and making it hard to customize, test, or replace individual components. Atomic
+  Agents takes the opposite approach — each component (agent, tool, context provider) is
+  atomic: single-purpose, reusable, composable, and predictable. Built on Instructor and
+  Pydantic, it enables developers to build agentic pipelines using familiar software
+  engineering principles like modularity and separation of concerns.
+
+use_cases:
+  - Build multi-step agent pipelines by composing atomic single-purpose components into complex workflows
+  - Create tool-augmented agents that call external APIs and process structured responses with type safety
+  - Design context-aware agents that dynamically inject relevant information into system prompts
+  - Replace or swap individual agent components without rewriting entire pipelines
+  - Prototype and iterate on AI applications quickly using modular building blocks

--- a/tools/agent-frameworks/marvin.yaml
+++ b/tools/agent-frameworks/marvin.yaml
@@ -1,0 +1,30 @@
+name: Marvin
+description: A Python framework for producing structured outputs and building agentic AI workflows. It provides an intuitive API for defining tasks and delegating work to LLMs, with support for type-safe results, multi-agent orchestration, and thread management.
+tagline: Type-safe AI functions and agents in pure Python
+
+github_url: https://github.com/PrefectHQ/marvin
+website_url: https://askmarvin.ai
+docs_url: https://askmarvin.ai
+
+category: Agents
+tags: [python, ai-agent, llm, structured-output, agentic-workflows, pydantic, openai, task-orchestration, multi-agent, prefect]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install marvin
+
+problem_solved: |
+  Integrating LLMs into production Python applications is hard because LLM outputs are
+  unstructured, unpredictable, and difficult to validate. Marvin solves this by providing
+  type-safe, structured outputs from AI models using Pydantic, and an intuitive framework
+  for building multi-step agentic workflows. It eliminates manual prompt engineering for
+  consistent data formats and provides observability and control over complex AI agent
+  coordination.
+
+use_cases:
+  - Cast, classify, extract, and generate structured data from any inputs using LLMs with type safety
+  - Create specialized AI agents with distinct skills and personalities for task-specific problem solving
+  - Orchestrate multi-agent workflows by composing discrete observable tasks into threads
+  - Build AI-powered Slack bots and conversational assistants with structured conversation management
+  - Generate validated Pydantic models from unstructured text for reliable downstream processing

--- a/tools/agent-frameworks/pocketflow.yaml
+++ b/tools/agent-frameworks/pocketflow.yaml
@@ -1,0 +1,30 @@
+name: PocketFlow
+description: A 100-line minimalist LLM framework for building AI agents, workflows, and RAG pipelines with zero dependencies and zero vendor lock-in. Its core abstraction is a Graph and SharedStore model where Nodes handle tasks, Flows connect nodes via labeled Actions, and a SharedStore manages inter-node communication.
+tagline: The 100-line LLM framework — minimal, composable, zero lock-in
+
+github_url: https://github.com/The-Pocket/PocketFlow
+website_url: https://the-pocket.github.io/PocketFlow/
+docs_url: https://the-pocket.github.io/PocketFlow/
+
+category: Agents
+tags: [python, llm-framework, minimal, agents, rag, workflow, agentic-ai, graph, zero-dependency, composable]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install pocketflow
+
+problem_solved: |
+  Existing LLM frameworks like LangChain and CrewAI are bloated with tens of thousands of
+  lines, heavy dependencies, and vendor-specific wrappers that create lock-in and maintenance
+  burdens. PocketFlow provides just the essential graph abstraction (Node, Flow, SharedStore)
+  in roughly 100 lines of zero-dependency Python, eliminating framework bloat while still
+  supporting advanced patterns like multi-agent orchestration, RAG pipelines, and conditional
+  workflows.
+
+use_cases:
+  - Build autonomous AI agents that make decisions, use tools, and loop until tasks are complete
+  - Implement RAG pipelines that integrate document retrieval with LLM generation for grounded Q&A
+  - Orchestrate multiple specialized AI agents that collaborate on complex multi-step tasks
+  - Create conditional workflow pipelines that branch and route based on LLM outputs
+  - Rapidly prototype LLM applications using the minimal framework without vendor lock-in


### PR DESCRIPTION
## Tools Added

### 1. Marvin (Agents)
- **GitHub:** https://github.com/PrefectHQ/marvin
- **Website:** https://askmarvin.ai
- **License:** Apache-2.0
- **Install:** `pip install marvin`
- Python framework for producing structured outputs and building agentic AI workflows with type-safe results, multi-agent orchestration, and thread management.

### 2. Atomic Agents (Agents)
- **GitHub:** https://github.com/BrainBlend-AI/atomic-agents
- **Website:** https://brainblend-ai.github.io/atomic-agents/
- **License:** MIT
- **Install:** `pip install atomic-agents`
- Lightweight modular AI agent framework built around atomicity — single-purpose, reusable, composable components using Pydantic and Instructor for structured outputs.

### 3. PocketFlow (Agents)
- **GitHub:** https://github.com/The-Pocket/PocketFlow
- **Website:** https://the-pocket.github.io/PocketFlow/
- **License:** MIT
- **Install:** `pip install pocketflow`
- 100-line minimalist LLM framework for building AI agents, workflows, and RAG pipelines with zero dependencies and zero vendor lock-in.

## Validation Checklist

- [x] YAML files created in correct category directory (`agent-frameworks`)
- [x] Local validation passes (`npx tsx validate-tool.ts` ✅ for all 3)
- [x] Required fields present: name, description (20-500 chars), problem_solved (50+ chars), use_cases (3+ items, 10+ chars each), github_url
- [x] Install commands verified on PyPI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new AI agent frameworks to the registry: Atomic Agents (composable pipelines with type safety), Marvin (structured outputs with multi-agent orchestration), and PocketFlow (minimal-dependency framework supporting agents and RAG workflows).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->