### PR TITLE
Add Label Studio, Dagster, and Airbyte to catalog

### DIFF
--- a/tools/data/airbyte.yaml
+++ b/tools/data/airbyte.yaml
@@ -1,0 +1,27 @@
+name: Airbyte
+description: A data movement platform for replicating data from APIs, databases, files, and SaaS tools into warehouses, lakes, databases, and downstream AI applications through prebuilt connectors and managed or self-hosted deployment options.
+tagline: Move data from source systems into warehouses, lakes, and AI apps
+
+github_url: https://github.com/airbytehq/airbyte
+website_url: https://airbyte.com/
+docs_url: https://docs.airbyte.com/
+install_command: curl -LsfS https://get.airbyte.com | bash -
+
+category: Data
+tags: [data-replication, connectors, elt, etl, data-pipelines, databases, apis, ai-agents]
+pricing: freemium
+is_open_source: true
+license: Elastic License 2.0
+
+problem_solved: |
+  Pulling data from many operational systems into analytics or AI environments usually means building
+  and maintaining custom connectors, sync logic, and error handling for every source. Airbyte reduces
+  that integration burden with a large connector catalog and a platform for moving data from APIs,
+  databases, files, and SaaS tools into warehouses, lakes, and downstream AI workflows.
+
+use_cases:
+  - Replicate application databases into Snowflake, BigQuery, Databricks, or other analytics destinations
+  - Sync SaaS sources such as Salesforce, Google Sheets, and ad platforms into a central data warehouse
+  - Move file and object-store data into downstream databases or lakehouse environments
+  - Feed business data into AI agents, analytics models, and retrieval pipelines through scheduled syncs
+  - Standardize ingestion across many data sources without building custom connectors for each one

--- a/tools/data/dagster.yaml
+++ b/tools/data/dagster.yaml
@@ -1,0 +1,27 @@
+name: Dagster
+description: An open-source orchestration platform for building, running, and observing data pipelines and data assets, with developer-friendly workflows for testing, scheduling, lineage, and production operations.
+tagline: Orchestrate and observe data pipelines with software-engineering discipline
+
+github_url: https://github.com/dagster-io/dagster
+website_url: https://dagster.io/
+docs_url: https://docs.dagster.io/
+install_command: pip install dagster dagster-webserver dagster-dg-cli
+
+category: Data
+tags: [orchestration, data-pipelines, workflow, scheduling, lineage, data-assets, observability, python]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Data and AI teams need more than cron jobs and brittle scripts to run reliable pipelines. Dagster
+  provides a structured orchestration layer for defining data assets, dependencies, schedules, and
+  operational checks, so teams can build maintainable pipelines, understand lineage, and monitor data
+  workflows without stitching together their own orchestration and observability stack.
+
+use_cases:
+  - Orchestrate ETL and ELT pipelines that move data into warehouses, lakes, and feature stores
+  - Schedule and monitor data preparation workflows that feed RAG, analytics, or machine learning systems
+  - Manage lineage and health checks for production data assets across teams and environments
+  - Coordinate batch inference, evaluation, or retraining pipelines for AI applications
+  - Build local-to-production data workflows with testing, retries, and operational visibility

--- a/tools/data/label-studio.yaml
+++ b/tools/data/label-studio.yaml
@@ -1,0 +1,28 @@
+name: Label Studio
+description: An open-source data labeling and AI evaluation platform for collecting annotations, reviewing outputs, and running human-in-the-loop workflows across text, images, audio, video, and documents.
+tagline: Label data and evaluate AI systems with human-in-the-loop workflows
+
+github_url: https://github.com/HumanSignal/label-studio
+website_url: https://labelstud.io/
+docs_url: https://labelstud.io/guide/
+install_command: pip install label-studio
+
+category: Data
+tags: [data-labeling, annotation, ai-evaluation, human-in-the-loop, multimodal, rlhf, rag-evaluation, open-source]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Training and evaluating AI systems requires high-quality labeled data, review workflows, and human
+  feedback, but teams often end up juggling spreadsheets, ad hoc annotation tools, and custom review
+  UIs. Label Studio gives teams one platform to label multimodal datasets, review model outputs, and
+  capture human judgments for workflows such as model training, agent evaluation, and RAG quality
+  assessment.
+
+use_cases:
+  - Label images, text, audio, and documents to create datasets for machine learning workflows
+  - Review LLM, agent, or RAG outputs with human feedback before shipping to production
+  - Build RLHF and preference datasets from structured annotation and review tasks
+  - Run quality assurance workflows for document extraction, OCR, and classification systems
+  - Coordinate annotation projects across internal teams and external reviewers


### PR DESCRIPTION
## Summary
- Add Label Studio to the Data catalog
- Add Dagster to the Data catalog
- Add Airbyte to the Data catalog

## Tool links
- Label Studio: https://github.com/HumanSignal/label-studio
- Dagster: https://github.com/dagster-io/dagster
- Airbyte: https://github.com/airbytehq/airbyte

## Use cases covered
- Data labeling, human review, and AI evaluation workflows
- Data orchestration and operational visibility for analytics and AI pipelines
- Connector-based data movement into warehouses, lakes, and AI applications

## Validation checklist
- [x] YAML files created in the correct category directory
- [x] Local validation passed for all three files
- [x] Only `tools/**/*.yaml` files are included in the PR
