### PR TITLE
Add llmware, Mesop, and Superagent to catalog

### DIFF
--- a/tools/dev-tools/mesop.yaml
+++ b/tools/dev-tools/mesop.yaml
@@ -1,0 +1,29 @@
+name: Mesop
+description: A Python-based UI framework for rapidly building web apps—especially AI apps—without writing JavaScript, CSS, or HTML. Provides a declarative, reactive UI paradigm with strong IDE support and hot reload.
+tagline: Build rich web UIs and AI apps entirely in Python
+
+github_url: https://github.com/mesop-dev/mesop
+website_url: https://mesop-dev.github.io/mesop/
+docs_url: https://mesop-dev.github.io/mesop/getting-started/installing/
+
+install_command: pip install mesop
+
+category: Dev Tools
+tags: [python, ui-framework, web-apps, ai-apps, prototyping, google]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Frontend development traditionally requires learning JavaScript, CSS, and HTML—creating a steep
+  barrier for Python developers and data scientists who want to ship interactive web apps or AI demos.
+  Mesop solves this by letting developers build rich, reactive UIs entirely in Python with a simple
+  component model, state management, streaming UI support, and hot reload. It was originally created
+  at Google and is used there for rapid internal and AI app development.
+
+use_cases:
+  - Build AI chat applications and text-to-image demos without writing any frontend code
+  - Create internal tools and enterprise dashboards with Python-native data-display components
+  - Rapidly prototype ML/AI interfaces and object-detection apps using declarative Python UIs
+  - Deploy custom web components that wrap existing JavaScript libraries inside a Python framework
+  - Develop streaming AI interfaces that show model outputs in real time with minimal boilerplate

--- a/tools/other/superagent.yaml
+++ b/tools/other/superagent.yaml
@@ -1,0 +1,32 @@
+name: Superagent
+description: An open-source SDK for AI agent safety. Block prompt injections, redact PII and secrets, scan repositories for threats, and run red team scenarios against your agents.
+tagline: Make your AI apps safe with open-source guardrails and red teaming
+
+github_url: https://github.com/superagent-ai/superagent
+website_url: https://superagent.sh
+docs_url: https://docs.superagent.sh
+
+install_command: |
+  pip install safety-agent
+  npm install safety-agent
+
+category: Other
+tags: [security, guardrails, prompt-injection, ai-safety, red-team, pii-redaction]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Modern AI apps rely on agents that read data, follow instructions, call tools, and produce outputs
+  users trust. These systems fail in ways traditional software does not—prompt injections, data leakage,
+  unsafe tool actions, workflow failures, and compliance violations. Superagent provides open-source
+  guardrails that detect and block prompt injections, redact sensitive information, scan codebases for
+  agent-targeted attacks, and enable red-team testing so developers can embed safety directly into
+  their apps and prove compliance to customers.
+
+use_cases:
+  - Detect and block prompt injections, malicious instructions, and unsafe tool calls at runtime
+  - Automatically redact PII, PHI, and secrets from agent inputs and outputs
+  - Scan repositories for AI agent-targeted attacks such as repo poisoning and malicious instructions
+  - Run automated red-team scenarios against production agents to find vulnerabilities before attackers do
+  - Secure RAG pipelines and image uploads against adversarial inputs

--- a/tools/rag/llmware.yaml
+++ b/tools/rag/llmware.yaml
@@ -1,0 +1,29 @@
+name: llmware
+description: A unified, enterprise-grade framework for building knowledge-based, local, private, and secure LLM applications. Provides 50+ small, specialized open-source models for RAG and multi-step agent workflows with on-device GPU, NPU, and edge deployment support.
+tagline: Enterprise RAG and agent workflows with small, specialized models
+
+github_url: https://github.com/llmware-ai/llmware
+website_url: https://llmware.ai
+docs_url: https://llmware-ai.github.io/llmware/
+
+install_command: pip install llmware
+
+category: RAG
+tags: [python, rag, enterprise, local-ai, agent-workflows, document-processing, edge-deployment]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Integrating open-source small specialized models and connecting enterprise knowledge sources safely
+  requires stitching together document parsing, chunking, embedding, retrieval, and model orchestration.
+  llmware provides a complete, secure toolkit that runs locally on AI PCs, laptops, and edge devices
+  across Windows, Mac, and Linux — eliminating cloud dependency, token costs, and data-leak risks
+  while enabling fast enterprise RAG and agent workflows.
+
+use_cases:
+  - Build private, on-device RAG pipelines over thousands of documents with no data leaving the environment
+  - Orchestrate multi-step agent workflows with function calling and specialized small models
+  - Extract, summarize, and analyze documents at scale for IT service and support ticket automation
+  - Run vision workflows that extract structured data from images and perform OCR or audio transcription
+  - Generate natural-language-to-SQL queries and data analysis reports from raw enterprise datasets


### PR DESCRIPTION
## Batch Tool Addition: llmware, Mesop, Superagent

This PR adds 3 new tools to the Agentic AI For Good catalog:

### llmware (RAG)
- **Category:** RAG
- **GitHub:** https://github.com/llmware-ai/llmware (14.8k+ stars)
- **Website:** https://llmware.ai
- **Description:** Unified enterprise-grade framework for building knowledge-based, local, private, and secure LLM applications with 50+ small specialized models.
- **Install:** `pip install llmware`
- **License:** Apache-2.0

### Mesop (Dev Tools)
- **Category:** Dev Tools
- **GitHub:** https://github.com/mesop-dev/mesop (6.5k+ stars)
- **Website:** https://mesop-dev.github.io/mesop/
- **Description:** Python-based UI framework for rapidly building web apps and AI apps without writing JavaScript, CSS, or HTML.
- **Install:** `pip install mesop`
- **License:** Apache-2.0

### Superagent (Other)
- **Category:** Other
- **GitHub:** https://github.com/superagent-ai/superagent (6.6k+ stars)
- **Website:** https://superagent.sh
- **Description:** Open-source SDK for AI agent safety — block prompt injections, redact PII, scan repositories, and run red team scenarios.
- **Install:** `pip install safety-agent` / `npm install safety-agent`
- **License:** MIT

### Validation Checklist
- [x] YAML files created in correct category directories
- [x] Local validation passes (`npx tsx scripts/validate-tool.ts`)
- [x] All required fields present (name, description, problem_solved, use_cases, URLs)
