### PR TITLE
Add FastGPT, QAnything, and Neo4j to catalog

### DIFF
--- a/tools/rag/fastgpt.yaml
+++ b/tools/rag/fastgpt.yaml
@@ -1,0 +1,42 @@
+name: FastGPT
+description: Open-source knowledge-based AI platform that provides out-of-the-box data processing, RAG retrieval, and visual AI workflow orchestration for building complex question-answering systems. Supports multi-source document ingestion, API integration, and team collaboration.
+tagline: Open-source AI knowledge base platform with visual workflow orchestration
+
+github_url: https://github.com/labring/FastGPT
+website_url: https://fastgpt.io/
+docs_url: https://doc.fastgpt.io/
+
+install_command: |
+  git clone https://github.com/labring/FastGPT.git
+  cd FastGPT/projects/app
+  cp .env.example .env
+  docker compose up -d
+
+category: RAG
+tags:
+  - rag
+  - knowledge-base
+  - qa
+  - document-retrieval
+  - llm
+  - workflow
+  - docker
+pricing: freemium
+is_open_source: true
+license: Apache 2.0 with additional conditions (FastGPT Open Source License)
+
+problem_solved: |
+  Building production-ready RAG systems requires significant engineering effort to
+  integrate document processing, embedding pipelines, vector storage, LLM
+  orchestration, and user management into a cohesive application. FastGPT solves
+  this by providing an all-in-one open-source platform with visual workflow
+  orchestration, automated data processing, and knowledge base management,
+  enabling teams to deploy intelligent Q&A applications without extensive
+  engineering effort.
+
+use_cases:
+  - Deploy a customer service chatbot that answers from your product documentation and support articles
+  - Create an internal knowledge base Q&A system for employee onboarding and policy lookup
+  - Build a document analysis and retrieval system for research teams and legal departments
+  - Set up an educational tutoring assistant that provides answers from course materials
+  - Orchestrate complex multi-step AI workflows with a visual drag-and-drop interface

--- a/tools/rag/qanything.yaml
+++ b/tools/rag/qanything.yaml
@@ -1,0 +1,40 @@
+name: QAnything
+description: Open-source RAG framework from NetEase that enables question answering over any document format. Supports over 10 file types including PDF, Word, Excel, PPT, and images, with hybrid retrieval combining semantic search and keyword matching for accurate answers.
+tagline: Question answering over any document format with hybrid retrieval
+
+github_url: https://github.com/netease-youdao/QAnything
+website_url: https://qanything.ai/
+docs_url: https://qanything.ai/docs
+
+install_command: |
+  git clone https://github.com/netease-youdao/QAnything.git
+  cd QAnything
+  docker compose up -d
+
+category: RAG
+tags:
+  - rag
+  - document-qa
+  - pdf
+  - retrieval
+  - knowledge-base
+  - docker
+  - hybrid-search
+pricing: freemium
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Organizations need to answer questions accurately across diverse document
+  formats (PDFs, Word docs, Excel spreadsheets, presentations, images) but
+  existing RAG solutions often struggle with complex table extraction, formula
+  rendering, and multi-format support. QAnything solves this with a unified
+  framework that handles 10+ file types, uses hybrid retrieval combining
+  semantic and keyword search, and supports local deployment for data privacy.
+
+use_cases:
+  - Enable question answering over a collection of PDF technical manuals and specifications
+  - Build a searchable knowledge base from mixed-format enterprise documents and spreadsheets
+  - Extract and query tabular data from financial reports and presentations
+  - Deploy a private on-premises Q&A system that keeps sensitive documents within company networks
+  - Process scanned documents with OCR-powered retrieval for historical archives

--- a/tools/vector-databases/neo4j.yaml
+++ b/tools/vector-databases/neo4j.yaml
@@ -1,0 +1,40 @@
+name: Neo4j
+description: Leading graph database with native vector search capabilities for AI applications. Stores and queries highly connected data while supporting vector embeddings for semantic similarity search, making it a powerful choice for knowledge graphs combined with RAG workflows.
+tagline: Graph database with vector search for AI-powered knowledge graphs
+
+github_url: https://github.com/neo4j/neo4j
+website_url: https://neo4j.com/
+docs_url: https://neo4j.com/docs/
+
+install_command: |
+  docker run --publish=7474:7474 --publish=7687:7687 neo4j:latest
+
+category: Vector DB
+tags:
+  - graph-database
+  - vector-search
+  - knowledge-graph
+  - rag
+  - graph-rag
+  - cypher
+  - docker
+  - enterprise
+pricing: freemium
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Traditional RAG pipelines treat documents as isolated chunks, missing the
+  rich relationships between entities, concepts, and data points. Neo4j solves
+  this by combining a native graph database with vector search capabilities,
+  enabling GraphRAG architectures that leverage both semantic similarity and
+  relationship traversal. This allows AI applications to answer questions that
+  require multi-hop reasoning across connected data — something flat vector
+  stores cannot do efficiently.
+
+use_cases:
+  - Build a GraphRAG system that traverses entity relationships for multi-hop question answering
+  - Store and query knowledge graphs alongside vector embeddings for hybrid AI retrieval
+  - Implement recommendation systems that combine collaborative filtering with semantic similarity
+  - Create a fraud detection pipeline that analyzes transaction patterns and entity relationships in real time
+  - Power a conversational AI that understands connections between people, places, and events in your data


### PR DESCRIPTION
## Tools Added

### FastGPT (RAG)
Open-source knowledge-based AI platform with visual workflow orchestration and RAG retrieval. Build complex Q&A systems without extensive setup.
- **GitHub:** https://github.com/labring/FastGPT
- **Stars:** ~28,100

### QAnything (RAG)
Open-source RAG framework from NetEase for question answering over any document format. Supports PDF, Word, Excel, PPT, images, and more with hybrid retrieval.
- **GitHub:** https://github.com/netease-youdao/QAnything
- **Stars:** ~14,000

### Neo4j (Vector DB)
Leading graph database with native vector search capabilities for GraphRAG and AI-powered knowledge graphs.
- **GitHub:** https://github.com/neo4j/neo4j
- **Stars:** ~16,600

## Validation Checklist
- [x] YAML files created in correct category directories
- [x] Local validation passes for all 3 files
- [x] Schema-compliant (name, description, problem_solved, use_cases, github_url, category, etc.)
- [x] Only `tools/` files modified
- [x] All tools verified as not already in the catalog
