### PR TITLE
Add Marker and Jan to catalog

### DIFF
--- a/tools/data/marker.yaml
+++ b/tools/data/marker.yaml
@@ -1,0 +1,32 @@
+name: Marker
+description: >
+  Marker converts PDFs, images, and office documents into structured markdown, JSON,
+  chunks, and HTML with OCR, layout understanding, table extraction, and optional
+  LLM-assisted cleanup for downstream AI and data pipelines.
+tagline: Convert complex documents into AI-ready structured data
+github_url: https://github.com/datalab-to/marker
+website_url: https://www.datalab.to
+install_command: pip install marker-pdf
+category: Data
+tags:
+  - document-intelligence
+  - pdf
+  - ocr
+  - markdown
+  - json
+  - html
+  - table-extraction
+  - rag
+pricing: freemium
+is_open_source: true
+license: GPL-3.0
+problem_solved: >
+  Teams building AI and analytics pipelines often start with messy scanned PDFs,
+  slide decks, spreadsheets, and image-heavy reports that are hard to parse reliably.
+  Marker automates OCR, layout analysis, and structured conversion so those documents
+  become usable markdown, JSON, or HTML instead of requiring brittle manual extraction
+  steps and custom parsing glue.
+use_cases:
+  - Convert PDFs and scanned reports into markdown chunks for RAG ingestion
+  - Extract tables and document structure into JSON for downstream data pipelines
+  - Turn DOCX, PPTX, XLSX, HTML, and EPUB files into machine-readable content for search and analysis

--- a/tools/llm/jan.yaml
+++ b/tools/llm/jan.yaml
@@ -1,0 +1,31 @@
+name: Jan
+description: >
+  Jan is an open-source desktop AI assistant for macOS, Windows, and Linux that lets
+  users run local models privately, connect cloud models when needed, and expose a
+  built-in OpenAI-compatible API for other apps on the same machine.
+tagline: Private desktop AI with local models and an OpenAI-compatible API
+github_url: https://github.com/janhq/jan
+website_url: https://jan.ai/
+docs_url: https://jan.ai/docs/desktop
+category: LLM
+tags:
+  - llm
+  - local-llm
+  - desktop-app
+  - openai-compatible-api
+  - privacy
+  - offline
+  - chat-interface
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: >
+  Many developers want ChatGPT-style workflows without sending every prompt,
+  conversation, and file to a hosted API, but local model stacks are usually fragmented
+  and difficult to wire into everyday tools. Jan packages private local inference, a
+  usable desktop chat interface, and a local OpenAI-compatible API into one app so
+  people can run and integrate models on their own hardware with less setup friction.
+use_cases:
+  - Run local LLMs privately on a laptop for writing, coding, and research tasks
+  - Expose a local OpenAI-compatible endpoint for apps and agents that need on-device inference
+  - Create task-specific assistants and organized projects without relying only on cloud AI services


### PR DESCRIPTION
## Summary
- Adds Marker to the Data catalog
- Adds Jan to the LLM catalog

## Tools added
### Marker
- Category: Data
- GitHub: https://github.com/datalab-to/marker
- Website: https://www.datalab.to
- Use cases:
  - Convert PDFs and scanned reports into markdown chunks for RAG ingestion
  - Extract tables and document structure into JSON for downstream data pipelines
  - Turn DOCX, PPTX, XLSX, HTML, and EPUB files into machine-readable content for search and analysis

### Jan
- Category: LLM
- GitHub: https://github.com/janhq/jan
- Website: https://jan.ai/
- Use cases:
  - Run local LLMs privately on a laptop for writing, coding, and research tasks
  - Expose a local OpenAI-compatible endpoint for apps and agents that need on-device inference
  - Create task-specific assistants and organized projects without relying only on cloud AI services

## Validation
- [x] `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- [x] `npx tsx scripts/validate-tool.ts tools/data/marker.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/llm/jan.yaml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added manifest file for Marker tool with metadata including description, category, tags, and pricing details.
  * Added manifest file for Jan open-source AI assistant with documentation links, category, tags, and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->