### PR TITLE
Add MarkItDown, LocalAI, and Vercel AI SDK to catalog

### DIFF
--- a/tools/data/markitdown.yaml
+++ b/tools/data/markitdown.yaml
@@ -1,0 +1,32 @@
+name: MarkItDown
+description: >
+  MarkItDown is a Python document-conversion library from Microsoft that turns PDFs,
+  Office files, HTML, images, audio, and other formats into structured Markdown for
+  LLM pipelines, search, and downstream text analysis.
+tagline: Convert messy files into LLM-friendly Markdown
+github_url: https://github.com/microsoft/markitdown
+website_url: https://pypi.org/project/markitdown/
+docs_url: https://github.com/microsoft/markitdown#readme
+install_command: pip install markitdown
+category: Data
+tags:
+  - data-ingestion
+  - markdown
+  - document-processing
+  - pdf
+  - office-documents
+  - llm
+  - preprocessing
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: >
+  Teams building RAG systems and document-aware agents often waste time writing one-off
+  parsers for PDFs, DOCX, PPTX, spreadsheets, web pages, and other file types before they
+  can even start chunking or embedding content. MarkItDown standardizes that messy ingestion
+  step by converting many common formats into clean Markdown that preserves useful structure
+  such as headings, lists, tables, and links.
+use_cases:
+  - Convert PDFs, DOCX, PPTX, and XLSX files into Markdown before chunking and embedding
+  - Normalize mixed document collections for enterprise search, copilots, and agent workflows
+  - Preprocess exported web pages, reports, and archives into token-efficient text for LLM analysis

--- a/tools/dev-tools/vercel-ai-sdk.yaml
+++ b/tools/dev-tools/vercel-ai-sdk.yaml
@@ -1,0 +1,31 @@
+name: Vercel AI SDK
+description: >
+  Vercel AI SDK is a TypeScript toolkit for building AI-powered applications and agents
+  across React, Next.js, Vue, Svelte, and Node.js. It standardizes model integration,
+  streaming, tool calling, and structured generation so developers can ship AI features faster.
+tagline: Universal TypeScript AI layer for apps and agents
+github_url: https://github.com/vercel/ai
+website_url: https://ai-sdk.dev
+docs_url: https://ai-sdk.dev/docs/introduction
+install_command: npm install ai
+category: Dev Tools
+tags:
+  - typescript
+  - nextjs
+  - react
+  - ai-sdk
+  - tool-calling
+  - streaming
+  - structured-output
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: >
+  Building production AI features in TypeScript usually means wiring together provider-specific
+  SDKs, custom streaming code, ad hoc tool-calling logic, and hand-rolled schemas for structured
+  outputs. Vercel AI SDK removes that boilerplate by giving developers one consistent interface
+  for providers, UI streaming, tools, and typed generation across modern JavaScript frameworks.
+use_cases:
+  - Build chat and assistant interfaces in Next.js or React with streaming model responses
+  - Add tool-calling agents to Node.js backends without writing provider-specific glue code
+  - Swap between model providers while preserving a consistent TypeScript application layer

--- a/tools/llm/localai.yaml
+++ b/tools/llm/localai.yaml
@@ -1,0 +1,32 @@
+name: LocalAI
+description: >
+  LocalAI is a self-hosted, OpenAI-compatible inference server for running language,
+  vision, image, and audio models on local hardware. It helps teams replace hosted APIs
+  with a private local stack while keeping a familiar developer interface.
+tagline: Self-hosted OpenAI-compatible AI stack for local models
+github_url: https://github.com/mudler/LocalAI
+website_url: https://localai.io/
+docs_url: https://localai.io/
+install_command: docker run -p 8080:8080 --name local-ai -ti localai/localai:latest
+category: LLM
+tags:
+  - llm
+  - self-hosted
+  - openai-compatible
+  - local-inference
+  - privacy
+  - multimodal
+  - edge-ai
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: >
+  Many teams want the flexibility of OpenAI-style APIs without sending sensitive prompts,
+  files, or telemetry to third-party clouds, but stitching together local inference stacks
+  and adapting application code to each runtime is painful. LocalAI solves that by exposing
+  a familiar API for self-hosted models, making it easier to move apps and agents to private,
+  offline, or edge environments with minimal code changes.
+use_cases:
+  - Run a private OpenAI-compatible endpoint for internal copilots, agents, and automation tools
+  - Deploy local multimodal models on edge devices or air-gapped infrastructure
+  - Replace cloud LLM API calls in existing applications with self-hosted inference for privacy control


### PR DESCRIPTION
## Summary
- Add MarkItDown in the Data category
- Add LocalAI in the LLM category
- Add Vercel AI SDK in the Dev Tools category

## Tool Links
- MarkItDown: https://github.com/microsoft/markitdown
- LocalAI: https://github.com/mudler/LocalAI
- Vercel AI SDK: https://github.com/vercel/ai

## Why these tools
- **MarkItDown** helps convert mixed file formats into Markdown for RAG, search, and agent pipelines.
- **LocalAI** gives developers a self-hosted OpenAI-compatible inference stack for privacy-sensitive or offline deployments.
- **Vercel AI SDK** provides a unified TypeScript layer for streaming, tool calling, and structured AI outputs.

## Example use cases
- Document ingestion and normalization before chunking and embedding
- Private or edge-hosted copilots and agent backends
- Building chat apps and tool-calling agents in Next.js, React, and Node.js

## Validation
- [x] `npx tsx scripts/validate-tool.ts tools/data/markitdown.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/llm/localai.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/dev-tools/vercel-ai-sdk.yaml`
- [x] Only `tools/` files are included in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added tool registry entries for MarkItDown document conversion, Vercel AI SDK, and LocalAI with metadata and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->