### PR TITLE
Add Instructor, Guardrails AI, and Mirascope to catalog

### DIFF
--- a/tools/agent-frameworks/mirascope.yaml
+++ b/tools/agent-frameworks/mirascope.yaml
@@ -1,0 +1,27 @@
+name: Mirascope
+description: "Mirascope provides open-source Python and TypeScript SDKs for building LLM-powered applications with provider-agnostic calls, tools, structured outputs, streaming, tracing, versioning, and analytics."
+tagline: "Provider-agnostic toolkit for building observable LLM agents"
+github_url: https://github.com/Mirascope/mirascope
+website_url: https://mirascope.com
+docs_url: https://mirascope.com/docs
+install_command: "pip install mirascope[all]"
+category: Agents
+tags:
+  - llm
+  - agents
+  - ai-sdk
+  - tool-calling
+  - structured-outputs
+  - observability
+  - prompt-engineering
+  - python
+  - typescript
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Mirascope helps developers build production LLM agents without heavy framework abstractions by unifying provider APIs while preserving control, type safety, observability, and reliable tool-calling patterns."
+use_cases:
+  - "Build tool-using LLM agents with OpenAI, Anthropic, Google, and other providers"
+  - "Add tracing, versioning, and cost tracking to LLM application workflows"
+  - "Generate structured outputs from LLMs using typed schemas and validation"
+  - "Stream model responses and manage multi-turn conversation history"

--- a/tools/llm/guardrails-ai.yaml
+++ b/tools/llm/guardrails-ai.yaml
@@ -1,0 +1,25 @@
+name: Guardrails AI
+description: "Guardrails AI is a Python framework for building reliable AI applications by validating LLM inputs and outputs, mitigating risks, and helping generate structured data from LLMs."
+tagline: "Open-source guardrails for safer, more reliable LLM apps"
+github_url: https://github.com/guardrails-ai/guardrails
+website_url: https://guardrailsai.com/guardrailsoss
+docs_url: https://guardrailsai.com/guardrails/docs
+install_command: "pip install guardrails-ai"
+category: LLM
+tags:
+  - guardrails
+  - llm-safety
+  - validation
+  - policy-enforcement
+  - structured-outputs
+  - hallucination-detection
+  - pii-detection
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Guardrails AI helps teams detect and mitigate LLM risks such as PII leakage, hallucinations, jailbreaks, unsafe content, policy violations, and malformed structured outputs before they reach users."
+use_cases:
+  - "Validate LLM inputs and outputs for safety and policy compliance"
+  - "Detect PII leakage, hallucinations, jailbreaks, and unsafe content"
+  - "Generate and enforce structured outputs from large language models"
+  - "Add runtime guardrails to chatbots, RAG pipelines, and agent workflows"

--- a/tools/llm/instructor.yaml
+++ b/tools/llm/instructor.yaml
@@ -1,0 +1,25 @@
+name: Instructor
+description: "Instructor is an open-source library for extracting structured data from LLMs using Pydantic models, with type safety, validation, retries, streaming, and support for multiple LLM providers."
+tagline: "Reliable structured outputs from LLMs with Pydantic validation"
+github_url: https://github.com/567-labs/instructor
+website_url: https://python.useinstructor.com/
+docs_url: https://python.useinstructor.com/
+install_command: "pip install instructor"
+category: LLM
+tags:
+  - structured-outputs
+  - llm
+  - pydantic
+  - validation
+  - extraction
+  - json
+  - python
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Instructor reduces the engineering burden of parsing, validating, and retrying unreliable LLM responses by returning typed, validated structured data directly from model calls."
+use_cases:
+  - "Extract structured records from unstructured text using Pydantic schemas"
+  - "Validate LLM outputs automatically and retry when responses fail schema checks"
+  - "Build provider-agnostic structured-output workflows across multiple LLMs"
+  - "Stream partial structured responses for real-time extraction and processing"


### PR DESCRIPTION
## Summary

Adds three validated catalog entries:

- Instructor (LLM) — structured LLM outputs with Pydantic validation
- Guardrails AI (LLM) — runtime guardrails for safer LLM applications
- Mirascope (Agents) — provider-agnostic SDKs for building observable LLM agents

## Links

- https://github.com/567-labs/instructor
- https://github.com/guardrails-ai/guardrails
- https://github.com/Mirascope/mirascope

## Use cases

- Structured output extraction and validation
- LLM safety, policy enforcement, and hallucination/PII checks
- Tool-using and observable agent application development

## Validation

- [x] `npx tsx scripts/validate-tool.ts tools/llm/instructor.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/llm/guardrails-ai.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/agent-frameworks/mirascope.yaml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added catalog metadata for Mirascope agent framework with tool-calling and streaming capabilities
  * Added catalog metadata for Guardrails AI for input/output validation and safety checks
  * Added catalog metadata for Instructor library for structured data extraction and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->