### PR TITLE
Log sync errors and retrigger recent catalog syncs

### DIFF
--- a/scripts/sync-to-supabase.ts
+++ b/scripts/sync-to-supabase.ts
@@ -161,8 +161,13 @@ async function main() {
   for (const file of filesToSync) {
     try {
       await syncTool(file)
-    } catch {
+    } catch (error) {
       console.error(`Failed to sync ${file}`)
+      if (error instanceof Error) {
+        console.error(error.stack ?? error.message)
+      } else {
+        console.error(error)
+      }
       failed++
     }
   }

--- a/tools/fine-tuning/ms-swift.yaml
+++ b/tools/fine-tuning/ms-swift.yaml
@@ -1,6 +1,6 @@
 name: ms-swift
 description: Open-source framework from the ModelScope community for training, alignment, inference, evaluation, quantization, and deployment across hundreds of LLM and multimodal models.
-tagline: Fine-tune, align, and deploy LLMs and multimodal models in one framework
+tagline: Fine-tune, align, and deploy LLMs and multimodal models in one framework.
 
 github_url: https://github.com/modelscope/ms-swift
 website_url: https://modelscope.cn/home

--- a/tools/fine-tuning/openrlhf.yaml
+++ b/tools/fine-tuning/openrlhf.yaml
@@ -1,6 +1,6 @@
 name: OpenRLHF
 description: Open-source framework for RLHF and agentic reinforcement learning that combines distributed rollout, training, inference, and reward integration for scalable LLM and VLM training.
-tagline: Scale RLHF and agentic RL training with Ray, vLLM, and DeepSpeed
+tagline: Scale RLHF and agentic RL training with Ray, vLLM, and DeepSpeed.
 
 github_url: https://github.com/OpenRLHF/OpenRLHF
 website_url: https://openrlhf.readthedocs.io/

--- a/tools/llm/lmdeploy.yaml
+++ b/tools/llm/lmdeploy.yaml
@@ -1,6 +1,6 @@
 name: LMDeploy
 description: Open-source toolkit for compressing, deploying, and serving large language and vision-language models with optimized inference backends, quantization, and OpenAI-compatible APIs.
-tagline: Deploy and serve LLMs efficiently with optimized inference and APIs
+tagline: Deploy and serve LLMs efficiently with optimized inference and APIs.
 
 github_url: https://github.com/InternLM/lmdeploy
 website_url: https://lmdeploy.readthedocs.io/en/latest/

--- a/tools/monitoring/langwatch.yaml
+++ b/tools/monitoring/langwatch.yaml
@@ -1,6 +1,6 @@
 name: LangWatch
 description: Platform for LLM evaluations, AI agent testing, and production observability with tracing, simulations, datasets, and prompt tooling for development and runtime monitoring.
-tagline: Evaluate, test, and observe AI agents and LLM apps
+tagline: Evaluate, test, and observe AI agents and LLM apps.
 
 github_url: https://github.com/langwatch/langwatch
 website_url: https://langwatch.ai

--- a/tools/monitoring/trulens.yaml
+++ b/tools/monitoring/trulens.yaml
@@ -1,6 +1,6 @@
 name: TruLens
 description: Open-source evaluation and tracing framework for AI agents and LLM apps that captures OpenTelemetry traces, runs feedback metrics, and helps teams compare app versions.
-tagline: Evaluate and trace LLM apps and agents with OpenTelemetry
+tagline: Evaluate and trace LLM apps and agents with OpenTelemetry.
 
 github_url: https://github.com/truera/trulens
 website_url: https://www.trulens.org/

--- a/tools/vector-databases/typesense.yaml
+++ b/tools/vector-databases/typesense.yaml
@@ -1,6 +1,6 @@
 name: Typesense
 description: Open-source search engine for fast keyword, typo-tolerant, faceted, vector, and semantic search via an API, available for self-hosting or as a managed cloud service.
-tagline: Fast keyword and vector search with simple APIs and self-hosting
+tagline: Fast keyword and vector search with simple APIs and self-hosting.
 
 github_url: https://github.com/typesense/typesense
 website_url: https://typesense.org/


### PR DESCRIPTION
## Summary
- log the real exception in `scripts/sync-to-supabase.ts` when sync-on-merge fails
- retrigger sync for the six tools added in PRs #105 and #106 by making trivial YAML-only content updates

## Why
Recent `sync-on-merge.yml` runs failed after merge, but the workflow logs only showed `Failed to sync ...` without the underlying exception. This PR makes future failures diagnosable and reruns sync for:
- TruLens
- LMDeploy
- LangWatch
- OpenRLHF
- ms-swift
- Typesense

## Validation checklist
- [x] Local YAML validation passed with `npx tsx validate-tool.ts`
- [x] Sync script now logs the caught exception object
- [x] Touched tool YAML files to retrigger sync on merge
