### PR TITLE
Add BentoML, txtai, and Portkey to catalog

### DIFF
--- a/tools/dev-tools/bentoml.yaml
+++ b/tools/dev-tools/bentoml.yaml
@@ -1,0 +1,26 @@
+name: BentoML
+description: Open-source inference and deployment platform for packaging, serving, and scaling AI models and custom AI applications across local and cloud environments.
+tagline: Package, serve, and scale AI systems
+
+github_url: https://github.com/bentoml/BentoML
+website_url: https://www.bentoml.com/
+docs_url: https://docs.bentoml.com/en/latest/
+install_command: pip install bentoml
+
+category: Dev Tools
+tags: [inference, deployment, serving, llm, rag, agents, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Shipping AI systems to production usually means combining model packaging, API serving,
+  autoscaling, and infrastructure glue from several different tools before a team can deploy
+  reliably. BentoML provides a unified framework to package models and custom inference pipelines,
+  expose them as services, and run them consistently across local and cloud environments.
+
+use_cases:
+  - Serve OpenAI-compatible model APIs from your own infrastructure or cloud environment
+  - Deploy private RAG systems and custom inference services for internal or customer-facing apps
+  - Package and scale agent backends, batch jobs, or multimodel AI application workflows
+  - Standardize model serving for teams that need repeatable builds and deployments

--- a/tools/monitoring/portkey.yaml
+++ b/tools/monitoring/portkey.yaml
@@ -1,0 +1,28 @@
+name: Portkey
+description: Production platform for GenAI applications with an AI gateway, observability, guardrails, routing, and prompt management across multiple model providers.
+tagline: Production stack for GenAI builders
+
+github_url: https://github.com/Portkey-AI/gateway
+website_url: https://portkey.ai/
+docs_url: https://portkey.ai/docs/introduction/what-is-portkey
+install_command: |
+  npx @portkey-ai/gateway
+  pip install portkey-ai
+
+category: Monitoring
+tags: [observability, gateway, routing, guardrails, prompts, llm, production]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Production LLM systems often sprawl across providers, prompts, retries, fallbacks, logging, and
+  governance rules, which makes them difficult to monitor and operate consistently. Portkey brings
+  gateway routing, observability, prompt management, and guardrails into one platform so teams can
+  run and control AI traffic with fewer custom integrations.
+
+use_cases:
+  - Monitor LLM requests, traces, and usage metrics across multiple model providers
+  - Route traffic with retries, fallbacks, and provider selection through a unified AI gateway
+  - Apply guardrails and governance controls to production AI application traffic
+  - Manage prompts and API-backed prompt templates for teams shipping GenAI features

--- a/tools/rag/txtai.yaml
+++ b/tools/rag/txtai.yaml
@@ -1,0 +1,26 @@
+name: txtai
+description: Open-source AI framework for semantic search, embeddings, retrieval-backed applications, and language model workflows across text, audio, images, and video.
+tagline: Semantic search and RAG framework for multimodal data
+
+github_url: https://github.com/neuml/txtai
+website_url: https://neuml.github.io/txtai/
+docs_url: https://neuml.github.io/txtai/
+install_command: pip install txtai
+
+category: RAG
+tags: [rag, semantic-search, embeddings, retrieval, multimodal, python, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Teams building retrieval-backed AI applications often have to stitch together embeddings,
+  vector search, pipelines, and orchestration from separate libraries before they can answer
+  questions over their own data reliably. txtai combines semantic search, embeddings storage,
+  workflow primitives, and LLM-friendly retrieval capabilities in one framework.
+
+use_cases:
+  - Build retrieval-augmented generation and chat systems over internal knowledge bases
+  - Run semantic and similarity search across text, images, audio, and video collections
+  - Create knowledge sources for question answering, recommendation, and research workflows
+  - Connect embeddings, pipelines, and agent components in a single Python application


### PR DESCRIPTION
## Summary
- add BentoML in the Dev Tools category
- add txtai in the RAG category
- add Portkey in the Monitoring category
- validate all three YAML entries locally with the repo validator

## Tool links
- BentoML: https://www.bentoml.com/
- txtai: https://neuml.github.io/txtai/
- Portkey: https://portkey.ai/

## Example use cases
- Package and deploy AI inference services and model APIs with BentoML
- Build retrieval-augmented applications and semantic search workflows with txtai
- Monitor, route, and govern production LLM traffic with Portkey

## Validation checklist
- [x] YAML files created in correct category directories
- [x] Local validation passed with `npx tsx scripts/validate-tool.ts`
- [x] Only `tools/**/*.yaml` files are included in this PR
