### PR TITLE
Add GraphRAG, Pathway, and Open WebUI to catalog

### DIFF
--- a/tools/data/pathway.yaml
+++ b/tools/data/pathway.yaml
@@ -1,0 +1,26 @@
+name: Pathway
+description: A Python data processing framework for real-time ETL, streaming analytics, LLM pipelines, and RAG workloads, powered by an incremental computation engine designed for continuously changing data.
+tagline: Real-time ETL and live AI data pipelines in Python
+
+github_url: https://github.com/pathwaycom/pathway
+website_url: https://pathway.com/
+docs_url: https://pathway.com/developers/api-docs/pathway
+install_command: pip install -U pathway
+
+category: Data
+tags: [python, data, etl, stream-processing, real-time, rag, analytics]
+pricing: freemium
+is_open_source: false
+license: Business Source License 1.1
+
+problem_solved: |
+  Teams often split batch ETL, stream processing, analytics, and AI ingestion across separate tools,
+  which creates latency, duplicated logic, and brittle pipelines. Pathway provides one framework for
+  continuously updating dataflows so developers can build real-time ETL, live analytics, and RAG or
+  LLM pipelines without maintaining disconnected processing systems.
+
+use_cases:
+  - Build real-time ETL pipelines that continuously update outputs as source data changes
+  - Power live RAG systems that ingest fresh documents, events, and database updates automatically
+  - Create streaming analytics and alerting workflows on operational or product event data
+  - Connect private data sources to LLM applications without waiting for batch refresh cycles

--- a/tools/dev-tools/open-webui.yaml
+++ b/tools/dev-tools/open-webui.yaml
@@ -1,0 +1,26 @@
+name: Open WebUI
+description: A self-hosted AI interface for running local or cloud models through a single chat experience, with support for Ollama, OpenAI-compatible APIs, built-in RAG, and Python-based extensibility.
+tagline: Self-hosted AI workspace for local and cloud models
+
+github_url: https://github.com/open-webui/open-webui
+website_url: https://openwebui.com/
+docs_url: https://docs.openwebui.com/
+install_command: pip install open-webui
+
+category: Dev Tools
+tags: [self-hosted, ai-interface, ollama, openai-compatible, rag, python, workspace]
+pricing: freemium
+is_open_source: false
+license: Open WebUI License
+
+problem_solved: |
+  Many teams want a private, customizable interface for AI models without handing data to a hosted
+  chat product or building an internal UI from scratch. Open WebUI provides a self-hosted front end
+  that connects local and remote model backends, adds retrieval and Python tool support, and lets
+  organizations control deployment, access, and data flow on their own infrastructure.
+
+use_cases:
+  - Deploy an internal AI chat platform that runs on private infrastructure with local models
+  - Give teams one interface for Ollama and OpenAI-compatible APIs instead of separate tools
+  - Extend chat workflows with built-in RAG and Python functions for domain-specific tasks
+  - Run offline or low-connectivity AI environments where hosted chat products are not acceptable

--- a/tools/rag/graphrag.yaml
+++ b/tools/rag/graphrag.yaml
@@ -1,0 +1,26 @@
+name: GraphRAG
+description: Microsoft's graph-based Retrieval-Augmented Generation system that turns unstructured documents into a knowledge graph with community summaries, then uses that structure to answer complex questions over private data.
+tagline: Graph-based RAG for complex questions over private data
+
+github_url: https://github.com/microsoft/graphrag
+website_url: https://microsoft.github.io/graphrag/
+docs_url: https://microsoft.github.io/graphrag/get_started/
+install_command: python -m pip install graphrag
+
+category: RAG
+tags: [python, rag, graph-rag, knowledge-graph, microsoft, private-data]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Standard vector-search RAG often misses relationships that span many documents and struggles with
+  broad, corpus-level questions. GraphRAG builds a knowledge graph, hierarchical communities, and
+  summary layers from raw text so teams can answer both entity-specific and holistic questions over
+  large private datasets without manually stitching context together.
+
+use_cases:
+  - Build a knowledge-graph-backed RAG system for enterprise documents and research corpora
+  - Answer global questions that require themes and relationships across many documents
+  - Run entity-centric investigations with local graph context around people, places, or systems
+  - Create richer retrieval pipelines for compliance, intelligence, and due-diligence workflows


### PR DESCRIPTION
## Summary
- Add GraphRAG to the RAG catalog
- Add Pathway to the Data catalog
- Add Open WebUI to the Dev Tools catalog

## Tool links
- GraphRAG: https://github.com/microsoft/graphrag
- Pathway: https://github.com/pathwaycom/pathway
- Open WebUI: https://github.com/open-webui/open-webui

## Use cases covered
- Graph-based retrieval for complex questions across private corpora
- Real-time ETL, streaming analytics, and live RAG data pipelines
- Self-hosted AI chat interfaces for local and cloud models

## Validation checklist
- [x] YAML files added under `tools/`
- [x] Local validation passed with `npx tsx scripts/validate-tool.ts`
- [x] No unrelated repo files included in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added Pathway to the tools catalog—a real-time ETL and streaming analytics solution.
  * Added Open WebUI to the tools catalog—a self-hosted AI workspace platform.
  * Added GraphRAG to the tools catalog—a graph-based retrieval-augmented generation tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->