### PR TITLE
Add OpenObserve, HippoRAG, and ObjectBox to catalog

### DIFF
--- a/tools/monitoring/openobserve.yaml
+++ b/tools/monitoring/openobserve.yaml
@@ -1,0 +1,43 @@
+name: OpenObserve
+tagline: Open source, petabyte-scale observability platform for logs, metrics, traces, and LLM observability
+description: >
+  OpenObserve is an open-source observability platform for logs, metrics, traces,
+  frontend monitoring, data pipelines, and LLM observability. It serves as a sophisticated,
+  simple, and highly performant alternative to Datadog, Splunk, and Elasticsearch with
+  140x lower storage costs and single binary deployment.
+problem_solved: >
+  Reduces the cost and complexity of observability at scale by providing a single
+  unified platform for logs, metrics, traces, and LLM monitoring with dramatically
+  lower storage overhead and simpler deployment compared to traditional enterprise stacks.
+use_cases:
+  - Centralized log management and search at petabyte scale with SQL-like querying
+  - Metrics collection, dashboards, and alerting for infrastructure and applications
+  - Distributed tracing and frontend real-user monitoring (RUM) for full-stack visibility
+  - LLM observability and prompt tracing to monitor AI application performance and costs
+  - Stream processing and data pipelines for real-time analytics and event-driven workflows
+github_url: https://github.com/openobserve/openobserve
+website_url: https://openobserve.ai
+docs_url: https://openobserve.ai/docs/
+install_command: |
+  docker run -d \
+    --name openobserve \
+    -v $PWD/data:/data \
+    -p 5080:5080 \
+    -e ZO_ROOT_USER_EMAIL="root@example.com" \
+    -e ZO_ROOT_USER_PASSWORD="Complexpass#123" \
+    public.ecr.aws/zinclabs/openobserve:latest
+license: AGPL-3.0
+is_open_source: true
+pricing: freemium
+category: Monitoring
+tags:
+  - observability
+  - logs
+  - metrics
+  - tracing
+  - llm-observability
+  - monitoring
+  - datadog-alternative
+  - splunk-alternative
+  - docker
+  - single-binary

--- a/tools/rag/hipporag.yaml
+++ b/tools/rag/hipporag.yaml
@@ -1,0 +1,40 @@
+name: HippoRAG
+tagline: Neurobiologically inspired long-term memory for large language models
+description: >
+  HippoRAG is a novel retrieval-augmented generation framework inspired by human
+  long-term memory, enabling LLMs to continuously integrate knowledge across external
+  documents. It combines RAG with knowledge graphs and personalized PageRank to
+  deliver state-of-the-art multi-hop question answering and continual learning over
+  large corpora.
+problem_solved: >
+  Traditional RAG systems struggle with multi-hop reasoning and continual knowledge
+  integration across large document collections. HippoRAG solves this by modeling
+  memory as a dynamic knowledge graph with personalized PageRank, allowing LLMs to
+  perform complex sense-making and retrieve facts across disconnected documents.
+use_cases:
+  - Multi-hop question answering over large, heterogeneous document corpora
+  - Continual knowledge integration into a live, evolving memory graph for long-term learning
+  - Complex narrative sense-making and factual memory retrieval across disconnected sources
+  - Local and private vLLM deployment for sensitive enterprise knowledge bases
+  - Dynamic knowledge base construction and maintenance from streaming documents
+github_url: https://github.com/OSU-NLP-Group/HippoRAG
+website_url: https://arxiv.org/abs/2405.14831
+docs_url: https://github.com/OSU-NLP-Group/HippoRAG/blob/main/README.md
+install_command: |
+  conda create -n hipporag python=3.10
+  conda activate hipporag
+  pip install hipporag
+license: MIT
+is_open_source: true
+pricing: free
+category: RAG
+tags:
+  - rag
+  - knowledge-graph
+  - multi-hop-qa
+  - llm-memory
+  - neurips
+  - page-rank
+  - continual-learning
+  - vllm
+  - python

--- a/tools/vector-databases/objectbox.yaml
+++ b/tools/vector-databases/objectbox.yaml
@@ -1,0 +1,38 @@
+name: ObjectBox
+tagline: The edge vector database — first on-device vector DB for mobile, IoT, and edge hardware
+description: >
+  ObjectBox is a high-performance, lightweight on-device database and vector database
+  designed for local object persistence. It delivers approximate nearest neighbor (ANN)
+  search via HNSW indexing, enabling on-device AI, RAG, and similarity search without
+  cloud connectivity. It is 10× faster than SQLite, ACID-compliant, and supports
+  Java, Kotlin, Python, Dart, Flutter, Swift, Go, and C/C++.
+problem_solved: >
+  Provides fast, private, offline-first data persistence and vector search for mobile,
+  IoT, automotive, and edge devices, eliminating complex SQL setup and cloud dependency
+  while enabling on-device AI and RAG applications with minimal resource footprint.
+use_cases:
+  - On-device AI and RAG applications with local vector search, embeddings, and LangChain integration
+  - Offline-first mobile apps on Android, iOS, and Flutter with reliable local data persistence
+  - Automotive and IoT edge computing on ECUs, gateways, and industrial PCs
+  - Point-of-sale terminals and retail systems requiring fast, reliable offline transactions
+  - Embedded systems and robotics requiring low-latency vector similarity search
+github_url: https://github.com/objectbox/objectbox-java
+website_url: https://objectbox.io/
+docs_url: https://docs.objectbox.io/
+install_command: pip install --upgrade objectbox
+license: Apache-2.0
+is_open_source: true
+pricing: freemium
+category: Vector DB
+tags:
+  - vector-database
+  - embedded-database
+  - edge-database
+  - mobile-database
+  - offline-first
+  - on-device-ai
+  - rag
+  - hnsw
+  - iot
+  - automotive
+  - langchain


### PR DESCRIPTION
## New Tools Added

### OpenObserve (Monitoring)
- **GitHub:** https://github.com/openobserve/openobserve
- Open-source observability platform for logs, metrics, traces, frontend monitoring, pipelines, and LLM observability. Alternative to Datadog and Splunk with 140x lower storage costs and single binary deployment.
- **Install:** Docker one-liner
- **License:** AGPL-3.0

### HippoRAG (RAG)
- **GitHub:** https://github.com/OSU-NLP-Group/HippoRAG
- NeurIPS'24 retrieval-augmented generation framework inspired by human long-term memory. Combines RAG with knowledge graphs and personalized PageRank for state-of-the-art multi-hop QA and continual learning.
- **Install:** `conda create -n hipporag python=3.10 && conda activate hipporag && pip install hipporag`
- **License:** MIT

### ObjectBox (Vector DB)
- **GitHub:** https://github.com/objectbox/objectbox-java
- High-performance, lightweight on-device vector database for mobile, IoT, automotive, and edge devices. Delivers ANN search via HNSW indexing with support for Python, Java, Dart, Swift, Go, and C/C++.
- **Install:** `pip install --upgrade objectbox`
- **License:** Apache-2.0

### Validation Checklist
- [x] YAML files created in correct category directories
- [x] Local validation passes (`npx tsx scripts/validate-tool.ts`)
- [x] Branch pushed

## Files Changed
- `tools/monitoring/openobserve.yaml`
- `tools/rag/hipporag.yaml`
- `tools/vector-databases/objectbox.yaml`
