### PR TITLE
Add DeepSeek, dbt, and PraisonAI to catalog

### DIFF
--- a/tools/agent-frameworks/praisonai.yaml
+++ b/tools/agent-frameworks/praisonai.yaml
@@ -1,0 +1,28 @@
+name: PraisonAI
+description: PraisonAI is a production-ready, open-source multi-agent framework for Python and JavaScript. It enables developers to deploy autonomous, self-improving AI agents with built-in memory, RAG, MCP tool support, and 100+ LLM integrations in just a few lines of code.
+tagline: Deploy autonomous multi-agent teams with memory, RAG, and 100+ LLMs
+
+github_url: https://github.com/MervinPraison/PraisonAI
+website_url: https://praison.ai
+docs_url: https://docs.praison.ai/
+
+install_command: pip install praisonai
+
+category: Agents
+tags: [python, agents, multi-agent, framework, automation, mcp, rag, llm, javascript]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Building autonomous AI agent systems from scratch requires significant boilerplate for memory
+  management, tool integration, RAG pipelines, and multi-platform deployment. PraisonAI eliminates
+  this complexity by providing a production-ready framework that lets developers ship multi-agent
+  workflows with persistent memory, tool use, and deployment to messaging platforms in minutes.
+
+use_cases:
+  - Conduct deep research and generate insights from multiple sources using coordinated agent teams
+  - Write, debug, and refactor code with AI agents that understand your codebase and context
+  - Generate blog posts, documentation, and marketing copy with specialized multi-agent pipelines
+  - Extract, transform, and analyze data from APIs, databases, and web sources autonomously
+  - Deploy 24/7 support bots on Telegram, Discord, Slack, and WhatsApp with memory-backed responses

--- a/tools/data/dbt.yaml
+++ b/tools/data/dbt.yaml
@@ -1,0 +1,28 @@
+name: dbt
+description: dbt enables data analysts and engineers to transform their data using analytics engineering best practices by writing SQL select statements, while dbt handles turning these statements into tables and views in a data warehouse.
+tagline: Transform data in your warehouse with software engineering best practices
+
+github_url: https://github.com/dbt-labs/dbt-core
+website_url: https://www.getdbt.com
+docs_url: https://docs.getdbt.com
+
+install_command: pip install dbt-core
+
+category: Data
+tags: [data-transformation, analytics-engineering, sql, data-pipelines, etl, data-warehouse, python]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Data transformation workflows are often messy, ungoverned, and lack software engineering discipline
+  like version control, testing, and documentation. dbt applies these best practices to analytics
+  workflows by letting analysts write modular SQL select statements that dbt compiles into tested,
+  documented tables and views across any major data warehouse.
+
+use_cases:
+  - Build modular, tested, and version-controlled SQL data pipelines in your warehouse
+  - Collaborate on data models with interactive lineage and column-level dependency tracing
+  - Automate data quality testing and auto-generate documentation for analytics datasets
+  - Deploy and monitor data transformations in production with built-in CI/CD support
+  - Centralize analytics code with governance guardrails to produce AI-ready clean datasets

--- a/tools/llm/deepseek.yaml
+++ b/tools/llm/deepseek.yaml
@@ -1,0 +1,30 @@
+name: DeepSeek
+description: DeepSeek is a Chinese AI research company providing powerful open-source and proprietary LLMs (DeepSeek-V3, R1) through a free chat interface and a low-cost, OpenAI-compatible API.
+tagline: High-performance open-source and proprietary LLMs with affordable API access
+
+github_url: https://github.com/deepseek-ai/DeepSeek-V3
+website_url: https://www.deepseek.com
+docs_url: https://api-docs.deepseek.com/
+
+install_command: |
+  pip install openai
+  npm install openai
+
+category: LLM
+tags: [llm, api, coding, reasoning, open-source, moe, chatbot, chinese]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Frontier-level large language models are often expensive, proprietary, or require complex infrastructure
+  to run locally. DeepSeek provides affordable, high-performance LLMs for coding, reasoning, and general
+  AI tasks through a low-cost OpenAI-compatible API and freely available open-source weights, making
+  advanced AI accessible without vendor lock-in.
+
+use_cases:
+  - Generate code and solve complex programming problems with state-of-the-art coding models
+  - Build AI chatbots and applications via the OpenAI-compatible API at a fraction of the cost
+  - Deploy open-source MoE models locally for private, on-premise inference without data leaving your environment
+  - Perform advanced mathematical reasoning and logical problem solving with specialized reasoning models
+  - Integrate tool calling and structured JSON outputs into production agentic workflows


### PR DESCRIPTION
## New Tools Added

| Tool | Category | Stars | License |
|------|----------|-------|---------|
| DeepSeek | LLM | 103k | MIT |
| dbt | Data | 12.7k | Apache-2.0 |
| PraisonAI | Agents | 7.7k | MIT |

### DeepSeek
Chinese AI research company providing powerful open-source and proprietary LLMs (DeepSeek-V3, R1) through a free chat interface and a low-cost, OpenAI-compatible API.

### dbt
dbt enables data analysts and engineers to transform their data using analytics engineering best practices by writing SQL select statements, while dbt handles turning these statements into tables and views in a data warehouse.

### PraisonAI
Production-ready, open-source multi-agent framework for Python and JavaScript. Deploy autonomous, self-improving AI agents with built-in memory, RAG, MCP tool support, and 100+ LLM integrations in just a few lines of code.

## Validation Checklist
- [x] YAML files created in correct category directories
- [x] Local validation passes (`npx tsx scripts/validate-tool.ts`)
- [x] Required fields present (name, description, problem_solved, use_cases, github_url)
