### PR TITLE
Add NVIDIA Triton Inference Server, Jupyter, and WhyLabs to catalog

### DIFF
--- a/tools/dev-tools/jupyter.yaml
+++ b/tools/dev-tools/jupyter.yaml
@@ -1,0 +1,24 @@
+name: Jupyter
+description: Jupyter is an open-source, web-based interactive computing platform that allows users to create and share documents containing live code, equations, visualizations, and narrative text. It supports over 40 programming languages including Python, R, and Julia, and is the de facto standard for exploratory data analysis, ML prototyping, and reproducible research.
+tagline: Web-based interactive computing for data science, ML, and research
+
+github_url: https://github.com/jupyter/jupyter
+docs_url: https://docs.jupyter.org
+website_url: https://jupyter.org
+install_command: pip install jupyter
+
+category: Dev Tools
+tags: [notebook, interactive, data-science, python, visualization, research, reproducible, development]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Data science and ML workflows require iterating between code, results, visualizations, and documentation — a cycle that breaks with traditional script-based development. Jupyter solves this by providing an interactive web-based notebook environment where live code, execution results, rich visualizations, and markdown documentation live together in a single shareable document, enabling rapid iteration and reproducible research.
+
+use_cases:
+  - Prototype and visualize ML models with live code execution and inline plots
+  - Create reproducible research documents combining code, results, and narrative text
+  - Perform exploratory data analysis with interactive visualizations and statistical summaries
+  - Teach and learn data science with executable, self-contained tutorial notebooks
+  - Build dashboards and reports with interactive widgets for non-technical stakeholders

--- a/tools/monitoring/whylabs.yaml
+++ b/tools/monitoring/whylabs.yaml
@@ -1,0 +1,24 @@
+name: WhyLabs
+description: WhyLabs is an AI observability platform that helps teams monitor, analyze, and improve the performance and data quality of machine learning models in production. It provides automated monitoring for data drift, model drift, data quality, and performance degradation with integrated root-cause analysis and alerting, powered by the open-source whylogs data logging library.
+tagline: AI observability for monitoring, analyzing, and improving ML in production
+
+github_url: https://github.com/whylabs/whylogs
+docs_url: https://docs.whylabs.ai
+website_url: https://whylabs.ai
+install_command: pip install whylogs
+
+category: Monitoring
+tags: [observability, monitoring, data-drift, model-drift, data-quality, mlops, logging, ai-monitoring, production]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  ML models in production degrade silently — data drift, feature skew, and performance drops often go undetected until users notice or downstream systems fail. WhyLabs solves this by providing continuous monitoring that profiles data and model outputs with the open-source whylogs library, detects drift and data quality issues automatically, and surfaces root causes through integrated dashboards and alerts, giving ML teams visibility into production model health.
+
+use_cases:
+  - Monitor ML models in production for data drift, model drift, and performance degradation
+  - Profile input data and model outputs with the open-source whylogs library for statistical summaries
+  - Set up automated alerts when data quality or model performance drops below thresholds
+  - Perform root-cause analysis for model failures by correlating drift across features and predictions
+  - Track model performance over time across deployments with privacy-preserving data logging

--- a/tools/other/triton-inference-server.yaml
+++ b/tools/other/triton-inference-server.yaml
@@ -1,0 +1,23 @@
+name: NVIDIA Triton Inference Server
+description: NVIDIA Triton Inference Server is an open-source inference serving software that streamlines AI inference by enabling teams to deploy, run, and scale trained models from any framework (TensorFlow, PyTorch, ONNX, TensorRT, and more) on GPU or CPU infrastructure with concurrent model serving, dynamic batching, and model pipelines.
+tagline: Standardized, optimized inference serving for any model on GPU or CPU
+
+github_url: https://github.com/triton-inference-server/server
+docs_url: https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/
+website_url: https://developer.nvidia.com/triton-inference-server
+
+category: Other
+tags: [inference-server, nvidia, model-serving, gpu, deep-learning, mlops, cloud, edge, production]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Deploying multiple models from different frameworks (TensorFlow, PyTorch, ONNX) on GPU infrastructure requires separate serving stacks per framework, wasting engineering effort and GPU memory. Triton solves this by providing a unified serving runtime that handles models from any framework with concurrent model management, dynamic batching for GPU utilization, model pipelines for preprocessing/postprocessing, and production features like health endpoints and metrics.
+
+use_cases:
+  - Serve multiple models from different frameworks on shared GPU infrastructure concurrently
+  - Optimize GPU utilization with dynamic batching and concurrent inference execution
+  - Build inference pipelines with pre-processing, post-processing, and ensemble models
+  - Deploy models at scale in production environments with health checks and Prometheus metrics
+  - Serve LLMs with optimized TensorRT-LLM backend for low-latency generation


### PR DESCRIPTION
Add three new tools to the Agentic AI For Good catalog:

## NVIDIA Triton Inference Server (Other)
- **Description:** Standardized, optimized inference serving for any model on GPU or CPU, supporting all major frameworks
- **GitHub:** https://github.com/triton-inference-server/server (10,667 stars, BSD-3-Clause)
- **Use cases:** Multi-framework model serving, dynamic batching, inference pipelines, LLM serving with TensorRT-LLM

## Jupyter (Dev Tools)
- **Description:** The de facto web-based interactive computing platform for data science, ML prototyping, and reproducible research
- **GitHub:** https://github.com/jupyter/jupyter (15,314 stars, BSD-3-Clause)
- **Use cases:** ML prototyping, reproducible research, data analysis, interactive visualization

## WhyLabs (Monitoring)
- **Description:** AI observability platform for monitoring data drift, model drift, data quality, and ML performance in production
- **GitHub:** https://github.com/whylabs/whylogs (2,820 stars, Apache-2.0)
- **Use cases:** Production ML monitoring, drift detection, root-cause analysis, alerting

### Validation Checklist
- [x] YAML files created in correct category directories
- [x] Local validation passes for all three tools
- [x] `description`, `problem_solved`, `use_cases` all meet length requirements
- [x] Required fields present for all tools
