### PR TITLE
Add Annoy, Braintrust, and Transformers.js to catalog

### DIFF
--- a/tools/monitoring/braintrust.yaml
+++ b/tools/monitoring/braintrust.yaml
@@ -1,0 +1,27 @@
+name: Braintrust
+description: AI observability and evaluation platform for tracing LLM and agent workflows, running structured evals, and monitoring prompt, model, and application behavior in production.
+tagline: Trace, evaluate, and monitor production AI systems
+
+github_url: https://github.com/braintrustdata/braintrust-sdk-python
+website_url: https://www.braintrust.dev/
+docs_url: https://www.braintrust.dev/docs
+install_command: |
+  pip install braintrust
+  npm install braintrust
+
+category: Monitoring
+tags: [observability, evaluations, tracing, llm, agents, prompts, monitoring]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Teams shipping LLM applications often lack a reliable way to trace prompt executions, compare
+  outputs, and measure whether model or prompt changes improved quality. Braintrust centralizes
+  traces, eval datasets, scoring, and experiment results so teams can debug failures, catch
+  regressions, and monitor how AI workflows behave after deployment.
+
+use_cases:
+  - Trace agent runs and LLM calls to debug failures in production applications
+  - Run offline and online evaluations against datasets before shipping prompt changes
+  - Compare model, prompt, and tool-calling variants with structured scores and feedback
+  - Monitor application behavior over time to catch regressions after deployment

--- a/tools/other/transformers-js.yaml
+++ b/tools/other/transformers-js.yaml
@@ -1,0 +1,26 @@
+name: Transformers.js
+description: Open-source JavaScript library for running Hugging Face transformer models in browsers and Node.js with a pipeline-style API backed by ONNX Runtime.
+tagline: Run transformer models directly in the browser or Node.js
+
+github_url: https://github.com/huggingface/transformers.js
+website_url: https://huggingface.co/docs/transformers.js
+docs_url: https://huggingface.co/docs/transformers.js
+install_command: npm i @huggingface/transformers
+
+category: Other
+tags: [javascript, browser, nodejs, transformers, onnx-runtime, nlp, computer-vision, speech]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  JavaScript teams often need a separate Python service just to run pretrained models for basic AI
+  features. Transformers.js lets developers execute many text, vision, audio, and multimodal models
+  directly in browser or Node.js environments, reducing backend complexity for prototyping and many
+  production inference workflows.
+
+use_cases:
+  - Add text classification, summarization, or embeddings to web apps with JavaScript
+  - Run speech recognition or audio analysis directly in browser-based experiences
+  - Build privacy-sensitive AI features that keep inference on the client device
+  - Prototype multimodal features in Node.js without standing up a separate model API

--- a/tools/vector-databases/annoy.yaml
+++ b/tools/vector-databases/annoy.yaml
@@ -1,0 +1,26 @@
+name: Annoy
+description: Open-source C++ library with Python bindings for approximate nearest-neighbor search on dense vectors, using compact mmap-backed indexes for fast loading and retrieval.
+tagline: Approximate nearest neighbors with compact, mmap-backed vector indexes
+
+github_url: https://github.com/spotify/annoy
+website_url: https://github.com/spotify/annoy
+docs_url: https://github.com/spotify/annoy#readme
+install_command: pip install annoy
+
+category: Vector DB
+tags: [vector-search, ann, similarity-search, embeddings, python, c-plus-plus, mmap]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Exact nearest-neighbor search becomes slow and memory-intensive once embedding collections grow
+  large. Annoy builds compact approximate indexes that can be memory-mapped from disk, making it
+  easier to serve fast similarity lookups, recommendations, and semantic retrieval without loading
+  every vector into one in-memory process.
+
+use_cases:
+  - Serve approximate vector search for embeddings in semantic retrieval systems
+  - Power recommendation features with fast nearest-neighbor lookups at low memory cost
+  - Share one read-only vector index across multiple application processes
+  - Load large similarity indexes quickly from disk in production services


### PR DESCRIPTION
## Summary
- add Annoy in Vector DB
- add Braintrust in Monitoring
- add Transformers.js in Other
- validate all three YAML entries locally with the catalog validator

## Tool links
- Annoy: https://github.com/spotify/annoy
- Braintrust: https://www.braintrust.dev/
- Transformers.js: https://github.com/huggingface/transformers.js

## Why these tools
- Annoy is a widely used approximate nearest-neighbor library for vector similarity search and recommendation workloads.
- Braintrust is a production-focused AI tracing and evaluation platform for LLM and agent applications.
- Transformers.js brings local model inference to browser and Node.js environments for JavaScript teams.

## Validation checklist
- [x] YAML files created in the correct category directories
- [x] Local validation passed for all added tools
- [x] Only `tools/**/*.yaml` files are included in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added metadata documentation for three development tools: Braintrust (observability platform), Transformers.js (ML library), and Annoy (vector database), expanding the tools registry with installation instructions, documentation links, and use case information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nimit2801/Agentic-AI-For-Good/pull/113)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->