### PR TITLE
Add KServe and Guidance to catalog

### DIFF
--- a/tools/llm/guidance.yaml
+++ b/tools/llm/guidance.yaml
@@ -1,0 +1,24 @@
+name: Guidance
+description: An open-source library from Microsoft that enables developers to control large language models more precisely than traditional prompting or chaining. It supports constrained generation with regex and context-free grammars, interleaving control logic with text generation, and producing structured outputs like JSON from schemas — reducing latency and cost through token fast-forwarding and efficient constrained decoding.
+tagline: A guidance language for controlling LLMs with constrained generation
+
+github_url: https://github.com/guidance-ai/guidance
+website_url: https://github.com/guidance-ai/guidance
+docs_url: https://guidance.readthedocs.io/en/latest/
+install_command: pip install guidance
+
+category: LLM
+tags: [llm, constrained-generation, structured-output, prompt-engineering, microsoft, json-generation, nlp, language-model]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Traditional LLM prompting lacks precise control over output structure and format, leading to unreliable results, high latency, and increased token costs from repetitive prompting. Guidance solves this by providing a programming paradigm where developers constrain LLM output with grammars, regex, and schemas while interleaving generation with control flow logic — guaranteeing structured output and reducing overhead.
+
+use_cases:
+  - Constrain LLM outputs with regex and context-free grammars for reliable structured generation
+  - Generate valid JSON from Pydantic schemas for data extraction and API integration
+  - Build multi-step prompting workflows with conditionals and loops for complex tasks
+  - Implement tool use and function calling with guaranteed syntax compliance
+  - Accelerate token generation through fast-forwarding cached prefix patterns

--- a/tools/other/kserve.yaml
+++ b/tools/other/kserve.yaml
@@ -1,0 +1,23 @@
+name: KServe
+description: KServe is a CNCF incubating project that provides a standardized serverless inference platform for both generative AI (LLMs via vLLM, OpenAI-compatible protocol) and predictive AI (TensorFlow, PyTorch, XGBoost, ONNX, scikit-learn) on Kubernetes. It features request-based autoscaling with scale-to-zero, canary rollouts, GPU acceleration, and inference pipelines for production-grade ML model serving.
+tagline: Serverless inference platform for generative and predictive AI on Kubernetes
+
+github_url: https://github.com/kserve/kserve
+website_url: https://kserve.github.io/website/
+docs_url: https://kserve.github.io/website/
+
+category: Other
+tags: [kubernetes, model-serving, inference, mlops, llm, serverless, cncf, vllm, kubeflow]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Deploying and scaling machine learning models in production across frameworks (PyTorch, TensorFlow, XGBoost, ONNX) and GPU configurations is complex — teams handle infrastructure plumbing instead of modeling. KServe provides a unified Kubernetes-native platform that standardizes inference serving with built-in autoscaling, canary deployments, monitoring, and a serverless architecture that reduces operational costs.
+
+use_cases:
+  - Deploy large language models with vLLM for production-grade inference on Kubernetes
+  - Serve predictive ML models (PyTorch, TensorFlow, XGBoost, ONNX) with autoscaling and scale-to-zero
+  - Implement canary rollouts and A/B testing for new model version deployments
+  - Build multi-step inference pipelines using InferenceGraph for complex serving workflows
+  - Achieve cost-efficient GPU serving with request-based autoscaling on Kubernetes clusters


### PR DESCRIPTION
Add two new tools to the Agentic AI For Good catalog:

## KServe (Other)
- **Description:** CNCF incubating serverless inference platform for generative and predictive AI on Kubernetes
- **GitHub:** https://github.com/kserve/kserve (5,480 stars, Apache-2.0)
- **Use cases:** LLM serving with vLLM, predictive model serving, canary rollouts, inference pipelines, GPU cost optimization

## Guidance (LLM)
- **Description:** Microsoft's open-source guidance language for controlling LLMs with constrained generation
- **GitHub:** https://github.com/guidance-ai/guidance (21,460+ stars, MIT)
- **Use cases:** Constrained generation with regex/CFGs, structured JSON outputs, multi-step prompting, tool use

### Validation Checklist
- [x] YAML files created in correct category directories
- [x] Local validation passes for both tools
- [x] `description` (20-500 chars), `problem_solved` (50+ chars), `use_cases` (3+ items, 10+ chars each)
- [x] Required fields present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guidance tool now available in the catalog with installation instructions, documentation links, and comprehensive use case information.
  * KServe tool added to the catalog, supporting generative and predictive model serving, autoscaling capabilities, canary rollouts, inference pipelines, and cost-efficient GPU serving.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nimit2801/Agentic-AI-For-Good/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->