### PR TITLE
Add pgvector, MinerU, and RAG-Anything to catalog

### DIFF
--- a/tools/data/mineru.yaml
+++ b/tools/data/mineru.yaml
@@ -1,0 +1,30 @@
+name: MinerU
+description: High-accuracy document parsing system that converts PDFs, images, DOCX, PPTX, and XLSX files into LLM-ready Markdown and JSON.
+tagline: Turn complex documents into LLM-ready Markdown and JSON
+
+github_url: https://github.com/opendatalab/MinerU
+website_url: https://mineru.net/
+docs_url: https://opendatalab.github.io/MinerU/
+
+install_command: |
+  pip install --upgrade pip
+  pip install uv
+  uv pip install -U "mineru[all]"
+
+category: Data
+tags: [document-processing, pdf, ocr, markdown, json, rag, agents, table-extraction, multimodal]
+pricing: free
+is_open_source: true
+license: MinerU Open Source License
+
+problem_solved: |
+  Real-world documents are messy: scans, tables, formulas, figures, and multi-column layouts are hard
+  to extract cleanly with basic OCR or brittle custom scripts. MinerU converts complex business and
+  research documents into structured Markdown and JSON with layout awareness, OCR, and table handling,
+  making them much easier to ingest into RAG systems, agent workflows, and downstream data pipelines.
+
+use_cases:
+  - Parse research papers and technical PDFs into structured Markdown for retrieval and question answering
+  - Extract tables, formulas, and figures from business reports before loading them into analytics or RAG pipelines
+  - Convert scanned multilingual documents into machine-readable JSON for agent automation workflows
+  - Process office files and PDFs at scale for document understanding, indexing, and knowledge base creation

--- a/tools/rag/rag-anything.yaml
+++ b/tools/rag/rag-anything.yaml
@@ -1,0 +1,26 @@
+name: RAG-Anything
+description: Open-source multimodal RAG framework for indexing and querying documents that mix text, images, tables, equations, and office files.
+tagline: All-in-one multimodal RAG for mixed-content documents
+
+github_url: https://github.com/HKUDS/RAG-Anything
+docs_url: https://github.com/HKUDS/RAG-Anything
+
+install_command: pip install raganything
+
+category: RAG
+tags: [rag, multimodal-rag, retrieval, documents, pdf, knowledge-graph, python]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Most RAG stacks are still text-centric and break down on real documents that combine prose,
+  charts, tables, equations, and embedded images. RAG-Anything unifies multimodal parsing,
+  representation, and retrieval in one framework so teams can build assistants and search systems
+  over mixed-content knowledge bases without stitching together several incompatible tools.
+
+use_cases:
+  - Build assistants that answer questions over research papers containing text, figures, and equations
+  - Create multimodal enterprise search across PDFs, office files, and image-heavy technical documentation
+  - Retrieve insights from reports that include tables and charts instead of plain text alone
+  - Power knowledge bases for scientific or engineering teams working with heterogeneous document collections

--- a/tools/vector-databases/pgvector.yaml
+++ b/tools/vector-databases/pgvector.yaml
@@ -1,0 +1,30 @@
+name: pgvector
+description: Open-source PostgreSQL extension for storing embeddings and running exact or approximate vector similarity search directly in SQL.
+tagline: Vector similarity search inside Postgres
+
+github_url: https://github.com/pgvector/pgvector
+docs_url: https://github.com/pgvector/pgvector#installation
+
+install_command: |
+  git clone https://github.com/pgvector/pgvector.git
+  cd pgvector
+  make
+  sudo make install
+
+category: Vector DB
+tags: [postgres, vector-database, embeddings, semantic-search, ann, sql]
+pricing: free
+is_open_source: true
+license: PostgreSQL License
+
+problem_solved: |
+  Many teams want semantic search and retrieval without introducing a separate vector database,
+  extra infrastructure, and a second operational surface area. pgvector adds native vector storage,
+  indexing, and nearest-neighbor search to PostgreSQL, letting developers combine embeddings with
+  joins, filters, transactions, and backups in the same database they already run.
+
+use_cases:
+  - Add semantic search to an existing PostgreSQL application without deploying a separate vector store
+  - Build RAG pipelines that retrieve relevant chunks from Postgres using exact or approximate nearest-neighbor search
+  - Power recommendation systems by comparing user or item embeddings alongside relational business data
+  - Run hybrid application queries that combine metadata filters, SQL joins, and vector similarity in one step


### PR DESCRIPTION
## Summary
- Add **pgvector** in **Vector DB**
- Add **MinerU** in **Data**
- Add **RAG-Anything** in **RAG**

## Links
- pgvector: https://github.com/pgvector/pgvector
- MinerU: https://github.com/opendatalab/MinerU
- RAG-Anything: https://github.com/HKUDS/RAG-Anything

## Why these tools
- **pgvector** brings vector similarity search directly into PostgreSQL for semantic search, RAG, and recommendations.
- **MinerU** turns complex PDFs and office documents into structured Markdown/JSON for document AI workflows.
- **RAG-Anything** focuses on multimodal RAG over mixed-content documents with text, images, tables, and equations.

## Validation
- [x] `npx tsx scripts/validate-tool.ts tools/vector-databases/pgvector.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/data/mineru.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/rag/rag-anything.yaml`
- [x] Local validation passed for all three files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MinerU document processing tool with OCR and table extraction capabilities for parsing PDFs and research papers.
  * Added RAG-Anything multimodal RAG framework for indexing and querying mixed-content documents.
  * Added pgvector vector database integration for semantic search and retrieval-augmented generation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->