### PR TITLE
Add RAGatouille, Ludwig, and ClickHouse to catalog

### DIFF
--- a/tools/fine-tuning/ludwig.yaml
+++ b/tools/fine-tuning/ludwig.yaml
@@ -1,0 +1,25 @@
+name: Ludwig
+description: |
+  Ludwig is a declarative deep learning framework that lets you train, fine-tune, and deploy AI models — from LLMs to multimodal and tabular tasks — using only a YAML config file and zero boilerplate Python. Built on PyTorch and hosted by the Linux Foundation AI & Data, it supports LoRA, QLoRA, and many other PEFT adapters out of the box for efficient LLM fine-tuning.
+tagline: Declarative deep learning framework for LLMs and multimodal models
+problem_solved: |
+  Training and fine-tuning AI models typically requires writing hundreds of lines of PyTorch boilerplate, managing complex data pipelines, and tuning numerous hyperparameters manually. Ludwig eliminates this by letting practitioners define the entire model, training, and evaluation pipeline in a single YAML file. You specify input features, output features, model type, and training parameters declaratively, and Ludwig handles the rest — data preprocessing, model construction, distributed training, and inference — making AI experimentation accessible to both researchers and engineers who want to move fast without sacrificing flexibility.
+use_cases:
+  - Fine-tuning Llama, Mistral, or other open LLMs with LoRA using a single YAML config
+  - Building multimodal classification models that combine text, image, and tabular inputs
+  - Rapidly prototyping tabular deep learning and time-series forecasting pipelines
+category: Fine-tuning
+tags:
+  - python
+  - pytorch
+  - llm
+  - fine-tuning
+  - declarative
+  - open-source
+github_url: https://github.com/ludwig-ai/ludwig
+website_url: https://ludwig.ai
+docs_url: https://ludwig.ai/latest/getting_started/
+install_command: pip install ludwig
+pricing: free
+is_open_source: true
+license: Apache-2.0

--- a/tools/rag/ragatouille.yaml
+++ b/tools/rag/ragatouille.yaml
@@ -1,0 +1,24 @@
+name: RAGatouille
+description: |
+  RAGatouille is a Python library that makes state-of-the-art late-interaction retrieval models, especially ColBERT, easy to use and train within any RAG pipeline. It bridges the gap between academic research and production RAG by providing modular, research-backed components for indexing, embedding, and retrieving documents with higher accuracy than dense embeddings alone.
+tagline: Easy-to-use late-interaction retrieval for any RAG pipeline
+problem_solved: |
+  Dense embedding retrieval is a good baseline for RAG, but research shows it often underperforms on complex or domain-specific queries. RAGatouille solves this by making advanced late-interaction models like ColBERT accessible to practitioners. ColBERT generalizes better to new domains, is more data-efficient, and handles non-English languages with less training data, yet it has been historically difficult to integrate. RAGatouille removes this friction with a simple pip-installable package that slots into existing LangChain, LlamaIndex, or custom RAG pipelines.
+use_cases:
+  - Replacing dense embedding retrieval with ColBERT for improved document relevance
+  - Fine-tuning retrieval models on low-resource languages or specialized domains
+  - Plugging advanced retrieval into LangChain or LlamaIndex RAG pipelines with minimal code changes
+category: RAG
+tags:
+  - python
+  - retrieval
+  - colbert
+  - embeddings
+  - open-source
+github_url: https://github.com/AnswerDotAI/RAGatouille
+website_url: https://ben.clavie.eu/ragatouille/
+docs_url: https://ben.clavie.eu/ragatouille/
+install_command: pip install ragatouille
+pricing: free
+is_open_source: true
+license: Apache-2.0

--- a/tools/vector-databases/clickhouse.yaml
+++ b/tools/vector-databases/clickhouse.yaml
@@ -1,0 +1,24 @@
+name: ClickHouse
+description: |
+  ClickHouse is an open-source, column-oriented database management system designed for real-time analytical data processing. It supports high-performance vector search through ANN (approximate nearest neighbor) indexes, making it a powerful backend for AI applications that need to combine fast analytics with semantic retrieval over large-scale datasets.
+tagline: Real-time analytics database with high-performance vector search
+problem_solved: |
+  AI applications often need to query both structured analytics data and high-dimensional vector embeddings in a single system, but separate databases for OLAP and vector search create data silos, synchronization overhead, and operational complexity. ClickHouse solves this by offering a unified columnar engine that can store billions of rows, run complex aggregations in milliseconds, and perform ANN vector search using built-in approximate indexes. Teams get one database for both real-time dashboards and semantic retrieval, reducing infrastructure footprint and query latency.
+use_cases:
+  - Powering real-time AI dashboards that combine semantic vector search with structured aggregations
+  - Storing and querying high-dimensional embeddings alongside event logs for recommendation systems
+  - Running fast nearest-neighbor lookups over billions of vectors in a single analytics query
+category: Vector DB
+tags:
+  - cpp
+  - analytics
+  - vector-search
+  - columnar
+  - open-source
+github_url: https://github.com/ClickHouse/ClickHouse
+website_url: https://clickhouse.com
+docs_url: https://clickhouse.com/docs
+install_command: curl https://clickhouse.com/ | sh
+pricing: free
+is_open_source: true
+license: Apache-2.0


### PR DESCRIPTION
## Add RAGatouille, Ludwig, and ClickHouse to catalog

**Categories:** RAG, Fine-tuning, Vector DB

### Tools added

**RAGatouille** (RAG)
- GitHub: https://github.com/AnswerDotAI/RAGatouille
- Website: https://ben.clavie.eu/ragatouille/
- What it does: Makes state-of-the-art late-interaction retrieval models like ColBERT easy to use and train in any RAG pipeline.

**Ludwig** (Fine-tuning)
- GitHub: https://github.com/ludwig-ai/ludwig
- Website: https://ludwig.ai
- What it does: Declarative deep learning framework for training, fine-tuning, and deploying LLMs and multimodal models with YAML configs and zero boilerplate.

**ClickHouse** (Vector DB)
- GitHub: https://github.com/ClickHouse/ClickHouse
- Website: https://clickhouse.com
- What it does: Open-source columnar analytics database with high-performance ANN vector search, unifying structured analytics and semantic retrieval.

### Validation checklist
- [x] YAML files created in correct category directories
- [x] Local validation passes (`npx tsx scripts/validate-tool.ts`)
- [x] Required fields present for all tools
