### PR TITLE
Add Bruno to catalog

### DIFF
--- a/tools/dev-tools/bruno.yaml
+++ b/tools/dev-tools/bruno.yaml
@@ -1,0 +1,29 @@
+name: Bruno
+description: Bruno is an open-source API client that stores collections as plain-text files on your filesystem. Built as a fast, git-friendly alternative to Postman and Insomnia, it lets developers version-control their API requests, collaborate without syncing to the cloud, and test APIs natively inside their existing workflow.
+tagline: Fast and git-friendly open-source API client
+
+website_url: https://www.usebruno.com
+github_url: https://github.com/usebruno/bruno
+docs_url: https://docs.usebruno.com
+
+install_command: npm install -g @usebruno/cli
+
+category: Dev Tools
+tags: [api-client, api-testing, open-source, git-friendly, postman-alternative, rest, graphql, cli]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Teams that rely on Postman or Insomnia face cloud lock-in, paid sync tiers, and collections stored in
+  opaque binary formats that are hard to review in pull requests. Bruno solves this by keeping every
+  request, environment, and script as human-readable .bru files on disk. Collections live inside the
+  project repository, travel with the codebase, and are reviewed, diffed, and merged just like source
+  code — no account required, no data leaves the machine.
+
+use_cases:
+  - Version-control API requests, environments, and scripts alongside application source code in the same git repository
+  - Run API test suites in CI/CD pipelines using the Bruno CLI without a GUI or cloud subscription
+  - Share API contracts across teams through pull requests, enabling structured review of endpoint changes
+  - Manage multiple environments (dev, staging, prod) with plain-text variable files kept out of version control via .gitignore
+  - Migrate existing Postman or Insomnia collections to an offline-first, open-source format with zero vendor dependency


### PR DESCRIPTION
## Summary
Add [Bruno](https://www.usebruno.com) — an open-source, git-friendly API client and Postman alternative — to the catalog.

Based on original PR #76 by @ganesh-bruno (DevRel @usebruno).

### Fixes from #76
- **category**: `Developer Tools` → `Dev Tools` (matches schema enum, original would fail CI)
- **directory**: moved from `tools/data/` to `tools/dev-tools/` (correct category directory)
- **description**: clarified `.bru` file format instead of "plain-text yaml"

### Validation
- [x] Local validation passes (`bruno — valid`)
- [x] All required fields present
- [x] URLs verified (GitHub 43.5K stars, website, docs all live)
- [x] `install_command` verified (npm package exists)
- [x] No hardcoded secrets
- [x] `approved: false` filter intact

## Type of Change
- [x] Adding a tool

## Related Issues
Supersedes #76
