### PR TITLE
Add OpenRLHF, ms-swift, and Typesense to catalog

### DIFF
--- a/tools/fine-tuning/ms-swift.yaml
+++ b/tools/fine-tuning/ms-swift.yaml
@@ -1,0 +1,25 @@
+name: ms-swift
+description: Open-source framework from the ModelScope community for training, alignment, inference, evaluation, quantization, and deployment across hundreds of LLM and multimodal models.
+tagline: Fine-tune, align, and deploy LLMs and multimodal models in one framework
+
+github_url: https://github.com/modelscope/ms-swift
+website_url: https://modelscope.cn/home
+docs_url: https://swift.readthedocs.io/en/latest/
+install_command: pip install ms-swift -U
+
+category: Fine-tuning
+tags: [python, fine-tuning, multimodal, rlhf, grpo, quantization, deployment, modelscope]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Teams working with open models often need separate tooling for supervised fine-tuning, alignment, evaluation,
+  quantization, inference, and deployment, which creates duplicated configs and brittle workflows. ms-swift unifies
+  those stages so developers can adapt, evaluate, and serve many text and multimodal models from one framework.
+
+use_cases:
+  - Fine-tune open LLMs with LoRA or full-parameter training workflows
+  - Run RLHF or GRPO-style alignment jobs for better model behavior
+  - Train and evaluate multimodal models using text, image, audio, or video inputs
+  - Quantize and deploy supported models with backends such as vLLM, SGLang, or LMDeploy

--- a/tools/fine-tuning/openrlhf.yaml
+++ b/tools/fine-tuning/openrlhf.yaml
@@ -1,0 +1,25 @@
+name: OpenRLHF
+description: Open-source framework for RLHF and agentic reinforcement learning that combines distributed rollout, training, inference, and reward integration for scalable LLM and VLM training.
+tagline: Scale RLHF and agentic RL training with Ray, vLLM, and DeepSpeed
+
+github_url: https://github.com/OpenRLHF/OpenRLHF
+website_url: https://openrlhf.readthedocs.io/
+docs_url: https://openrlhf.readthedocs.io/en/latest/
+install_command: pip install openrlhf[vllm]
+
+category: Fine-tuning
+tags: [python, fine-tuning, rlhf, reinforcement-learning, llm-training, distributed-training, ray, vllm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building RLHF pipelines usually means wiring together separate tools for rollout, reward modeling, distributed
+  training, inference, and checkpoint management across many GPUs. OpenRLHF packages those pieces into one framework
+  so teams can run scalable SFT, preference optimization, and reinforcement learning workflows with less glue code.
+
+use_cases:
+  - Train PPO, GRPO, or REINFORCE-style alignment workflows for open LLMs
+  - Fine-tune models with SFT, reward modeling, and DPO in one framework
+  - Run distributed multi-node RLHF jobs with Ray, vLLM, and DeepSpeed
+  - Train vision-language models with image inputs inside reinforcement learning loops

--- a/tools/vector-databases/typesense.yaml
+++ b/tools/vector-databases/typesense.yaml
@@ -1,0 +1,32 @@
+name: Typesense
+description: Open-source search engine for fast keyword, typo-tolerant, faceted, vector, and semantic search via an API, available for self-hosting or as a managed cloud service.
+tagline: Fast keyword and vector search with simple APIs and self-hosting
+
+github_url: https://github.com/typesense/typesense
+website_url: https://typesense.org/
+docs_url: https://typesense.org/docs/
+install_command: |
+  export TYPESENSE_API_KEY=xyz
+  mkdir "$(pwd)"/typesense-data
+  docker run -p 8108:8108 \
+    -v"$(pwd)"/typesense-data:/data typesense/typesense:30.2 \
+    --data-dir /data \
+    --api-key=$TYPESENSE_API_KEY \
+    --enable-cors
+
+category: Vector DB
+tags: [vector-database, search-engine, vector-search, semantic-search, full-text-search, faceted-search, typo-tolerance, self-hosted]
+pricing: freemium
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Many teams need both semantic retrieval and traditional search, but larger search stacks can be operationally heavy
+  for simple product, documentation, or knowledge-base use cases. Typesense provides one engine for keyword,
+  autocomplete, filtering, and vector search so developers can ship low-latency retrieval without a complex setup.
+
+use_cases:
+  - Power semantic and hybrid retrieval over internal knowledge bases
+  - Build website or documentation search with autocomplete and typo tolerance
+  - Add vector-backed product search and faceted browsing to commerce apps
+  - Create geo-aware or structured record search for internal business tools


### PR DESCRIPTION
## Summary
- Add **OpenRLHF** to the Fine-tuning catalog
- Add **ms-swift** to the Fine-tuning catalog
- Add **Typesense** to the Vector DB catalog

## Tool links
- OpenRLHF: https://openrlhf.readthedocs.io/ · https://github.com/OpenRLHF/OpenRLHF
- ms-swift: https://swift.readthedocs.io/en/latest/ · https://github.com/modelscope/ms-swift
- Typesense: https://typesense.org/ · https://github.com/typesense/typesense

## Why these tools
- **OpenRLHF** gives teams a scalable framework for RLHF and agentic RL training on top of Ray, vLLM, and DeepSpeed
- **ms-swift** unifies fine-tuning, alignment, evaluation, quantization, and deployment for many LLM and multimodal models
- **Typesense** combines keyword, faceted, and vector search in one low-latency engine for retrieval-heavy applications

## Validation checklist
- [x] YAML files added in the correct category directories
- [x] Local validation passed with `npx tsx validate-tool.ts`
- [x] Only `tools/**/*.yaml` files are included in this PR
