### PR TITLE
fix: run sync-on-merge on Node 22

### DIFF
--- a/.github/workflows/sync-on-merge.yml
+++ b/.github/workflows/sync-on-merge.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install script dependencies
         working-directory: scripts


### PR DESCRIPTION
## Summary
- Updates `sync-on-merge.yml` to use Node.js 22 instead of Node.js 20

## Why
- The merge-triggered Supabase sync failed on main because `@supabase/supabase-js` now expects native WebSocket support
- GitHub Actions on Node 20 raised `Error: Node.js 20 detected without native WebSocket support`
- Node 22 provides native WebSocket support, so the sync script can initialize the Supabase client normally

## Validation
- [x] Reviewed failing workflow logs for run `25504654697`
- [x] Confirmed failure occurs before YAML-specific sync logic, during Supabase client initialization
