### PR TITLE
Add GPT4All, Jina Reader, and Windsurf Editor to catalog

### DIFF
--- a/tools/data/jina-reader.yaml
+++ b/tools/data/jina-reader.yaml
@@ -1,0 +1,24 @@
+name: Jina Reader
+description: Jina Reader converts URLs and web search results into clean, LLM-friendly text so agents, RAG pipelines, and downstream data workflows can consume web content without brittle scraping logic.
+tagline: Turn URLs and search results into LLM-ready text
+
+github_url: https://github.com/jina-ai/reader
+website_url: https://jina.ai/reader
+docs_url: https://jina.ai/reader/
+
+category: Data
+tags: [web-content, search-grounding, data-ingestion, llm-ready, markdown, scraping, rag, agents]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Agent and RAG systems often need reliable access to messy web pages, JavaScript-heavy sites, PDFs,
+  and current search results, but raw HTML and custom scraping stacks create brittle ingestion pipelines.
+  Jina Reader standardizes this into directly usable LLM-friendly content that is easier to index and process.
+
+use_cases:
+  - Ingest public webpages and PDFs into RAG pipelines without writing custom scrapers for every source
+  - Ground autonomous agents with search results that already include fetched page content instead of only snippets
+  - Extract readable content from JavaScript-rendered pages for summarization, classification, or monitoring workflows
+  - Feed clean markdown-like page content into downstream parsing, chunking, and embedding pipelines

--- a/tools/dev-tools/windsurf-editor.yaml
+++ b/tools/dev-tools/windsurf-editor.yaml
@@ -1,0 +1,23 @@
+name: Windsurf Editor
+description: Windsurf Editor is an AI-native desktop IDE that combines agentic code generation, codebase-aware editing, autocomplete, terminal commands, browser previews, and optional cloud agents in one development environment.
+tagline: Built to keep you in flow state
+
+website_url: https://windsurf.com/editor
+docs_url: https://docs.windsurf.com/windsurf/getting-started
+
+category: Dev Tools
+tags: [ide, ai-coding, agentic-coding, autocomplete, terminal, browser-preview, developer-productivity, desktop-app]
+pricing: freemium
+is_open_source: false
+license: Proprietary
+
+problem_solved: |
+  Developers lose time switching between chat, editor, terminal, browser, and deployment tools while building software.
+  Windsurf centralizes agentic coding, context-aware edits, verification, and automation so teams can build,
+  debug, and ship faster with less workflow friction.
+
+use_cases:
+  - Generate and refactor multi-file application code from natural-language prompts using an AI-native IDE workflow
+  - Use browser previews and in-editor debugging to iterate on front-end UI without constantly leaving the editor
+  - Run natural-language terminal instructions and fix lint or implementation issues during feature development
+  - Adopt AI coding in teams that need centralized billing, admin controls, analytics, and enterprise-ready workflows

--- a/tools/llm/gpt4all.yaml
+++ b/tools/llm/gpt4all.yaml
@@ -1,0 +1,25 @@
+name: GPT4All
+description: GPT4All is an open-source local LLM runtime and desktop app from Nomic that lets users run, chat with, and serve large language models on everyday laptops and desktops without sending prompts to a hosted API.
+tagline: Run local LLMs privately on everyday devices
+
+github_url: https://github.com/nomic-ai/gpt4all
+website_url: https://www.nomic.ai/gpt4all
+docs_url: https://docs.gpt4all.io/
+install_command: pip install gpt4all
+
+category: LLM
+tags: [llm, local-inference, desktop-app, python-sdk, privacy, offline, retrieval, api]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Many teams need language model capabilities without depending on cloud APIs, exposing sensitive data,
+  or setting up specialized GPU infrastructure. GPT4All packages local model execution, desktop chat,
+  document-grounded retrieval, and a Python interface into one accessible tool that works on common hardware.
+
+use_cases:
+  - Run private on-device chat workflows for schools, nonprofits, clinics, and public sector teams handling sensitive data
+  - Prototype local LLM applications and APIs on a laptop before moving to larger hosted inference stacks
+  - Chat with internal documents using LocalDocs without uploading files to an external model provider
+  - Deploy offline language assistance in low-connectivity environments such as field operations or disaster response


### PR DESCRIPTION
## Summary
- Add GPT4All to the LLM catalog
- Add Jina Reader to the Data catalog
- Add Windsurf Editor to the Dev Tools catalog

## Tool links
- GPT4All: https://github.com/nomic-ai/gpt4all / https://www.nomic.ai/gpt4all
- Jina Reader: https://github.com/jina-ai/reader / https://jina.ai/reader
- Windsurf Editor: https://windsurf.com/editor

## Why these tools
- GPT4All covers private, offline local LLM workflows on consumer hardware
- Jina Reader covers web-to-LLM data ingestion and search grounding for agents and RAG
- Windsurf Editor covers AI-native developer workflows in an agentic IDE

## Validation
- [x] `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- [x] `npx tsx scripts/validate-tool.ts tools/llm/gpt4all.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/data/jina-reader.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/dev-tools/windsurf-editor.yaml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added metadata configurations for three new tools: Jina Reader for content ingestion and extraction, Windsurf Editor for development, and GPT4All for local language models. These configurations include descriptions, reference links, categories, and use-case information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->