### PR TITLE
Add llama.cpp, Outlines, and LlamaParse to catalog

### DIFF
--- a/tools/data/llamaparse.yaml
+++ b/tools/data/llamaparse.yaml
@@ -1,0 +1,28 @@
+name: LlamaParse
+description: Layout-aware document parsing service from LlamaIndex that converts PDFs, scans, tables, charts, and many other file types into clean markdown, text, and JSON for downstream AI workflows.
+tagline: Agentic document parser for LLM pipelines
+
+github_url: https://github.com/run-llama/llama_cloud_services
+website_url: https://www.llamaindex.ai/llamaparse
+docs_url: https://developers.llamaindex.ai/llamaparse/parse/
+install_command: |
+  pip install llama-cloud>=2.1
+  npm install @llamaindex/llama-cloud
+
+category: Data
+tags: [document-parsing, pdf, ocr, markdown, json, data-extraction, rag, tables]
+pricing: freemium
+is_open_source: false
+license: Proprietary
+
+problem_solved: |
+  Complex business documents, scans, and reports usually lose layout, tables, and hierarchy when pushed
+  through generic OCR or PDF-to-text tools. LlamaParse turns messy documents into structured AI-ready
+  outputs while preserving document structure, making it easier to ingest filings, contracts, forms, and
+  knowledge bases into RAG systems, agent workflows, and downstream automation pipelines.
+
+use_cases:
+  - Parse annual reports, investor decks, and research PDFs without losing table structure
+  - Convert contracts, policies, and knowledge base documents into clean markdown for retrieval systems
+  - Extract machine-readable content from scanned forms, invoices, and operational documents
+  - Prepare heterogeneous enterprise files for downstream agents, search, and document automation

--- a/tools/llm/llama-cpp.yaml
+++ b/tools/llm/llama-cpp.yaml
@@ -1,0 +1,25 @@
+name: llama.cpp
+description: Open-source C/C++ runtime for efficient local and server-side LLM inference across CPUs and GPUs, with quantization, broad hardware support, and an OpenAI-compatible API server.
+tagline: LLM inference in C/C++
+
+github_url: https://github.com/ggml-org/llama.cpp
+docs_url: https://github.com/ggml-org/llama.cpp/blob/master/docs/install.md
+install_command: brew install llama.cpp
+
+category: LLM
+tags: [llm-inference, local-llm, gguf, quantization, openai-compatible, cpp, edge-deployment]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Running modern language models locally often requires heavyweight infrastructure, GPU-specific stacks,
+  or custom serving code that is hard to port across laptops, servers, and edge devices. llama.cpp gives
+  developers a fast, portable inference runtime with quantization support and a built-in API server, so
+  they can run and serve GGUF models efficiently on a wide range of CPU and GPU hardware.
+
+use_cases:
+  - Run GGUF language models locally on laptops, desktops, or servers without a large cloud stack
+  - Serve open models behind an OpenAI-compatible API for apps, agents, and internal tooling
+  - Use quantized models to reduce memory usage and make inference feasible on constrained hardware
+  - Deploy private offline inference workflows for regulated or air-gapped environments

--- a/tools/llm/outlines.yaml
+++ b/tools/llm/outlines.yaml
@@ -1,0 +1,25 @@
+name: Outlines
+description: Python library for structured LLM generation that constrains outputs with JSON Schema, regexes, and grammars so developers can get reliable machine-readable results across many model providers.
+tagline: Guaranteed structured outputs from any LLM
+
+github_url: https://github.com/dottxt-ai/outlines
+docs_url: https://dottxt-ai.github.io/outlines/latest/
+install_command: pip install outlines
+
+category: LLM
+tags: [structured-output, json-schema, grammar, regex, llm, python, extraction]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  LLM applications often break because models return malformed JSON, inconsistent fields, or free-form
+  text that downstream code cannot parse safely. Outlines enforces structure during generation instead of
+  cleaning outputs afterward, helping developers eliminate brittle regex fixes, repeated retries, and
+  post-processing code when they need dependable structured responses.
+
+use_cases:
+  - Generate valid JSON objects from LLMs for production APIs and backend workflows
+  - Constrain model output with regex or grammar rules for extraction, classification, and parsing tasks
+  - Build information extraction pipelines that return predictable typed data instead of free-form text
+  - Standardize structured generation across providers such as OpenAI, Ollama, and vLLM


### PR DESCRIPTION
## Summary
- Add `llama.cpp` to the LLM catalog
- Add `Outlines` to the LLM catalog
- Add `LlamaParse` to the Data catalog

## Categories
- LLM: `llama.cpp`, `Outlines`
- Data: `LlamaParse`

## Links
- llama.cpp: https://github.com/ggml-org/llama.cpp
- Outlines: https://github.com/dottxt-ai/outlines
- LlamaParse: https://www.llamaindex.ai/llamaparse

## Use cases covered
- Local and OpenAI-compatible serving for open LLMs
- Structured generation and schema-constrained outputs
- Layout-aware parsing of PDFs, scans, tables, and forms for AI pipelines

## Validation checklist
- [x] YAML files created in correct category directories
- [x] Local validation passed with `npx tsx scripts/validate-tool.ts`
- [x] Only `tools/` files are included in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LlamaParse, a layout-aware document parsing service for processing documents
  * Added llama.cpp for local and server-based LLM inference capabilities
  * Added Outlines, a library for structured LLM output generation with support for JSON schema, regex, and grammar-constrained generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->