### PR TITLE
Add Aim, Delta Lake, and HNSWlib to catalog

### DIFF
--- a/tools/data/delta-lake.yaml
+++ b/tools/data/delta-lake.yaml
@@ -1,0 +1,28 @@
+name: Delta Lake
+description: An open-source storage framework enabling ACID transactions, scalable metadata handling, and unified batch/streaming processing on data lakes, backed by Apache Spark.
+tagline: Reliable Data Lakes with ACID Transactions
+
+github_url: https://github.com/delta-io/delta
+website_url: https://delta.io
+docs_url: https://docs.delta.io
+
+category: Data
+tags: [data-lake, lakehouse, spark, parquet, etl, big-data]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install delta-spark
+
+problem_solved: |
+  Traditional data lakes suffer from data inconsistency, lack of transactional guarantees,
+  and poor performance for mixed batch and streaming workloads. Delta Lake brings ACID
+  transactions, schema enforcement, scalable metadata handling, and unified batch/streaming
+  processing on top of existing data lake storage, making data lakes reliable and performant
+  for production data pipelines.
+
+use_cases:
+  - Build reliable lakehouse architectures with ACID transactions on data lake storage
+  - Process streaming and batch data uniformly with exactly-once semantics
+  - Enforce schema on write to prevent data corruption from malformed records
+  - Time-travel to previous versions of data for auditing and rollback

--- a/tools/monitoring/aim.yaml
+++ b/tools/monitoring/aim.yaml
@@ -1,0 +1,27 @@
+name: Aim
+description: An open-source experiment tracker for machine learning that logs hyperparameters, metrics, images, distributions, and audio across training runs with a powerful searchable UI.
+tagline: Supercharged Open-Source Experiment Tracker
+
+github_url: https://github.com/aimhubio/aim
+website_url: https://aimstack.io
+docs_url: https://aimstack.readthedocs.io
+
+category: Monitoring
+tags: [experiment-tracking, mlops, python, metrics, visualization]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install aim
+
+problem_solved: |
+  ML experiment tracking is often done with ad-hoc logging, spreadsheets, and manual
+  note-taking that makes it nearly impossible to compare runs, reproduce results, or
+  collaborate effectively. Aim gives teams a structured, searchable, and visual platform
+  for logging and comparing every detail of their ML experiments — from hyperparameters
+  and metrics to images and audio — with a powerful query interface.
+
+use_cases:
+  - Log and compare hundreds of ML training runs with a searchable, visual interface
+  - Track hyperparameters, metrics, images, distributions, and audio in one place
+  - Collaborate with team members by sharing experiment dashboards and comparisons

--- a/tools/vector-databases/hnswlib.yaml
+++ b/tools/vector-databases/hnswlib.yaml
@@ -1,0 +1,26 @@
+name: HNSWlib
+description: A header-only C++ library with Python bindings for fast approximate nearest neighbor search using the Hierarchical Navigable Small World algorithm.
+tagline: Fast Approximate Nearest Neighbor Search
+
+github_url: https://github.com/nmslib/hnswlib
+website_url: https://github.com/nmslib/hnswlib
+
+category: Vector DB
+tags: [vector-search, nearest-neighbor, ann, similarity-search, c-plus-plus, python]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install hnswlib
+
+problem_solved: |
+  Vector similarity search at scale requires efficient approximate nearest neighbor (ANN)
+  algorithms that balance speed, accuracy, and memory usage. HNSWlib provides a battle-tested,
+  production-grade implementation of the HNSW algorithm — widely regarded as one of the best
+  ANN methods — with a simple Python API. It is the underlying engine behind many vector
+  databases and semantic search systems.
+
+use_cases:
+  - Power vector similarity search in production semantic search and recommendation systems
+  - Accelerate nearest neighbor queries for embedding-based ML inference pipelines
+  - Build and query large-scale ANN indexes with configurable recall vs. speed tradeoffs


### PR DESCRIPTION
## Add Aim, Delta Lake, and HNSWlib to catalog

### Added tools:

**Aim** (Monitoring) — Open-source experiment tracker for ML runs. Log and compare hyperparameters, metrics, images, and distributions with a powerful searchable UI. 6.1k+ GitHub stars, Apache-2.0.

**Delta Lake** (Data) — Open-source storage framework that brings ACID transactions, scalable metadata, and unified batch/streaming to data lakes. 8.8k+ GitHub stars, Apache-2.0.

**HNSWlib** (Vector DB) — Header-only C++ library with Python bindings for fast approximate nearest neighbor search using the HNSW algorithm. 5.2k+ GitHub stars, Apache-2.0.

### Validation Checklist:
- [x] YAML files created in correct category directories (`monitoring/`, `data/`, `vector-databases/`)
- [x] Local validation passes (`npx tsx scripts/validate-tool.ts`) — all 3 ✅
- [x] All tools are open-source (Apache-2.0) with active GitHub repos
- [x] Required fields: name, description, problem_solved (50+ chars), use_cases (3+ items, 10+ chars each), github_url
