### PR TITLE
Add Lamini, pgvectorscale, and Nanobrowser to catalog

### DIFF
--- a/tools/agent-frameworks/nanobrowser.yaml
+++ b/tools/agent-frameworks/nanobrowser.yaml
@@ -1,0 +1,30 @@
+name: Nanobrowser
+description: An open-source Chrome extension for AI-powered web automation featuring a multi-agent system with planner, navigator, and validator agents that work together to complete complex browser tasks.
+tagline: Open-source AI web automation in your browser
+github_url: https://github.com/nanobrowser/nanobrowser
+website_url: https://nanobrowser.ai
+
+category: Agents
+tags: [typescript, browser-automation, agents, multi-agent, chrome-extension, web-automation, ai]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: |
+  Install from Chrome Web Store:
+  https://chromewebstore.google.com/detail/nanobrowser/imbddededgmcgfhfpcjmijokokekbkal
+
+problem_solved: |
+  Automating complex web tasks — form filling, data extraction, multi-step research — usually
+  requires writing brittle scripts or using expensive cloud automation platforms. Nanobrowser
+  brings a multi-agent AI system directly into your Chrome browser as a free extension. Its
+  Planner agent decomposes tasks, Navigator executes browser actions, and Validator checks
+  results — all running locally with your own LLM API key. No cloud dependency, no scripting,
+  no monthly fees.
+
+use_cases:
+  - Automate repetitive web research tasks like competitive analysis, price monitoring, and data collection
+  - Extract structured data from multi-page websites without writing scrapers or using cloud APIs
+  - Automate form filling and multi-step web workflows across SaaS applications
+  - Deploy as a free alternative to OpenAI Operator for personal and small-team browser automation
+  - Run multi-agent web automation pipelines where agents plan, navigate, and validate results collaboratively

--- a/tools/fine-tuning/lamini.yaml
+++ b/tools/fine-tuning/lamini.yaml
@@ -1,0 +1,29 @@
+name: Lamini
+description: A Python client and SDK for fine-tuning, evaluating, and deploying LLMs using the Lamini API, with support for memory tuning, RLHF, and enterprise-grade model management.
+tagline: Fine-tune and deploy LLMs with memory tuning
+github_url: https://github.com/lamini-ai/lamini
+website_url: https://lamini.ai
+docs_url: https://lamini-ai.github.io/
+
+category: Fine-tuning
+tags: [python, fine-tuning, llm, sdk, memory-tuning, rlhf, enterprise]
+pricing: paid
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install lamini
+
+problem_solved: |
+  Fine-tuning and deploying LLMs for enterprise use cases requires managing infrastructure,
+  data pipelines, experiment tracking, and model serving — a complex orchestration problem
+  that most teams don't have the resources to build from scratch. Lamini provides a managed
+  platform and Python SDK that handles the full lifecycle: data preparation, fine-tuning
+  with memory tuning and RLHF, evaluation, and deployment via a simple API. Teams can
+  start with a single pip install and scale to production without managing GPU clusters.
+
+use_cases:
+  - Fine-tune open-source LLMs on proprietary enterprise data with memory tuning for reduced hallucination
+  - Build RLHF pipelines that collect human preferences and optimize model behavior through reinforcement learning
+  - Deploy customized LLMs behind a managed API endpoint with automatic scaling and monitoring
+  - Evaluate fine-tuned models against baseline metrics using built-in evaluation harnesses
+  - Iterate on model quality with experiment tracking, data versioning, and A/B comparison dashboards

--- a/tools/vector-databases/pgvectorscale.yaml
+++ b/tools/vector-databases/pgvectorscale.yaml
@@ -1,0 +1,30 @@
+name: pgvectorscale
+description: A PostgreSQL extension that enhances pgvector with DiskANN-based vector indexes for faster approximate nearest neighbor search at scale, supporting up to 100x faster index build and 28x lower index storage costs.
+tagline: Faster vector search for PostgreSQL at any scale
+github_url: https://github.com/timescale/pgvectorscale
+website_url: https://www.timescale.com/ai
+
+category: Vector DB
+tags: [postgresql, vector-search, pgvector, diskann, extension, rust, timescale]
+pricing: free
+is_open_source: true
+license: PostgreSQL
+
+install_command: |
+  docker pull timescale/timescaledb-ha:pg17
+  psql -d "postgres://<user>:<pass>@<host>:<port>/<db>" -c "CREATE EXTENSION IF NOT EXISTS vectorscale CASCADE;"
+
+problem_solved: |
+  Standard pgvector indexes become slow and memory-intensive as the vector corpus grows
+  beyond RAM capacity, making production-scale similarity search expensive and impractical.
+  pgvectorscale brings DiskANN (Disk-based Approximate Nearest Neighbor) to PostgreSQL,
+  enabling vector indexes that scale beyond memory limits by using SSD-optimized graph
+  algorithms. This results in dramatically faster index builds, lower storage costs, and
+  reliable query performance at any scale — all within the familiar PostgreSQL ecosystem.
+
+use_cases:
+  - Build production RAG pipelines with millions of embeddings stored and queried directly in PostgreSQL
+  - Replace dedicated vector databases with PostgreSQL + pgvectorscale for simpler infrastructure
+  - Run real-time semantic search on document corpora too large to fit in memory
+  - Deploy cost-effective vector search at scale using commodity SSD storage instead of RAM-heavy solutions
+  - Combine vector search with full PostgreSQL querying — joins, filters, aggregations, and transactions


### PR DESCRIPTION
## Three new tools

### Lamini (Fine-tuning)
- **Stars:** 2,535 | **License:** Apache-2.0
- Python client and SDK for fine-tuning and deploying LLMs via the Lamini API with memory tuning.
- Install: `pip install lamini`
- [GitHub](https://github.com/lamini-ai/lamini) | [Website](https://lamini.ai)

### pgvectorscale (Vector DB)
- **Stars:** 3,031 | **License:** PostgreSQL
- PostgreSQL extension for DiskANN-based vector indexes that scale beyond RAM.
- Install: Docker + `CREATE EXTENSION vectorscale CASCADE`
- [GitHub](https://github.com/timescale/pgvectorscale) | [Website](https://www.timescale.com/ai)

### Nanobrowser (Agents)
- **Stars:** 13,049 | **License:** Apache-2.0
- Open-source Chrome extension for multi-agent AI-powered web automation.
- Install via Chrome Web Store
- [GitHub](https://github.com/nanobrowser/nanobrowser) | [Website](https://nanobrowser.ai)

## Validation
- [x] `npx tsx scripts/validate-tool.ts tools/fine-tuning/lamini.yaml` — ✅
- [x] `npx tsx scripts/validate-tool.ts tools/vector-databases/pgvectorscale.yaml` — ✅
- [x] `npx tsx scripts/validate-tool.ts tools/agent-frameworks/nanobrowser.yaml` — ✅
