### PR TITLE
Add Continue, PocketFlow, and Haystack to catalog

### DIFF
--- a/tools/agent-frameworks/continue.yaml
+++ b/tools/agent-frameworks/continue.yaml
@@ -1,0 +1,23 @@
+name: Continue
+github_url: https://github.com/continuedev/continue
+website_url: https://continue.dev
+docs_url: https://docs.continue.dev
+install_command: npm i -g @continuedev/cli
+tagline: "Source-controlled AI checks, enforceable in CI"
+description: "Continue is an open-source AI code assistant that runs source-controlled AI checks on every pull request. It includes a terminal-based coding agent and IDE extensions for VS Code and JetBrains, enabling automated code review, inline completions, and chat-driven development."
+problem_solved: "Ensuring consistent code quality and security standards across pull requests by automating AI-powered code review checks that are version-controlled alongside your codebase, replacing subjective and inconsistent manual review processes."
+use_cases:
+  - "Run AI-powered quality and security checks on every pull request as GitHub status checks"
+  - "Use the terminal coding agent (cn CLI) for multi-step code generation and editing tasks"
+  - "Integrate AI autocomplete, chat, and edit capabilities directly in VS Code or JetBrains IDEs"
+tags:
+  - ai-code-review
+  - pull-request-automation
+  - ci-cd
+  - coding-agent
+  - developer-tools
+  - ide-extension
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+category: Agents

--- a/tools/agent-frameworks/haystack.yaml
+++ b/tools/agent-frameworks/haystack.yaml
@@ -1,0 +1,28 @@
+name: Haystack
+github_url: https://github.com/deepset-ai/haystack
+website_url: https://haystack.deepset.ai
+docs_url: https://docs.haystack.deepset.ai/docs
+install_command: pip install haystack-ai
+tagline: "The open source AI framework for production-ready agents, RAG & context engineering"
+description: "Open-source AI orchestration framework for building context-engineered, production-ready LLM applications. Design modular pipelines and agent workflows with explicit control over retrieval, routing, memory, and generation."
+problem_solved: "Building production-ready LLM applications requires complex orchestration of retrieval, reasoning, memory, and tool use with full visibility and control over each step—something raw LLM APIs alone do not provide."
+use_cases:
+  - "Advanced RAG pipelines with hybrid retrieval and self-correction loops"
+  - "Production-ready AI agents with standardized tool calling and multi-step reasoning"
+  - "Multimodal AI applications spanning text, image, and audio processing"
+  - "Semantic search and information retrieval systems"
+  - "Conversational AI systems with context engineering"
+tags:
+  - python
+  - llm
+  - rag
+  - agents
+  - nlp
+  - ai-orchestration
+  - semantic-search
+  - generative-ai
+  - multimodal
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+category: Agents

--- a/tools/agent-frameworks/pocketflow.yaml
+++ b/tools/agent-frameworks/pocketflow.yaml
@@ -1,0 +1,25 @@
+name: PocketFlow
+github_url: https://github.com/The-Pocket/PocketFlow
+website_url: https://the-pocket.github.io/PocketFlow/
+docs_url: https://the-pocket.github.io/PocketFlow/
+install_command: pip install pocketflow
+tagline: "100-line LLM framework. Let Agents build Agents!"
+description: "A 100-line minimalist LLM framework for Agents, Task Decomposition, RAG, and more. Lightweight with zero dependencies and no vendor lock-in, yet expressive enough for complex LLM applications."
+problem_solved: "Building LLM-powered agent applications often requires heavy, opinionated frameworks with vendor lock-in. PocketFlow provides a minimal graph abstraction (just 100 lines) that lets developers compose nodes and flows to build agents, workflows, and RAG systems without framework bloat."
+use_cases:
+  - "Building autonomous AI agents that make decisions and take actions based on LLM reasoning"
+  - "Creating multi-step LLM workflows and pipelines for task decomposition and orchestration"
+  - "Implementing RAG (Retrieval-Augmented Generation) systems with custom retrieval and generation"
+tags:
+  - agentic-ai
+  - agents
+  - ai-framework
+  - llm-framework
+  - flow-based-programming
+  - workflow-orchestration
+  - retrieval-augmented-generation
+  - python
+pricing: free
+is_open_source: true
+license: MIT
+category: Agents


### PR DESCRIPTION
## Adding 3 tools to the catalog

### Continue
- **Category:** Agents
- **GitHub:** https://github.com/continuedev/continue (~32.8k stars)
- **Website:** https://continue.dev
- **Tagline:** Source-controlled AI checks, enforceable in CI
- **Use cases:** AI-powered PR checks, terminal coding agent, IDE extensions for VS Code/JetBrains
- **Pricing:** Freemium (Apache-2.0)

### PocketFlow
- **Category:** Agents
- **GitHub:** https://github.com/The-Pocket/PocketFlow (~10.5k stars)
- **Website:** https://the-pocket.github.io/PocketFlow/
- **Tagline:** 100-line LLM framework. Let Agents build Agents!
- **Use cases:** Autonomous AI agents, multi-step LLM workflows, RAG systems
- **Pricing:** Free (MIT)

### Haystack
- **Category:** Agents
- **GitHub:** https://github.com/deepset-ai/haystack (~25k stars)
- **Website:** https://haystack.deepset.ai
- **Tagline:** The open source AI framework for production-ready agents, RAG & context engineering
- **Use cases:** Advanced RAG pipelines, production AI agents, multimodal AI, semantic search, conversational AI
- **Pricing:** Freemium (Apache-2.0)

### Validation checklist
- [x] YAML files created in correct category directory (`tools/agent-frameworks/`)
- [x] Local validation passes for all 3 tools (`npx tsx scripts/validate-tool.ts`)
- [x] Branch follows naming convention: `feat/add-continue-pocketflow-haystack`
- [x] Only `tools/` files modified in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended agent framework ecosystem with three new integrations: Continue enables IDE-integrated AI-powered chat and code editing capabilities for developers. Haystack provides an enterprise-grade AI framework for structured data pipelines and processing. PocketFlow offers lightweight workflow automation and orchestration tools. All framework integrations include installation instructions, documented use cases, and comprehensive configuration metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->