### PR TITLE
Add Ray, Kubeflow, and Kafka to catalog

### DIFF
--- a/tools/data/kafka.yaml
+++ b/tools/data/kafka.yaml
@@ -1,0 +1,26 @@
+name: Kafka
+description: |
+  Apache Kafka is an open-source distributed event streaming platform used by thousands of companies for high-performance data pipelines, streaming analytics, data integration, and mission-critical applications. In AI workloads, Kafka serves as the real-time backbone for ingesting events, feeding streaming data to ML models, and synchronizing data between training, inference, and monitoring systems.
+tagline: Distributed event streaming platform for real-time data pipelines
+problem_solved: |
+  AI systems need to process large volumes of real-time events — user interactions, sensor readings, logs, and model predictions — but traditional batch pipelines introduce latency that makes real-time inference and feedback loops impossible. Kafka solves this by providing a fault-tolerant, horizontally scalable event streaming platform that can handle millions of events per second with low latency. It acts as the central nervous system for real-time AI applications, enabling streaming data ingestion, event-driven microservices, and reliable data movement between data lakes, vector databases, and model serving infrastructure.
+use_cases:
+  - Streaming real-time user events into feature stores and vector databases for live ML inference
+  - Building event-driven microservices that trigger model inference pipelines on new data
+  - Feeding log and metric streams into monitoring systems for real-time model observability
+category: Data
+tags:
+  - java
+  - streaming
+  - event-driven
+  - data-pipeline
+  - open-source
+github_url: https://github.com/apache/kafka
+website_url: https://kafka.apache.org
+docs_url: https://kafka.apache.org/documentation/
+install_command: |
+  curl -sSOL https://downloads.apache.org/kafka/3.8.0/kafka_2.13-3.8.0.tgz
+  tar -xzf kafka_2.13-3.8.0.tgz
+pricing: free
+is_open_source: true
+license: Apache-2.0

--- a/tools/dev-tools/kubeflow.yaml
+++ b/tools/dev-tools/kubeflow.yaml
@@ -1,0 +1,26 @@
+name: Kubeflow
+description: |
+  Kubeflow is an open-source machine learning toolkit for Kubernetes that makes deployments of ML workflows on Kubernetes simple, portable, and scalable. It provides a set of components for building end-to-end ML pipelines, including notebooks, training operators, hyperparameter tuning, and model serving.
+tagline: Machine learning toolkit for Kubernetes
+problem_solved: |
+  Deploying and managing machine learning workflows in production requires orchestrating notebooks, distributed training jobs, hyperparameter tuning, and model serving across a cluster. Doing this manually with raw Kubernetes is complex and error-prone. Kubeflow solves this by providing a dedicated, integrated platform that packages best practices for ML on Kubernetes into reusable components. Data scientists can work in Jupyter notebooks, launch distributed training with TFJob or PyTorchJob, run automated hyperparameter tuning with Katib, and deploy models with KServe — all within a single Kubernetes-native ecosystem that scales from experimentation to production.
+use_cases:
+  - Building end-to-end ML pipelines on Kubernetes from notebooks to model serving
+  - Running distributed TensorFlow or PyTorch training jobs with automatic cluster scheduling
+  - Automating hyperparameter optimization and model deployment in a shared Kubernetes environment
+category: Dev Tools
+tags:
+  - kubernetes
+  - ml-pipelines
+  - training
+  - serving
+  - open-source
+github_url: https://github.com/kubeflow/kubeflow
+website_url: https://www.kubeflow.org
+docs_url: https://www.kubeflow.org/docs/
+install_command: |
+  kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=2.0.3"
+  kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref=2.0.3"
+pricing: free
+is_open_source: true
+license: Apache-2.0

--- a/tools/other/ray.yaml
+++ b/tools/other/ray.yaml
@@ -1,0 +1,24 @@
+name: Ray
+description: |
+  Ray is an open-source AI compute engine that provides a core distributed runtime and a set of libraries for accelerating machine learning workloads. It simplifies scaling Python applications from a laptop to a cluster, with built-in support for training, hyperparameter tuning, reinforcement learning, and model serving.
+tagline: Distributed AI compute engine for scaling ML workloads
+problem_solved: |
+  Scaling machine learning workloads from a single machine to a cluster typically requires rewriting code with complex distributed systems primitives like MPI, Kubernetes, or Spark. Ray eliminates this barrier by providing a simple, universal API for distributed computing that works the same on a laptop and a 1000-node cluster. Its ecosystem of libraries (Ray Train, Ray Tune, Ray RLlib, Ray Serve) lets teams scale training, tuning, and serving without changing their PyTorch, TensorFlow, or XGBoost code, dramatically reducing the engineering effort needed for production ML infrastructure.
+use_cases:
+  - Scaling PyTorch or TensorFlow training across multiple GPUs or nodes with minimal code changes
+  - Running large-scale hyperparameter searches with Ray Tune on a distributed cluster
+  - Deploying and serving ML models in production with Ray Serve alongside existing applications
+category: Other
+tags:
+  - python
+  - distributed-computing
+  - ml-engineering
+  - cluster
+  - open-source
+github_url: https://github.com/ray-project/ray
+website_url: https://www.ray.io
+docs_url: https://docs.ray.io
+install_command: pip install ray
+pricing: free
+is_open_source: true
+license: Apache-2.0


### PR DESCRIPTION
## Add Ray, Kubeflow, and Kafka to catalog

**Categories:** Other, Dev Tools, Data

### Tools added

**Ray** (Other)
- GitHub: https://github.com/ray-project/ray
- Website: https://www.ray.io
- What it does: Open-source AI compute engine for scaling ML training, tuning, and serving from a laptop to a cluster with a unified Python API.

**Kubeflow** (Dev Tools)
- GitHub: https://github.com/kubeflow/kubeflow
- Website: https://www.kubeflow.org
- What it does: Machine learning toolkit for Kubernetes that provides notebooks, distributed training operators, hyperparameter tuning, and model serving.

**Kafka** (Data)
- GitHub: https://github.com/apache/kafka
- Website: https://kafka.apache.org
- What it does: Distributed event streaming platform that powers real-time data pipelines, streaming analytics, and event-driven AI microservices.

### Validation checklist
- [x] YAML files created in correct category directories
- [x] Local validation passes (`npx tsx scripts/validate-tool.ts`)
- [x] Required fields present for all tools
