### PR TITLE
Add LLaMA Factory, PEFT, and R2R to catalog

### DIFF
--- a/tools/fine-tuning/llama-factory.yaml
+++ b/tools/fine-tuning/llama-factory.yaml
@@ -1,0 +1,37 @@
+name: LLaMA Factory
+description: Open-source platform for fine-tuning and post-training 100+ large language and vision-language models with a CLI and web UI for SFT, LoRA, QLoRA, RLHF-style training, evaluation, and inference.
+tagline: Fine-tune and post-train open models with a CLI or web UI
+
+github_url: https://github.com/hiyouga/LLaMA-Factory
+docs_url: https://llamafactory.readthedocs.io/en/latest/
+install_command: |
+  git clone --depth 1 https://github.com/hiyouga/LLaMA-Factory.git
+  cd LLaMA-Factory
+  pip install -e .
+
+category: Fine-tuning
+tags:
+  - python
+  - fine-tuning
+  - llm
+  - vlm
+  - lora
+  - qlora
+  - rlhf
+  - web-ui
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Fine-tuning open models usually means stitching together separate scripts for dataset prep,
+  LoRA adapters, preference optimization, evaluation, and serving. LLaMA Factory puts those
+  workflows in one toolkit so teams can adapt language and vision-language models locally with
+  less boilerplate, less infrastructure glue code, and lower GPU memory requirements.
+
+use_cases:
+  - Supervised fine-tune an open LLM on domain-specific instruction data
+  - Run LoRA or QLoRA training on limited GPU memory for smaller teams
+  - Post-train chat models with DPO, PPO, KTO, or ORPO alignment workflows
+  - Adapt vision-language models for multimodal assistants and document tasks
+  - Let non-experts experiment locally through the built-in web UI and dashboards

--- a/tools/fine-tuning/peft.yaml
+++ b/tools/fine-tuning/peft.yaml
@@ -1,0 +1,35 @@
+name: PEFT
+description: Hugging Face library for parameter-efficient fine-tuning of large pretrained models using techniques like LoRA and QLoRA, reducing compute, memory, and storage costs versus full fine-tuning.
+tagline: Fine-tune large models with lightweight adapters instead of full retraining
+
+github_url: https://github.com/huggingface/peft
+website_url: https://huggingface.co/docs/peft/index
+docs_url: https://huggingface.co/docs/peft/index
+install_command: pip install peft
+
+category: Fine-tuning
+tags:
+  - python
+  - fine-tuning
+  - huggingface
+  - lora
+  - qlora
+  - adapters
+  - pytorch
+  - transformers
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Full fine-tuning of large language, vision, speech, or diffusion models is expensive and often
+  impractical for teams without large GPU budgets. PEFT lets developers adapt foundation models by
+  training only small adapter layers, which cuts memory usage, lowers checkpoint size, and makes
+  experimentation feasible on modest hardware.
+
+use_cases:
+  - Fine-tune LLMs on consumer GPUs with LoRA or QLoRA adapters
+  - Train task-specific adapters instead of storing full copies of each model
+  - Personalize diffusion models with lightweight DreamBooth-style adapter workflows
+  - Add efficient fine-tuning to TRL, Transformers, and Accelerate training pipelines
+  - Swap, merge, and manage multiple adapters on a shared base model

--- a/tools/rag/r2r.yaml
+++ b/tools/rag/r2r.yaml
@@ -1,0 +1,34 @@
+name: R2R
+description: Open-source agentic RAG system for ingesting multimodal data, running hybrid retrieval, building knowledge graphs, and serving citation-grounded answers through APIs for production applications.
+tagline: Build citation-aware RAG systems with ingestion, retrieval, and agents
+
+github_url: https://github.com/SciPhi-AI/R2R
+docs_url: https://github.com/SciPhi-AI/R2R/tree/main/docs
+install_command: pip install r2r
+
+category: RAG
+tags:
+  - rag
+  - retrieval
+  - agentic-rag
+  - hybrid-search
+  - knowledge-graph
+  - multimodal-ingestion
+  - self-hosted
+  - rest-api
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Building a production RAG stack usually requires separate tools for document ingestion, search,
+  agents, APIs, and citation handling. R2R combines those pieces into one system so teams can turn
+  messy internal documents into searchable knowledge bases with grounded answers, hybrid retrieval,
+  and optional knowledge-graph enrichment.
+
+use_cases:
+  - Build an internal knowledge assistant over company docs with source citations
+  - Ingest PDFs, JSON, images, audio, and web data into one retrieval pipeline
+  - Run hybrid semantic and keyword search across a private knowledge base
+  - Power research agents that combine local knowledge with external web context
+  - Self-host a REST API backend for enterprise RAG applications


### PR DESCRIPTION
## Summary
- Add **LLaMA Factory** to `tools/fine-tuning/llama-factory.yaml`
- Add **PEFT** to `tools/fine-tuning/peft.yaml`
- Add **R2R** to `tools/rag/r2r.yaml`

## Categories
- Fine-tuning: LLaMA Factory, PEFT
- RAG: R2R

## Links
- LLaMA Factory: https://github.com/hiyouga/LLaMA-Factory
- PEFT: https://github.com/huggingface/peft
- R2R: https://github.com/SciPhi-AI/R2R

## Why these tools
- LLaMA Factory is a widely used open-source post-training toolkit for local SFT, LoRA, QLoRA, and RLHF-style workflows.
- PEFT is a core Hugging Face library that makes adapter-based fine-tuning practical on modest hardware.
- R2R is a production-oriented open-source RAG system that combines ingestion, hybrid retrieval, APIs, and citation-grounded answers.

## Validation
- [x] YAML files created in the correct category directories
- [x] Local validation passed with `npx tsx scripts/validate-tool.ts`
- [x] Only `tools/**/*.yaml` files are included in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added tool manifests for LLaMA Factory, PEFT, and R2R, including metadata, installation instructions, and documented use cases for fine-tuning and RAG workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->