### PR TITLE
Add Baseten, Fivetran, and Neptune to catalog

### DIFF
--- a/tools/data/fivetran.yaml
+++ b/tools/data/fivetran.yaml
@@ -1,0 +1,24 @@
+name: Fivetran
+description: >
+  Fivetran is a fully managed, cloud-native data integration platform that automates data pipeline creation and maintenance, enabling reliable ETL from hundreds of sources into cloud data warehouses.
+problem_solved: >
+  Data teams spend excessive time building and maintaining brittle ETL pipelines. Fivetran solves this by providing automated, schema-drifting, fully managed data connectors that ensure reliable, up-to-date data syncs without engineering overhead.
+use_cases:
+  - "Automate data ingestion from SaaS applications into warehouses"
+  - "Centralize data into cloud data warehouses with managed connectors"
+  - "Build custom connectors with the open-source Connector SDK"
+github_url: https://github.com/fivetran/fivetran_connector_sdk
+website_url: https://fivetran.com
+docs_url: https://fivetran.com/docs
+install_command: pip install fivetran-connector-sdk
+tagline: "Automated data integration for the modern data stack"
+tags:
+  - etl
+  - data-integration
+  - data-pipeline
+  - saas
+  - warehouse
+  - connector
+pricing: paid
+is_open_source: false
+license: Proprietary

--- a/tools/monitoring/neptune.yaml
+++ b/tools/monitoring/neptune.yaml
@@ -1,0 +1,24 @@
+name: Neptune
+description: >
+  Neptune is an experiment tracking and model monitoring platform for ML teams. It logs metadata, metrics, and artifacts to help manage the full machine learning lifecycle from training to production.
+problem_solved: >
+  Machine learning experiments are hard to track, compare, and reproduce. Neptune solves this by providing a centralized platform to log hyperparameters, metrics, model artifacts, and lineage, enabling collaboration and reproducibility across teams.
+use_cases:
+  - "Track and compare deep learning experiments across teams"
+  - "Manage model registry and artifact versioning centrally"
+  - "Monitor production model performance and detect drift"
+github_url: https://github.com/neptune-ai/neptune-client
+website_url: https://neptune.ai
+docs_url: https://docs.neptune.ai
+install_command: pip install neptune
+tagline: "Experiment tracking and model monitoring for ML teams"
+tags:
+  - mlops
+  - experiment-tracking
+  - monitoring
+  - model-registry
+  - metadata
+  - logging
+pricing: freemium
+is_open_source: true
+license: Apache-2.0

--- a/tools/other/baseten.yaml
+++ b/tools/other/baseten.yaml
@@ -1,0 +1,25 @@
+name: Baseten
+description: >
+  Baseten is a production platform for ML and AI inference. It provides managed infrastructure to deploy, serve, and scale machine learning models with auto-scaling GPUs, serverless functions, and real-time APIs.
+problem_solved: >
+  Deploying ML models to production requires complex infrastructure, container orchestration, and GPU management. Baseten solves this by offering a managed platform that handles scaling, hardware provisioning, and API serving so developers can focus on model development.
+use_cases:
+  - "Deploy LLMs with auto-scaling GPUs for production workloads"
+  - "Build real-time ML-powered applications with managed inference"
+  - "Run scheduled inference jobs with serverless functions and CRON"
+github_url: https://github.com/basetenlabs/truss
+website_url: https://baseten.co
+docs_url: https://docs.baseten.co
+install_command: pip install baseten
+tagline: "Production inference platform for ML models"
+tags:
+  - mlops
+  - model-serving
+  - deployment
+  - gpu
+  - ai
+  - serverless
+  - inference
+pricing: paid
+is_open_source: false
+license: Proprietary


### PR DESCRIPTION
Adds three new tools to the catalog:

- **Baseten** (Other) — Production inference platform for ML models
- **Fivetran** (Data) — Automated data integration for the modern data stack
- **Neptune** (Monitoring) — Experiment tracking and model monitoring for ML teams

Validation checklist:
- [x] YAML files created in correct category directories
- [x] Local validation passes for all three tools
- [x] Required fields present and meet length requirements
