### PR TITLE
Add Cerebras, Modal, and RunPod to catalog

### DIFF
--- a/tools/llm/cerebras.yaml
+++ b/tools/llm/cerebras.yaml
@@ -1,0 +1,28 @@
+name: Cerebras
+description: Cloud API for ultra-fast LLM inference powered by the Wafer-Scale Engine (WSE-3), delivering 2,000+ tokens per second with OpenAI-compatible endpoints.
+tagline: The world's fastest AI inference — 2,000+ tokens per second
+
+github_url: https://github.com/Cerebras/cerebras-cloud-sdk-python
+website_url: https://cerebras.ai
+docs_url: https://inference-docs.cerebras.ai
+install_command: pip install cerebras-cloud-sdk
+
+category: LLM
+tags: [inference, llm, api, openai-compatible, ultra-fast, reasoning, wafer-scale]
+pricing: freemium
+is_open_source: false
+license: Apache-2.0
+
+problem_solved: |
+  LLM inference is too slow for real-time applications like voice assistants, agentic
+  loops, coding copilots, and interactive chat — users experience multi-second latency
+  with GPU-based inference at scale. Cerebras' Wafer-Scale Engine delivers 10-15x faster
+  inference than GPU alternatives (2,000+ tokens/second), enabling genuinely real-time AI
+  experiences with an OpenAI-compatible API so switching requires just changing the endpoint.
+
+use_cases:
+  - Power real-time voice AI assistants with sub-100ms response latency for natural conversation
+  - Enable multi-step agentic workflows without timeout or stall delays between reasoning turns
+  - Build interactive coding copilots where completions appear instantly during typing
+  - Deploy high-throughput batch inference at lower cost-per-token using ultra-fast token generation
+  - Run complex reasoning chains and logic traces in under a second for search and analysis

--- a/tools/other/modal.yaml
+++ b/tools/other/modal.yaml
@@ -1,0 +1,29 @@
+name: Modal
+description: Serverless GPU cloud platform for AI inference, training, batch processing, and data pipelines with sub-second cold starts and per-second billing.
+tagline: High-performance serverless AI infrastructure developers love
+
+github_url: https://github.com/modal-labs/modal-client
+website_url: https://modal.com
+docs_url: https://modal.com/docs
+install_command: pip install modal
+
+category: Other
+tags: [serverless, gpu, inference, training, batch-processing, cloud, infrastructure, python, autoscaling]
+pricing: freemium
+is_open_source: false
+license: Apache-2.0
+
+problem_solved: |
+  AI teams waste significant time and money managing GPU infrastructure — provisioning
+  instances, configuring Docker containers, handling autoscaling, and paying for idle
+  compute. Modal eliminates all of that by providing a serverless platform where you
+  write Python functions, annotate them with @app.function, and Modal handles deployment,
+  scaling, and billing down to the second. Cold starts in under a second and automatic
+  scale-to-zero mean you never pay for idle GPUs.
+
+use_cases:
+  - Deploy and scale LLM inference endpoints with automatic scale-to-zero when not in use
+  - Run ephemeral GPU workloads like model fine-tuning or batch inference without provisioning servers
+  - Execute massively parallel batch inference jobs across thousands of containers simultaneously
+  - Serve diffusion models and image/video generation with request-based autoscaling
+  - Launch ephemeral cloud notebooks and sandboxes for collaborative ML development

--- a/tools/other/runpod.yaml
+++ b/tools/other/runpod.yaml
@@ -1,0 +1,29 @@
+name: RunPod
+description: Cloud computing platform for AI and ML workloads offering GPU pods, serverless GPU workers, and endpoints — with 30+ GPU SKUs at affordable rates.
+tagline: The cloud built for AI — affordable GPU compute at scale
+
+github_url: https://github.com/runpod/runpod-python
+website_url: https://www.runpod.io
+docs_url: https://docs.runpod.io
+install_command: pip install runpod
+
+category: Other
+tags: [gpu, cloud, serverless, inference, training, fine-tuning, compute, infrastructure, docker]
+pricing: freemium
+is_open_source: false
+license: MIT
+
+problem_solved: |
+  GPU cloud compute is typically expensive, complex to set up, and difficult to scale.
+  Traditional cloud providers charge high premiums for GPU instances and require manual
+  infrastructure management. RunPod solves this by offering GPU instances starting at
+  $0.22/hr via its Community Cloud (peer-to-peer GPU sharing) plus Secure Cloud for
+  enterprise workloads, and Serverless GPU workers that auto-scale from 0 and charge
+  per second — making GPU compute accessible and affordable for developers of all sizes.
+
+use_cases:
+  - Run cost-effective GPU instances for training and fine-tuning models without cloud lock-in
+  - Deploy serverless inference endpoints that auto-scale to zero when idle to minimize costs
+  - Launch Jupyter notebooks with pre-installed AI frameworks in under a minute for experiments
+  - Host custom Docker containers with GPU support for ML experiments and CI pipelines
+  - Build and deploy production AI applications with global low-latency serverless endpoints


### PR DESCRIPTION
## Three new tools for the catalog (replenishment batch 21)

### Cerebras (LLM)
Ultra-fast LLM inference powered by the Wafer-Scale Engine (WSE-3) — 2,000+ tokens per second with OpenAI-compatible API endpoints.

- **Category:** LLM
- **Pricing:** freemium
- **License:** Apache-2.0 (SDK)

### Modal (Other)
Serverless GPU cloud platform for AI inference, training, batch processing, and data pipelines with sub-second cold starts and per-second billing.

- **Category:** Other
- **Pricing:** freemium
- **License:** Apache-2.0

### RunPod (Other)
Cloud computing platform for AI/ML offering GPU pods, serverless workers, and endpoints — 30+ GPU SKUs from $0.22/hr via Community Cloud.

- **Category:** Other
- **Pricing:** freemium
- **License:** MIT

### Validation
- [x] All 3 YAML files validated locally via `validate-tool.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cerebras as a new LLM provider supporting OpenAI-compatible inference, with pricing details and use cases
  * Integrated Modal serverless GPU cloud platform with documentation links and installation instructions
  * Integrated RunPod GPU cloud platform with installation support and documented use cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nimit2801/Agentic-AI-For-Good-Website/pull/94)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->