### PR TITLE
Add TensorBoard, Dask, and Grafana to catalog

### DIFF
--- a/tools/data/dask.yaml
+++ b/tools/data/dask.yaml
@@ -1,0 +1,22 @@
+name: Dask
+description: "Dask is a flexible parallel computing library for Python that scales analytics and machine learning workflows from a single laptop to a cluster. It provides dynamic task scheduling and parallel implementations of NumPy arrays, Pandas DataFrames, and scikit-learn estimators, enabling users to work with datasets larger than memory without rewriting their code."
+tagline: "Parallel computing library for scaling Python analytics"
+github_url: https://github.com/dask/dask
+website_url: https://dask.org
+docs_url: https://docs.dask.org
+install_command: "pip install dask[complete]"
+category: Data
+tags:
+  - parallel-computing
+  - data-processing
+  - distributed-computing
+  - python
+  - big-data
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Python developers working with large datasets hit the memory and compute limits of single-machine tools like Pandas and NumPy. Traditional distributed computing frameworks like Spark require rewriting code in a different paradigm and managing complex clusters, creating a steep learning curve and high operational overhead for data teams."
+use_cases:
+  - "Process datasets larger than RAM using out-of-core DataFrames with the same Pandas-like API"
+  - "Train machine learning models on large datasets using distributed scikit-learn, XGBoost, and PyTorch integrations"
+  - "Build and schedule complex multi-step data pipelines with dynamic task graphs and lazy evaluation"

--- a/tools/monitoring/grafana.yaml
+++ b/tools/monitoring/grafana.yaml
@@ -1,0 +1,25 @@
+name: Grafana
+description: "Grafana is an open-source observability platform for querying, visualizing, and alerting on metrics, logs, and traces from any data source. It connects to time-series databases like Prometheus, InfluxDB, and Elasticsearch, and is widely used to monitor LLM applications, AI infrastructure, and production systems through customizable dashboards, panels, and alerting rules."
+tagline: "Open-source observability and data visualization platform"
+github_url: https://github.com/grafana/grafana
+website_url: https://grafana.com
+docs_url: https://grafana.com/docs
+install_command: |
+  brew install grafana
+  # Or download from https://grafana.com/grafana/download
+category: Monitoring
+tags:
+  - observability
+  - visualization
+  - dashboards
+  - metrics
+  - alerting
+  - llm-monitoring
+pricing: freemium
+is_open_source: true
+license: AGPL-3.0
+problem_solved: "Engineering teams lack a unified view of their systems' health, with metrics scattered across different data stores (Prometheus for metrics, Loki for logs, Elasticsearch for traces) and no consistent way to correlate signals. Without customizable dashboards and alerting, teams can't detect anomalies, debug production issues, or track LLM application performance in real time."
+use_cases:
+  - "Monitor LLM application metrics (latency, token usage, error rates) alongside infrastructure health in real-time dashboards"
+  - "Correlate logs, metrics, and traces from multiple data sources to debug production AI system issues"
+  - "Set up alerting rules with multiple notification channels (Slack, PagerDuty, email) for automated incident response"

--- a/tools/monitoring/tensorboard.yaml
+++ b/tools/monitoring/tensorboard.yaml
@@ -1,0 +1,22 @@
+name: TensorBoard
+description: "TensorBoard is TensorFlow's visualization toolkit for inspecting and understanding machine learning experiments. It provides interactive dashboards for tracking metrics like loss and accuracy over time, visualizing model graphs, projecting high-dimensional embeddings, and inspecting images, text, and audio data logged during training — all through a lightweight web application."
+tagline: "Visualization toolkit for ML experiment tracking"
+github_url: https://github.com/tensorflow/tensorboard
+website_url: https://www.tensorflow.org/tensorboard
+docs_url: https://www.tensorflow.org/tensorboard/get_started
+install_command: "pip install tensorboard"
+category: Monitoring
+tags:
+  - visualization
+  - experiment-tracking
+  - tensorflow
+  - metrics
+  - debugging
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Machine learning experiments produce vast amounts of numerical and structural data — loss curves, gradient histograms, model graphs, embeddings, and sample outputs — that are difficult to interpret from raw log files alone. Teams lack an intuitive, interactive way to inspect training runs, compare experiments, and diagnose issues like overfitting, vanishing gradients, or poor convergence."
+use_cases:
+  - "Track training metrics (loss, accuracy, learning rate) across epochs with interactive time-series visualizations"
+  - "Visualize model architecture graphs and debug computation flow for TensorFlow and PyTorch models"
+  - "Project high-dimensional embeddings into 2D/3D space using PCA, t-SNE, or UMAP for qualitative inspection"


### PR DESCRIPTION
## Add TensorBoard, Dask, and Grafana to catalog

### TensorBoard (tools/monitoring/tensorboard.yaml)
- **Category:** Monitoring
- **GitHub:** tensorflow/tensorboard (7,189★)
- **License:** Apache-2.0
- TensorFlow's visualization toolkit for inspecting ML experiments

### Dask (tools/data/dask.yaml)
- **Category:** Data
- **GitHub:** dask/dask (13,847★)
- **License:** BSD-3-Clause
- Parallel computing library for scaling Python analytics

### Grafana (tools/monitoring/grafana.yaml)
- **Category:** Monitoring
- **GitHub:** grafana/grafana (74,150★)
- **License:** AGPL-3.0
- Open-source observability and data visualization platform

### Validation checklist
- [x] YAML files created in correct category directories
- [x] Local validation passes for all three files
- [x] Required fields present: name, description, problem_solved, use_cases, github_url
- [x] problem_solved > 50 chars each
- [x] use_cases >= 3 items, each >= 10 chars
- [x] No duplicate names in catalog (verified with find + grep)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded tools registry with metadata entries for three new tools: Dask (data processing), Grafana (monitoring and visualization), and TensorBoard (model monitoring). Each entry includes descriptions, documentation links, installation instructions, categorization, and relevant use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->