### PR TITLE
Add AutoGPT, OpenAI Agents SDK, and Exa to catalog

### DIFF
--- a/tools/agent-frameworks/autogpt.yaml
+++ b/tools/agent-frameworks/autogpt.yaml
@@ -1,0 +1,26 @@
+name: AutoGPT
+description: AutoGPT is a platform for creating, deploying, and managing continuous AI agents that automate multi-step workflows. The repository also includes the newer AutoGPT Platform plus older AutoGPT Classic components.
+tagline: Build, deploy, and run AI agents
+
+github_url: https://github.com/Significant-Gravitas/AutoGPT
+website_url: https://agpt.co/
+docs_url: https://agpt.co/docs/
+install_command: curl -fsSL https://setup.agpt.co/install.sh -o install.sh && bash install.sh
+
+category: Agents
+tags: [agents, workflow-automation, low-code, self-hosted, docker, llm, autonomous-agents]
+pricing: freemium
+is_open_source: false
+license: Polyform Shield License 1.0.0 / MIT
+
+problem_solved: |
+  AutoGPT helps teams move from manual or brittle scripted workflows to persistent AI agents that
+  can execute multi-step tasks, trigger on events, and coordinate tools through a managed platform.
+  It reduces the engineering overhead of stitching together long-running automation logic, agent
+  state, and deployment infrastructure from scratch.
+
+use_cases:
+  - Automate routine business workflows with long-running agents that react to triggers and execute multi-step tasks
+  - Build low-code internal agents for research, content generation, or operational support without custom orchestration code
+  - Deploy self-hosted agent systems that combine tools, memory, and continuous execution for repeated business processes
+  - Prototype autonomous task pipelines that coordinate planning, execution, and reporting across connected services

--- a/tools/agent-frameworks/openai-agents-sdk.yaml
+++ b/tools/agent-frameworks/openai-agents-sdk.yaml
@@ -1,0 +1,25 @@
+name: OpenAI Agents SDK
+description: Open-source Python SDK from OpenAI for building agentic applications. It provides primitives for agents, handoffs, tools, guardrails, sessions, human-in-the-loop flows, and tracing.
+tagline: Build multi-agent Python workflows with tools, handoffs, and tracing
+
+github_url: https://github.com/openai/openai-agents-python
+docs_url: https://openai.github.io/openai-agents-python/
+install_command: pip install openai-agents
+
+category: Agents
+tags: [python, agents, multi-agent, orchestration, tool-calling, guardrails, tracing, mcp]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  OpenAI Agents SDK helps developers build multi-agent Python workflows with tool execution,
+  delegation between agents, validation, stateful sessions, and tracing without having to assemble
+  those orchestration pieces from scratch. It shortens the path from basic LLM calls to production
+  agent systems with clearer control flow and observability.
+
+use_cases:
+  - Build multi-agent applications where specialists hand work off between agents in a controlled workflow
+  - Add tool-calling agents to Python services that need structured actions instead of plain text responses
+  - Enforce input and output validation with guardrails before agent results reach downstream systems
+  - Implement human-in-the-loop approval steps for sensitive actions such as support, finance, or operations

--- a/tools/rag/exa.yaml
+++ b/tools/rag/exa.yaml
@@ -1,0 +1,28 @@
+name: Exa
+description: Exa is a hosted web search and content retrieval API for AI systems. It offers search, content extraction, answer, and monitoring endpoints, with official Python and JavaScript SDKs plus an MCP server.
+tagline: Web search and retrieval API for AI agents
+
+github_url: https://github.com/exa-labs
+website_url: https://exa.ai/
+docs_url: https://exa.ai/docs/reference/search-api-guide
+install_command: |
+  pip install exa-py
+  npm install exa-js
+
+category: RAG
+tags: [web-search, retrieval, rag, api, agents, mcp, crawling, structured-output]
+pricing: paid
+is_open_source: false
+license: Proprietary hosted service; SDKs MIT
+
+problem_solved: |
+  Exa gives agents live web retrieval and page-content extraction, reducing stale model knowledge
+  and making it easier to ground answers, research steps, and coding help in current web data. It
+  replaces brittle scraping and ad hoc search integrations with a single API built for LLM-driven
+  applications.
+
+use_cases:
+  - Ground coding or research agents with current web documentation instead of stale training data
+  - Retrieve cited search results and page contents for RAG pipelines that need live external knowledge
+  - Monitor websites or topics over time and trigger downstream workflows when new content appears
+  - Fetch structured highlights or extracted page text for chatbots, analysts, and automated research tools


### PR DESCRIPTION
## Summary
- Add AutoGPT to the Agents catalog
- Add OpenAI Agents SDK to the Agents catalog
- Add Exa to the RAG catalog

## Tool details
### AutoGPT
- Category: Agents
- GitHub: https://github.com/Significant-Gravitas/AutoGPT
- Website: https://agpt.co/
- Use cases: long-running workflow automation, self-hosted agent systems, low-code internal agents

### OpenAI Agents SDK
- Category: Agents
- GitHub: https://github.com/openai/openai-agents-python
- Docs: https://openai.github.io/openai-agents-python/
- Use cases: multi-agent orchestration, tool-calling Python apps, guardrails and tracing

### Exa
- Category: RAG
- Website: https://exa.ai/
- Docs: https://exa.ai/docs/reference/search-api-guide
- Use cases: live web retrieval, cited search for RAG, monitored web content ingestion

## Validation
- [x] `npx tsx scripts/validate-tool.ts tools/agent-frameworks/autogpt.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/agent-frameworks/openai-agents-sdk.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/rag/exa.yaml`
- [x] Only `tools/**/*.yaml` files included in the PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AutoGPT agent framework integration
  * Added OpenAI Agents SDK integration
  * Added Exa as a RAG tool for web search and content retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->