### PR TITLE
Add NumPy, Apache Arrow, and Apache NiFi to catalog

### DIFF
--- a/tools/data/apache-arrow.yaml
+++ b/tools/data/apache-arrow.yaml
@@ -1,0 +1,22 @@
+name: Apache Arrow
+description: "Apache Arrow is a cross-language development platform for in-memory data that defines a standardized columnar format for efficient data interchange and analytics. It provides zero-copy data sharing between languages (Python, C++, Java, R, Rust), high-performance compute kernels, and native support for Parquet, CSV, and JSON files through the PyArrow library."
+tagline: "Universal columnar format for fast data interchange"
+github_url: https://github.com/apache/arrow
+website_url: https://arrow.apache.org
+docs_url: https://arrow.apache.org/docs
+install_command: "pip install pyarrow"
+category: Data
+tags:
+  - columnar-format
+  - data-interchange
+  - in-memory-analytics
+  - parquet
+  - data-engineering
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Data scientists and ML engineers waste significant time and memory on serialization overhead when moving data between different languages, tools, and frameworks. Traditional row-based formats like CSV and JSON are slow to parse, and each library uses its own in-memory representation, forcing costly copies and conversions for even simple data pipelines."
+use_cases:
+  - "Read and write large Parquet, CSV, and JSON datasets with zero-copy columnar access for ML training pipelines"
+  - "Share data between Python, R, C++, and Java applications without serialization overhead using the Arrow IPC format"
+  - "Perform high-performance in-memory analytics on large datasets using Arrow compute kernels and dataset APIs"

--- a/tools/data/apache-nifi.yaml
+++ b/tools/data/apache-nifi.yaml
@@ -1,0 +1,26 @@
+name: Apache NiFi
+description: "Apache NiFi is an open-source data flow automation system designed for securely moving, transforming, and routing data between systems at scale. It features a web-based drag-and-drop interface for building data pipelines, provenance tracking for every data record, back-pressure handling, and extensive processor libraries for ingesting data from databases, file systems, message queues, and APIs."
+tagline: "Data flow automation and pipeline orchestration"
+github_url: https://github.com/apache/nifi
+website_url: https://nifi.apache.org
+docs_url: https://nifi.apache.org/docs.html
+install_command: |
+  # Download and extract
+  curl -sSOL https://dlcdn.apache.org/nifi/2.0.0/nifi-2.0.0-bin.tar.gz
+  tar -xzf nifi-2.0.0-bin.tar.gz
+  cd nifi-2.0.0 && ./bin/nifi.sh start
+category: Data
+tags:
+  - data-pipeline
+  - data-integration
+  - etl
+  - workflow-automation
+  - data-engineering
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Engineering teams building ML pipelines must ingest, transform, and route data from dozens of disparate sources (databases, APIs, file shares, message queues, IoT devices) into ML training and inference systems. Manually wiring these integrations is brittle, lacks observability, and makes it impossible to trace data lineage when a model produces unexpected results."
+use_cases:
+  - "Ingest and route streaming data from databases, APIs, and IoT devices into ML training pipelines with automated back-pressure handling"
+  - "Track end-to-end data provenance for every record with built-in data lineage and provenance reporting"
+  - "Visually design and monitor complex ETL workflows through a drag-and-drop web interface with 300+ built-in processors"

--- a/tools/dev-tools/numpy.yaml
+++ b/tools/dev-tools/numpy.yaml
@@ -1,0 +1,22 @@
+name: NumPy
+description: "NumPy is the fundamental package for scientific computing with Python, providing N-dimensional array objects, broadcasting functions, linear algebra routines, Fourier transforms, and random number generation. It serves as the core numerical foundation for nearly every Python-based machine learning framework, including PyTorch, TensorFlow, scikit-learn, and JAX."
+tagline: "Fundamental numerical computing library for Python"
+github_url: https://github.com/numpy/numpy
+website_url: https://numpy.org
+docs_url: https://numpy.org/doc
+install_command: "pip install numpy"
+category: Dev Tools
+tags:
+  - numerical-computing
+  - python
+  - arrays
+  - linear-algebra
+  - data-science
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Python as a general-purpose language lacks built-in support for efficient numerical operations on large multi-dimensional arrays. Looping over array elements in pure Python is orders of magnitude slower than compiled languages, making it impractical for machine learning, scientific computing, or data-intensive workloads without a specialized numerical library."
+use_cases:
+  - "Provide the core N-dimensional array data structure underpinning all major Python ML frameworks (PyTorch, TensorFlow, scikit-learn)"
+  - "Perform high-performance linear algebra, Fourier transforms, and random number generation for model training pipelines"
+  - "Serve as the universal interchange format for numerical data between Python libraries via the standard ndarray interface"


### PR DESCRIPTION
## Add NumPy, Apache Arrow, and Apache NiFi to catalog

### NumPy (tools/dev-tools/numpy.yaml)
- **Category:** Dev Tools
- **GitHub:** numpy/numpy (32,147★)
- **License:** BSD-3-Clause
- Fundamental numerical computing library for Python ML ecosystem

### Apache Arrow (tools/data/apache-arrow.yaml)
- **Category:** Data
- **GitHub:** apache/arrow (16,807★)
- **License:** Apache-2.0
- Universal columnar format for fast data interchange and analytics

### Apache NiFi (tools/data/apache-nifi.yaml)
- **Category:** Data
- **GitHub:** apache/nifi (6,109★)
- **License:** Apache-2.0
- Data flow automation and pipeline orchestration

### Validation checklist
- [x] YAML files created in correct category directories
- [x] Local validation passes for all three files
- [x] Required fields present: name, description, problem_solved, use_cases, github_url
- [x] problem_solved > 50 chars each
- [x] use_cases >= 3 items, each >= 10 chars
- [x] No duplicate names in catalog (verified with find + grep)
