### PR TITLE
Add Weights and Biases, DVC, and OpenSearch to catalog

### DIFF
--- a/tools/data/dvc.yaml
+++ b/tools/data/dvc.yaml
@@ -1,0 +1,28 @@
+name: DVC
+description: Open-source CLI and VS Code extension for versioning datasets and models, defining reproducible data pipelines, and tracking ML experiments with Git-linked metadata and remote storage.
+tagline: Git-like data and model versioning with pipelines and local experiment tracking
+
+github_url: https://github.com/treeverse/dvc
+website_url: https://dvc.org/
+docs_url: https://doc.dvc.org/
+install_command: pip install dvc
+
+category: Data
+tags: [data-versioning, mlops, pipelines, experiment-tracking, reproducibility, git, cli]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Git handles code well but breaks down when teams need to version large datasets, model artifacts,
+  and multi-step preprocessing or training pipelines. DVC keeps lightweight metadata in Git while
+  storing heavy files in external remotes, making data changes, pipeline stages, metrics, and
+  experiment results reproducible and shareable without stuffing binaries into the repository.
+
+use_cases:
+  - Version training datasets and model artifacts without storing binaries in Git
+  - Define reproducible multi-step ML pipelines in dvc.yaml
+  - Cache pipeline outputs so only changed stages rerun
+  - Store data in S3, GCS, Azure, SSH, or other remote backends
+  - Compare experiment metrics, params, and plots across local runs
+  - Share and reproduce experiments across teammates using Git and DVC remotes

--- a/tools/monitoring/weights-and-biases.yaml
+++ b/tools/monitoring/weights-and-biases.yaml
@@ -1,0 +1,28 @@
+name: Weights & Biases
+description: AI developer platform for experiment tracking, model and asset registry, hyperparameter sweeps, and LLM tracing and evaluation across ML and GenAI workflows.
+tagline: Experiment tracking, LLM tracing, and model registry for ML and AI teams
+
+github_url: https://github.com/wandb/wandb
+website_url: https://wandb.ai/
+docs_url: https://docs.wandb.ai/
+install_command: pip install wandb
+
+category: Monitoring
+tags: [experiment-tracking, llm-observability, model-registry, sweeps, mlops, evaluations, artifacts]
+pricing: freemium
+is_open_source: false
+license: MIT
+
+problem_solved: |
+  ML and LLM teams often scatter metrics, configs, prompts, traces, and artifacts across notebooks,
+  scripts, dashboards, and ad hoc spreadsheets. Weights & Biases gives teams one system to log runs,
+  compare experiments, version artifacts, trace LLM applications, and review results collaboratively
+  so they can reproduce work, catch regressions, and decide which models or prompts actually improved.
+
+use_cases:
+  - Track training metrics, configs, and checkpoints across many model runs
+  - Compare prompt, model, and parameter variants for LLM applications
+  - Store versioned datasets, models, and artifacts with lineage metadata
+  - Run hyperparameter sweeps and review results in one workspace
+  - Trace LLM or agent calls and score outputs during evaluation workflows
+  - Share dashboards, reports, and alerts with researchers and product teams

--- a/tools/vector-databases/opensearch.yaml
+++ b/tools/vector-databases/opensearch.yaml
@@ -1,0 +1,28 @@
+name: OpenSearch
+description: Open-source search and analytics engine with keyword, hybrid, and vector search for document retrieval, RAG backends, observability, and security analytics.
+tagline: Open-source search and vector engine for retrieval, analytics, and observability
+
+github_url: https://github.com/opensearch-project/OpenSearch
+website_url: https://opensearch.org/
+docs_url: https://docs.opensearch.org/latest/
+install_command: docker pull opensearchproject/opensearch:3.6.0
+
+category: Vector DB
+tags: [search-engine, vector-search, hybrid-search, analytics, observability, rag, lucene]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Teams building search, RAG, observability, or security systems often end up stitching together
+  separate engines for keyword search, filtering, analytics, and embedding retrieval. OpenSearch
+  lets them index documents, logs, and vectors in one engine and run keyword, hybrid, and vector
+  queries from a single platform instead of maintaining multiple specialized backends.
+
+use_cases:
+  - Semantic document retrieval for RAG pipelines
+  - Hybrid keyword and vector search over internal knowledge bases
+  - Log analytics and observability dashboards for distributed systems
+  - Enterprise website or document search with filtering and ranking
+  - Security event correlation and threat analytics across large log streams
+  - E-commerce product search with vector similarity and relevance tuning


### PR DESCRIPTION
## Summary
- add Weights & Biases in `tools/monitoring/weights-and-biases.yaml`
- add DVC in `tools/data/dvc.yaml`
- add OpenSearch in `tools/vector-databases/opensearch.yaml`

## Categories
- Monitoring: Weights & Biases
- Data: DVC
- Vector DB: OpenSearch

## Links
- Weights & Biases: https://wandb.ai/ · https://github.com/wandb/wandb
- DVC: https://dvc.org/ · https://github.com/treeverse/dvc
- OpenSearch: https://opensearch.org/ · https://github.com/opensearch-project/OpenSearch

## Use cases
- Track experiments, artifacts, and LLM traces with Weights & Biases
- Version datasets and reproduce ML pipelines with DVC
- Run hybrid and vector retrieval for RAG and search with OpenSearch

## Validation
- [x] `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- [x] `npx tsx scripts/validate-tool.ts tools/monitoring/weights-and-biases.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/data/dvc.yaml`
- [x] `npx tsx scripts/validate-tool.ts tools/vector-databases/opensearch.yaml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added tool metadata for DVC, Weights & Biases, and OpenSearch, including descriptions, installation instructions, and use cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nimit2801/Agentic-AI-For-Good-Website/pull/110)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->