### PR TITLE
Add Replicate, W&B Weave, and Langflow to catalog

### DIFF
--- a/tools/dev-tools/langflow.yaml
+++ b/tools/dev-tools/langflow.yaml
@@ -1,0 +1,26 @@
+name: Langflow
+description: Open-source visual framework for building, testing, and deploying AI workflows, agents, and RAG applications with reusable components and APIs.
+tagline: Visual builder for AI workflows, agents, and RAG apps
+
+github_url: https://github.com/langflow-ai/langflow
+website_url: https://www.langflow.org/
+docs_url: https://docs.langflow.org/
+install_command: uv pip install langflow
+
+category: Dev Tools
+tags: [workflow-builder, agents, rag, visual-builder, low-code, python, open-source]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Building AI workflows often means wiring prompts, models, tools, retrieval, and APIs together by
+  hand before you can even test whether the overall experience works. Langflow provides a visual,
+  component-based builder with playground and deployment paths so teams can prototype, iterate, and
+  operationalize agentic and RAG-style applications faster than assembling each integration manually.
+
+use_cases:
+  - Build chatbot and assistant workflows with drag-and-drop components and reusable logic
+  - Prototype retrieval-augmented generation pipelines for document question answering
+  - Create and test agentic application flows before embedding them into a product
+  - Expose completed flows through an API for internal tools, demos, or production integrations

--- a/tools/llm/replicate.yaml
+++ b/tools/llm/replicate.yaml
@@ -1,0 +1,26 @@
+name: Replicate
+description: Hosted platform and API for running, fine-tuning, and deploying AI models without managing your own GPU inference stack.
+tagline: Run and ship AI models through a hosted API
+
+github_url: https://github.com/replicate/replicate-python
+website_url: https://replicate.com/
+docs_url: https://replicate.com/docs
+install_command: pip install replicate
+
+category: LLM
+tags: [llm, inference, model-hosting, fine-tuning, deployment, multimodal, api]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Teams often want to use or customize AI models without provisioning GPUs, building inference
+  services, or handling deployment and scaling for each model separately. Replicate provides a
+  hosted API and deployment workflow for running public models and custom private models so teams
+  can integrate generation, fine-tuning, and inference into products without operating the full
+  model-serving infrastructure themselves.
+
+use_cases:
+  - Run image, video, speech, and language models through a single hosted API
+  - Fine-tune supported models on hosted infrastructure instead of managing training hardware
+  - Deploy private custom models with autoscaling for product features or internal tools
+  - Prototype AI application features quickly from Python, JavaScript, or direct HTTP calls

--- a/tools/monitoring/wb-weave.yaml
+++ b/tools/monitoring/wb-weave.yaml
@@ -1,0 +1,26 @@
+name: "W&B Weave"
+description: Weights & Biases' observability and evaluation platform for tracing, testing, debugging, and improving LLM apps and agents.
+tagline: Track, test, and improve language model apps
+
+github_url: https://github.com/wandb/weave
+website_url: https://wandb.ai/site/weave
+docs_url: https://docs.wandb.ai/weave
+install_command: pip install weave
+
+category: Monitoring
+tags: [observability, tracing, evaluation, llm, agents, monitoring, debugging]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  LLM applications and agents are hard to evaluate after the prompt leaves a notebook: teams lose
+  visibility into traces, cannot compare prompt or model changes reliably, and struggle to monitor
+  quality, latency, cost, and safety in production. W&B Weave captures traces, supports evaluation
+  workflows, and helps teams compare versions and monitor real application behavior over time.
+
+use_cases:
+  - Trace and debug LLM application inputs, outputs, and call trees during development
+  - Evaluate model or agent responses with judges, scorers, and repeatable test datasets
+  - Compare prompts, datasets, and application versions across experiments and releases
+  - Monitor production AI quality, latency, token usage, and cost trends over time


### PR DESCRIPTION
## Summary
- add Replicate in the LLM category
- add W&B Weave in the Monitoring category
- add Langflow in the Dev Tools category
- validate all three YAML entries locally with the repo validator

## Tool links
- Replicate: https://replicate.com/
- W&B Weave: https://wandb.ai/site/weave
- Langflow: https://www.langflow.org/

## Example use cases
- Run hosted multimodal and language models through Replicate without operating GPU inference infrastructure
- Trace, evaluate, and monitor LLM applications with W&B Weave
- Build and deploy visual AI workflows, agents, and RAG apps with Langflow

## Validation checklist
- [x] YAML files created in correct category directories
- [x] Local validation passed with `npx tsx scripts/validate-tool.ts`
- [x] Only `tools/**/*.yaml` files are included in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three new integrations: Langflow (development tools), Replicate (large language models), and W&B Weave (monitoring and tracing).
  * Each integration provides platform metadata, installation guides, pricing information, open-source status, and comprehensive documentation of use cases and problem statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->