### PR TITLE
Add LightRAG, Oumi, and Zvec to catalog

### DIFF
--- a/tools/fine-tuning/oumi.yaml
+++ b/tools/fine-tuning/oumi.yaml
@@ -1,0 +1,24 @@
+name: Oumi
+description: Oumi is an open-source platform that streamlines the entire lifecycle of foundation models — from data preparation and fine-tuning to evaluation and deployment. Supports SFT, LoRA, QLoRA, GRPO, DPO, and more across models from 10M to 405B parameters (Llama, DeepSeek, Qwen, Gemma, Phi). Runs on laptops, clusters, or cloud infrastructure.
+tagline: Everything you need to build state-of-the-art foundation models, end-to-end
+
+github_url: https://github.com/oumi-ai/oumi
+docs_url: https://oumi.ai/docs
+website_url: https://oumi.ai
+install_command: pip install oumi
+
+category: Fine-tuning
+tags: [fine-tuning, sft, dpo, lora, qlora, grpo, training, llm, evaluation, inference, vlm, deepseek, llama, qwen]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Fine-tuning and deploying foundation models involves a fragmented toolchain — separate scripts for data prep, training, evaluation, and inference across different hardware configurations. Oumi unifies this lifecycle by providing one configuration-driven platform that handles data synthesis, LLM-as-a-judge curation, distributed training (SFT/DPO/GRPO/LoRA), standard benchmarks, and vLLM/SGLang-based deployment — from laptop to multi-node clusters.
+
+use_cases:
+  - Full fine-tuning and LoRA/QLoRA tuning of open-source LLMs like Llama 4 and DeepSeek
+  - GRPO/RLHF fine-tuning for improving reasoning model performance
+  - Synthesize training data and curate datasets with LLM-as-a-judge evaluation
+  - Evaluate models across standard LLM and VLM benchmarks in a consistent pipeline
+  - Deploy fine-tuned models with optimized inference engines (vLLM, SGLang) to production

--- a/tools/rag/lightrag.yaml
+++ b/tools/rag/lightrag.yaml
@@ -1,0 +1,24 @@
+name: LightRAG
+description: LightRAG is a graph-based RAG framework published at EMNLP 2025 that builds a knowledge graph from documents for efficient retrieval. It supports incremental updates, hybrid search combining dense and graph traversal, multimodal document processing, and multiple storage backends including Neo4j, MongoDB, PostgreSQL, and OpenSearch.
+tagline: Simple and fast retrieval-augmented generation with graph-based document retrieval
+
+github_url: https://github.com/HKUDS/LightRAG
+docs_url: https://github.com/HKUDS/LightRAG#readme
+website_url: https://github.com/HKUDS/LightRAG
+install_command: pip install lightrag-hku
+
+category: RAG
+tags: [rag, knowledge-graph, graphrag, retrieval, llm, genai, hybrid-search, emnlp, python]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Traditional RAG systems struggle with multi-hop reasoning, context diversity, and incremental updates — retrieving isolated chunks rather than understanding document relationships. LightRAG solves this by constructing a knowledge graph from documents so retrieval follows entity relationships, supports incremental graph updates without full re-indexing, and combines dense vector search with graph traversal for more accurate answers on complex queries.
+
+use_cases:
+  - Build knowledge-graph-powered RAG systems for enterprise document question answering
+  - Perform multi-hop reasoning across complex, interconnected document collections
+  - Incrementally add new documents with automatic graph regeneration and deduplication
+  - Enable hybrid search combining dense embeddings and graph traversal for higher recall
+  - Support multimodal RAG pipelines with text, image, and table extraction integration

--- a/tools/vector-databases/zvec.yaml
+++ b/tools/vector-databases/zvec.yaml
@@ -1,0 +1,26 @@
+name: Zvec
+description: Zvec is an open-source, in-process vector database from Alibaba that embeds directly into applications as a library with no server process. It supports dense and sparse vector types, hybrid search with structured metadata filters, write-ahead logging for durability, concurrent multi-process reads, and cross-platform deployment including Linux, macOS, Windows, iOS, and Android.
+tagline: A lightweight, lightning-fast, in-process vector database
+
+github_url: https://github.com/alibaba/zvec
+docs_url: https://github.com/alibaba/zvec#readme
+website_url: https://github.com/alibaba/zvec
+install_command: |
+  pip install zvec
+  npm install @zvec/zvec
+
+category: Vector DB
+tags: [vector-database, embedded, in-process, hnsw, similarity-search, semantic-search, rag, llm-memory, agent-skills, local, edge]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Production vector search often requires running a separate server process (Pinecone, Qdrant, Weaviate), adding operational complexity, latency, and cost for edge or embedded scenarios. Zvec solves this by embedding directly into the application as a lightweight library — no server, no network calls — while still providing production-grade durability through write-ahead logging, concurrent multi-process reads, and structured metadata filtering across platforms.
+
+use_cases:
+  - Embed vector similarity search inside serverless or edge applications without a server process
+  - Build local-first RAG applications on laptops, edge devices, or mobile platforms
+  - Power AI agent memory backends with a lightweight, in-process vector store
+  - Enable on-device semantic search for iOS and Android applications via Dart/Flutter SDK
+  - Perform hybrid search combining dense embeddings with structured metadata filters at low latency


### PR DESCRIPTION
Add three new tools to the Agentic AI For Good catalog:

## LightRAG (RAG)
- **Description:** Graph-based RAG framework (EMNLP 2025) that builds knowledge graphs from documents for efficient retrieval with hybrid search
- **GitHub:** https://github.com/HKUDS/LightRAG (35,277 stars, MIT)
- **Use cases:** Knowledge-graph RAG, multi-hop reasoning, incremental document ingestion, multimodal RAG

## Oumi (Fine-tuning)
- **Description:** Open-source end-to-end platform for fine-tuning, evaluating, and deploying foundation models from 10M to 405B parameters
- **GitHub:** https://github.com/oumi-ai/oumi (9,227 stars, Apache-2.0)
- **Use cases:** SFT/LoRA/QLoRA/GRPO/DPO fine-tuning, data synthesis, LLM-as-a-judge, model evaluation, deployment

## Zvec (Vector DB)
- **Description:** Lightweight, in-process vector database from Alibaba that embeds as a library with no server process
- **GitHub:** https://github.com/alibaba/zvec (9,633 stars, Apache-2.0)
- **Use cases:** Edge/serverless vector search, local-first RAG, AI agent memory, on-device semantic search

### Validation Checklist
- [x] YAML files created in correct category directories
- [x] Local validation passes for all three tools
- [x] `description`, `problem_solved`, `use_cases` all meet length requirements
- [x] Required fields present for all tools
