### PR TITLE
Add Letta, Opik, and Promptfoo to catalog

### DIFF
--- a/tools/agent-frameworks/letta.yaml
+++ b/tools/agent-frameworks/letta.yaml
@@ -1,0 +1,27 @@
+name: Letta
+tagline: Stateful AI agents with persistent long-term memory
+description: "Letta is the platform for building stateful agents: AI with advanced memory that can learn and self-improve over time. Formerly MemGPT, it provides a framework for creating LLM agents with persistent long-term memory that can learn and adapt from experience."
+problem_solved: "LLM agents are inherently stateless and forget context between interactions. Letta solves this by providing a memory-first agent architecture where agents maintain persistent state, form memories about users and the world, and continuously improve over time — enabling truly personalized, long-lived AI agents."
+use_cases:
+  - "Building stateful conversational AI agents with persistent long-term memory"
+  - "Creating personalized coding assistants that learn coding conventions over time"
+  - "Developing autonomous digital employees for research, email, and calendar management"
+  - "Deploying AI companions with customized personalities and evolving memories"
+  - "Building multi-step agentic workflows with memory-augmented LLM agents"
+github_url: https://github.com/letta-ai/letta
+website_url: https://www.letta.com
+docs_url: https://docs.letta.com
+install_command: pip install letta
+category: Agents
+tags:
+  - ai
+  - ai-agents
+  - llm
+  - llm-agent
+  - memory
+  - stateful-agents
+  - agent-framework
+  - memgpt
+pricing: freemium
+is_open_source: true
+license: Apache-2.0

--- a/tools/monitoring/opik.yaml
+++ b/tools/monitoring/opik.yaml
@@ -1,0 +1,29 @@
+name: Opik
+tagline: Debug, evaluate, and monitor your LLM applications
+description: "Debug, evaluate, and monitor your LLM applications, RAG systems, and agentic workflows with comprehensive tracing, automated evaluations, and production-ready dashboards."
+problem_solved: "LLM applications and agentic workflows are difficult to debug, evaluate, and monitor in production. Opik solves this by providing comprehensive tracing, automated LLM-as-a-judge evaluations, prompt optimization, and production-ready monitoring dashboards — giving developers end-to-end observability from prototype to production."
+use_cases:
+  - "Trace and debug LLM calls and agentic workflows during development and in production with detailed context and spans"
+  - "Automate LLM application evaluation using datasets, experiments, and LLM-as-a-judge metrics for hallucination detection and RAG assessment"
+  - "Monitor production AI systems with dashboards tracking feedback scores, token usage, costs, latency, and online evaluation rules"
+  - "Optimize prompts and agent configurations using built-in optimization algorithms and the Agent Playground"
+  - "Integrate CI/CD testing for LLM applications via PyTest integration to catch regressions before deployment"
+github_url: https://github.com/comet-ml/opik
+website_url: https://www.comet.com/site/products/opik/
+docs_url: https://www.comet.com/docs/opik/
+install_command: pip install opik
+category: Monitoring
+tags:
+  - llm
+  - llm-evaluation
+  - llm-observability
+  - monitoring
+  - tracing
+  - evaluation
+  - prompt-engineering
+  - open-source
+  - llmops
+  - rag
+pricing: freemium
+is_open_source: true
+license: Apache-2.0

--- a/tools/monitoring/promptfoo.yaml
+++ b/tools/monitoring/promptfoo.yaml
@@ -1,0 +1,31 @@
+name: Promptfoo
+tagline: Test, evaluate, and red-team LLM applications
+description: "Promptfoo is an open-source CLI and library for evaluating and red-teaming LLM apps. It enables test-driven LLM development with automated evaluations, side-by-side model comparisons, vulnerability scanning, and CI/CD integration to help teams ship secure, reliable AI applications."
+problem_solved: "Developers lack systematic tools to evaluate, test, and secure LLM prompts and applications. Promptfoo eliminates trial-and-error prompt development by providing automated evaluations, red teaming for vulnerability detection, and side-by-side model comparisons, enabling data-driven decisions about LLM quality and security."
+use_cases:
+  - "Automated evaluation and benchmarking of LLM prompt quality across multiple models including OpenAI, Anthropic, Azure, Bedrock, and Ollama"
+  - "Red teaming and vulnerability scanning of LLM applications to detect prompt injections, jailbreaks, data leaks, and other security risks"
+  - "CI/CD integration for continuous LLM eval and security testing in development workflows using GitHub Actions and other pipelines"
+  - "Side-by-side comparison of different LLM models and prompt variations to identify the best-performing configuration"
+  - "Code scanning for LLM-related security and compliance issues in pull requests"
+github_url: https://github.com/promptfoo/promptfoo
+website_url: https://promptfoo.dev
+docs_url: https://promptfoo.dev/docs/intro/
+install_command: |
+  npm install -g promptfoo
+  pip install promptfoo
+category: Monitoring
+tags:
+  - llm
+  - evaluation
+  - red-teaming
+  - prompt-testing
+  - vulnerability-scanning
+  - ci-cd
+  - llm-evaluation
+  - prompt-engineering
+  - rag
+  - monitoring
+pricing: freemium
+is_open_source: true
+license: MIT


### PR DESCRIPTION
## Add Letta, Opik, and Promptfoo to catalog

### Letta (Agents → agent-frameworks)
- **GitHub**: https://github.com/letta-ai/letta (22.3k stars)
- **Website**: https://www.letta.com
- **License**: Apache-2.0
- **Install**: `pip install letta`
- Stateful AI agents with persistent long-term memory (formerly MemGPT)

### Opik (Monitoring → monitoring)
- **GitHub**: https://github.com/comet-ml/opik (19.1k stars)
- **Website**: https://www.comet.com/site/products/opik/
- **License**: Apache-2.0
- **Install**: `pip install opik`
- LLM evaluation, monitoring, and observability platform by Comet

### Promptfoo (Monitoring → monitoring)
- **GitHub**: https://github.com/promptfoo/promptfoo (20.7k stars)
- **Website**: https://promptfoo.dev
- **License**: MIT
- **Install**: `npm install -g promptfoo` / `pip install promptfoo`
- LLM evaluation, red-teaming, and prompt testing CLI

### Validation checklist
- [x] YAML files created in correct category directories
- [x] Local validation passes for all 3 tools
- [x] All required fields present (name, description, problem_solved, use_cases, github_url)
- [x] install_command uses proper multiline format for Promptfoo (npm + pip)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new tools to the registry: Letta for agent frameworks, Opik for LLM monitoring and observability, and Promptfoo for evaluation and red-teaming, complete with installation instructions and reference links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->