### PR TITLE
Add Crawl4AI, SGLang, and Kotaemon to catalog

### DIFF
--- a/tools/data/crawl4ai.yaml
+++ b/tools/data/crawl4ai.yaml
@@ -1,0 +1,30 @@
+name: Crawl4AI
+description: An async web crawler and scraper that turns any website into clean, LLM-ready Markdown or structured data for RAG, agents, and data pipelines.
+tagline: Open-source LLM-friendly web crawler and scraper
+
+github_url: https://github.com/unclecode/crawl4ai
+website_url: https://docs.crawl4ai.com
+docs_url: https://docs.crawl4ai.com
+
+category: Data
+tags: [python, crawler, scraper, markdown, rag, async]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Raw web pages are noisy — ads, navigation, scripts, and inconsistent markup make them hard to
+  ingest into LLMs and RAG pipelines. Manual extraction doesn't scale, and generic scrapers often
+  miss the semantic structure. Crawl4AI automates the full pipeline: it fetches pages, executes
+  JavaScript, extracts meaningful content, and outputs clean Markdown or structured JSON. This
+  eliminates hours of cleanup and makes any web source usable for AI applications immediately.
+
+install_command: |
+  pip install crawl4ai
+  crawl4ai-setup
+
+use_cases:
+  - Generate clean Markdown from any website for RAG ingestion and vector indexing
+  - Extract structured product data, prices, and reviews using CSS, XPath, or LLM-based strategies
+  - Crawl documentation sites recursively to build a searchable knowledge base for support agents
+  - Perform large-scale parallel crawling with proxies, stealth modes, and session reuse for research pipelines

--- a/tools/llm/sglang.yaml
+++ b/tools/llm/sglang.yaml
@@ -1,0 +1,29 @@
+name: SGLang
+description: A high-performance serving framework for large language models and multimodal models, designed for low-latency, high-throughput inference from single GPUs to large distributed clusters.
+tagline: Fast serving framework for LLMs and multimodal models
+
+github_url: https://github.com/sgl-project/sglang
+website_url: https://sglang.ai
+docs_url: https://docs.sglang.ai
+
+category: LLM
+tags: [python, inference, serving, llm, multimodal, distributed]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Production LLM inference is expensive and hard to scale. Existing serving frameworks often
+  struggle with efficient batching, speculative decoding, and handling multimodal workloads under
+  latency constraints. SGLang addresses this by co-designing the runtime with a flexible language
+  for structured generation, enabling advanced scheduling like radix caching, speculative execution,
+  and chunked prefill. The result is significantly higher throughput and lower latency across
+  diverse hardware setups, from a single consumer GPU to large distributed clusters.
+
+install_command: pip install sglang
+
+use_cases:
+  - Deploy production-grade LLM APIs with state-of-the-art throughput and latency performance
+  - Serve multimodal models including vision-language and diffusion models from a unified backend
+  - Run RL and post-training inference rollouts for frontier model development at scale
+  - Replace vLLM or TGI in existing stacks to improve request-per-second metrics on the same hardware

--- a/tools/rag/kotaemon.yaml
+++ b/tools/rag/kotaemon.yaml
@@ -1,0 +1,30 @@
+name: Kotaemon
+description: An open-source, clean, and customizable RAG UI for chatting with your documents, built for both end users and developers who want full control over their RAG pipeline.
+tagline: Open-source RAG UI for chatting with your documents
+
+github_url: https://github.com/Cinnamon/kotaemon
+website_url: https://cinnamon.github.io/kotaemon/
+docs_url: https://cinnamon.github.io/kotaemon/
+
+category: RAG
+tags: [python, rag, ui, documents, chat, self-hosted]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Most RAG solutions force a choice between black-box SaaS products that expose your data to
+  third parties, or raw frameworks that require extensive coding to get a usable interface.
+  Kotaemon bridges this gap by providing a fully functional, self-hosted RAG web UI out of the
+  box, with support for multiple LLM and embedding providers, hybrid retrieval, multi-user
+  collections, and advanced citation viewing. It gives teams a private, customizable document
+  QA system without months of frontend and pipeline engineering.
+
+install_command: |
+  docker run -e GRADIO_SERVER_NAME=0.0.0.0 -e GRADIO_SERVER_PORT=7860 -v ./ktem_app_data:/app/ktem_app_data -p 7860:7860 -it --rm ghcr.io/cinnamon/kotaemon:main-full
+
+use_cases:
+  - Deploy a self-hosted team knowledge base where users chat with private documents in shared or personal collections
+  - Perform multimodal question answering on documents containing figures, tables, and charts with in-browser previews
+  - Build a customizable RAG pipeline by swapping LLMs, embedding models, retrievers, and re-rankers via configuration
+  - Enable advanced citation viewing with highlighted PDF sources for high-stakes research and compliance workflows


### PR DESCRIPTION
## Tools Added

- **Crawl4AI** (Data) — Async web crawler and scraper that turns any website into clean, LLM-ready Markdown or structured data.
- **SGLang** (LLM) — High-performance serving framework for LLMs and multimodal models, from single GPUs to distributed clusters.
- **Kotaemon** (RAG) — Open-source, customizable RAG UI for chatting with documents, built for end users and developers.

## Validation

- [x] `npx tsx scripts/validate-tool.ts tools/data/crawl4ai.yaml` — valid
- [x] `npx tsx scripts/validate-tool.ts tools/llm/sglang.yaml` — valid
- [x] `npx tsx scripts/validate-tool.ts tools/rag/kotaemon.yaml` — valid

## Checklist

- [x] YAML files created in correct category directories
- [x] Local validation passes
- [x] Only `tools/` files modified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Crawl4AI tool for web crawling with clean Markdown output and structured data extraction capabilities.
  * Added SGLang LLM serving framework for low-latency, high-throughput multimodal inference and API deployment.
  * Added Kotaemon RAG UI tool for private document interactions with multimodal support and citation viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->