### PR TITLE
Add OpenAI, torchtune, and Vespa to catalog

### DIFF
--- a/tools/fine-tuning/torchtune.yaml
+++ b/tools/fine-tuning/torchtune.yaml
@@ -1,0 +1,26 @@
+name: torchtune
+description: PyTorch-native library for LLM post-training and fine-tuning with configurable recipes for supervised tuning, LoRA/QLoRA, preference optimization, distillation, and quantization.
+tagline: PyTorch-native library for LLM post-training and fine-tuning
+
+github_url: https://github.com/meta-pytorch/torchtune
+website_url: https://pytorch.org/torchtune/
+docs_url: https://pytorch.org/torchtune/main/index.html
+install_command: pip install torchtune
+
+category: Fine-tuning
+tags: [pytorch, fine-tuning, lora, qlora, distillation, post-training, llm]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Adapting open language models usually requires custom training code, experiment scaffolding, and careful
+  memory optimization before teams can run practical fine-tuning jobs. torchtune packages common post-training
+  workflows into reusable PyTorch recipes, YAML configs, and a CLI so developers can fine-tune, distill,
+  optimize, and evaluate models with less glue code.
+
+use_cases:
+  - Run LoRA or QLoRA fine-tuning for Llama, Qwen, Gemma, or Mistral models
+  - Launch supervised fine-tuning jobs from reusable YAML training recipes
+  - Distill larger teacher models into smaller student models for deployment
+  - Experiment with preference optimization workflows such as DPO, PPO, or GRPO

--- a/tools/llm/openai.yaml
+++ b/tools/llm/openai.yaml
@@ -1,0 +1,27 @@
+name: OpenAI
+description: API platform and official SDKs for accessing OpenAI models for text generation, vision, and realtime multimodal interactions from Python and JavaScript.
+tagline: Model APIs and SDKs for text, vision, and realtime multimodal apps
+
+github_url: https://github.com/openai
+website_url: https://openai.com/
+docs_url: https://platform.openai.com/docs/api-reference
+install_command: |
+  pip install openai
+  npm install openai
+
+category: LLM
+tags: [llm, api, vision, realtime, multimodal, python, javascript]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Teams often need one reliable API surface for text generation, image understanding, structured outputs,
+  tool calling, and low-latency multimodal interactions without assembling multiple model vendors and SDKs.
+  OpenAI provides hosted models and official client libraries so developers can build production AI features
+  from Python or JavaScript with one platform.
+
+use_cases:
+  - Generate text responses and structured outputs with the Responses API
+  - Analyze images and multimodal inputs in applications and workflows
+  - Build realtime text and audio assistants with low-latency streaming APIs
+  - Add tool calling and agent-like workflows inside production apps

--- a/tools/vector-databases/vespa.yaml
+++ b/tools/vector-databases/vespa.yaml
@@ -1,0 +1,26 @@
+name: Vespa
+description: Open-source AI search and data serving engine for querying and ranking vectors, tensors, text, and structured data in real time, with support for large-scale retrieval, filtering, and learned ranking.
+tagline: Open-source engine for real-time vector, text, and structured search
+
+github_url: https://github.com/vespa-engine/vespa
+website_url: https://vespa.ai/
+docs_url: https://docs.vespa.ai/
+install_command: docker run --detach --name vespa --hostname vespa-tutorial --publish 8080:8080 --publish 19071:19071 --publish 19092:19092 vespaengine/vespa
+
+category: Vector DB
+tags: [vector-database, search, hybrid-search, retrieval, ranking, ann, open-source]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Teams building retrieval systems often need vector similarity, keyword search, metadata filters, and ranking
+  over large datasets that change continuously. Vespa combines vector search, text search, tensor operations,
+  filtering, and learned ranking in one engine so developers can serve low-latency retrieval and recommendation
+  workloads without stitching together separate serving layers.
+
+use_cases:
+  - Build hybrid search across text, vectors, and metadata filters
+  - Power RAG retrieval with ranking, filtering, and real-time index updates
+  - Serve recommendation and personalization systems for content or products
+  - Run large-scale semantic search over enterprise or application data


### PR DESCRIPTION
## Summary
- Add OpenAI to the LLM catalog
- Add torchtune to the Fine-tuning catalog
- Add Vespa to the Vector DB catalog

## Tool links
- OpenAI: https://openai.com/
- torchtune: https://pytorch.org/torchtune/
- Vespa: https://vespa.ai/

## Use cases covered
- Hosted model APIs and SDKs for text, vision, tool calling, and realtime multimodal apps
- PyTorch-native LLM post-training workflows including LoRA/QLoRA, distillation, and preference optimization
- Hybrid retrieval systems combining vector search, keyword search, filtering, and ranking

## Validation
- [x] `npx tsx scripts/validate-tool.ts tools/llm/openai.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/fine-tuning/torchtune.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/vector-databases/vespa.yaml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added entries for three tools: torchtune (fine-tuning framework), OpenAI (LLM platform), and Vespa (vector database), each with descriptions, installation guides, categorization, and supported use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->