### PR TITLE
chore: retrigger sync for AnythingLLM, Embedchain, and LM Studio

### DIFF
--- a/tools/dev-tools/lm-studio.yaml
+++ b/tools/dev-tools/lm-studio.yaml
@@ -2,7 +2,7 @@ name: LM Studio
 description: >
   LM Studio is a desktop tool for running large language models locally on macOS, Windows, and Linux,
   with chat, document RAG, local APIs, SDKs, and optional headless deployment for private inference.
-tagline: Run AI models locally and privately
+tagline: Run AI models locally and privately.
 github_url: https://github.com/lmstudio-ai
 website_url: https://lmstudio.ai/
 docs_url: https://lmstudio.ai/docs/app

--- a/tools/rag/anythingllm.yaml
+++ b/tools/rag/anythingllm.yaml
@@ -2,7 +2,7 @@ name: AnythingLLM
 description: >
   AnythingLLM is an open-source AI workspace for document chat, retrieval-augmented generation,
   and agents that runs on desktop or self-hosted infrastructure with support for local and cloud LLMs.
-tagline: The all-in-one AI productivity accelerator
+tagline: The all-in-one AI productivity accelerator.
 github_url: https://github.com/Mintplex-Labs/anything-llm
 website_url: https://anythingllm.com/
 docs_url: https://docs.anythingllm.com/

--- a/tools/rag/embedchain.yaml
+++ b/tools/rag/embedchain.yaml
@@ -2,7 +2,7 @@ name: Embedchain
 description: >
   Embedchain is an open-source framework for building and deploying personalized LLM apps on your own
   data by handling ingestion, chunking, embeddings, vector storage, and retrieval for chat and Q&A.
-tagline: Create AI apps on your own data in minutes
+tagline: Create AI apps on your own data in minutes.
 github_url: https://github.com/embedchain/embedchain
 website_url: https://embedchain.ai/
 docs_url: https://docs.embedchain.ai/


### PR DESCRIPTION
## Summary
- Makes a no-op copy edit to three newly added tool YAML files
- Intentionally re-triggers `sync-on-merge.yml` after the Node 22 workflow fix merged

## Files
- `tools/rag/anythingllm.yaml`
- `tools/rag/embedchain.yaml`
- `tools/dev-tools/lm-studio.yaml`

## Why
- The original sync run on main failed before any YAML-specific logic because the workflow was still using Node 20
- PR #79 updated the workflow to Node 22
- This PR touches the same three tool files so the fixed workflow will re-run and sync them to Supabase

## Validation
- [x] `npx tsx scripts/validate-tool.ts tools/rag/anythingllm.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/rag/embedchain.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/dev-tools/lm-studio.yaml`
