### PR TITLE
Add scikit-learn, OpenCV, and XGBoost to catalog

### DIFF
--- a/tools/data/xgboost.yaml
+++ b/tools/data/xgboost.yaml
@@ -1,0 +1,23 @@
+name: XGBoost
+description: "XGBoost is an optimized distributed gradient boosting library designed for speed and performance in machine learning tasks. It implements gradient-boosted decision trees (GBDT, GBRT) with regularization to prevent overfitting, built-in cross-validation, tree pruning, and native handling of missing values. It runs on single machines as well as distributed frameworks like Spark, Dask, and Flink."
+tagline: "Optimized gradient boosting for machine learning"
+github_url: https://github.com/dmlc/xgboost
+website_url: https://xgboost.readthedocs.io
+docs_url: https://xgboost.readthedocs.io/en/stable
+install_command: "pip install xgboost"
+category: Data
+tags:
+  - gradient-boosting
+  - machine-learning
+  - decision-trees
+  - python
+  - r
+  - spark
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Traditional machine learning models like single decision trees suffer from high bias or high variance, while ensemble methods can be slow to train and difficult to tune. Teams need a battle-tested, high-performance gradient boosting framework that handles missing data natively, prevents overfitting through regularization, and scales from a single laptop to distributed clusters."
+use_cases:
+  - "Train state-of-the-art gradient boosting models for structured/tabular data classification and regression tasks"
+  - "Perform feature importance analysis and model interpretation with built-in gain, cover, and frequency metrics"
+  - "Scale model training across Spark, Dask, or Kubernetes clusters for large datasets that don't fit in memory"

--- a/tools/dev-tools/scikit-learn.yaml
+++ b/tools/dev-tools/scikit-learn.yaml
@@ -1,0 +1,23 @@
+name: scikit-learn
+description: "scikit-learn is a Python library for machine learning built on NumPy, SciPy, and Matplotlib. It provides simple and efficient tools for predictive data analysis, including classification, regression, clustering, dimensionality reduction, model selection, and preprocessing — all through a consistent API. It is one of the most widely used ML libraries in production and research."
+tagline: "Machine learning in Python — simple and efficient"
+github_url: https://github.com/scikit-learn/scikit-learn
+website_url: https://scikit-learn.org
+docs_url: https://scikit-learn.org/stable/documentation.html
+install_command: "pip install scikit-learn"
+category: Dev Tools
+tags:
+  - machine-learning
+  - python
+  - classification
+  - regression
+  - clustering
+  - data-science
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Building and evaluating machine learning models from scratch requires deep mathematical expertise and significant engineering effort. Data scientists and developers need a consistent, well-tested API for common ML tasks like classification, regression, clustering, and dimensionality reduction without having to implement algorithms manually or navigate incompatible library interfaces."
+use_cases:
+  - "Train classification and regression models using algorithms like random forests, SVMs, and gradient boosting with a consistent fit/predict API"
+  - "Evaluate model performance with cross-validation, hyperparameter tuning via grid search, and standardized scoring metrics"
+  - "Preprocess and transform data pipelines using scaling, encoding, dimensionality reduction (PCA, t-SNE), and feature selection"

--- a/tools/other/opencv.yaml
+++ b/tools/other/opencv.yaml
@@ -1,0 +1,22 @@
+name: OpenCV
+description: "OpenCV (Open Source Computer Vision Library) is a comprehensive computer vision and machine learning library with 2,500+ optimized algorithms for image processing, object detection, face recognition, camera calibration, and video analysis. It supports Python, C++, Java, and JavaScript, and is widely used in AI applications requiring visual perception, from autonomous vehicles to document processing pipelines."
+tagline: "Open-source computer vision and image processing library"
+github_url: https://github.com/opencv/opencv
+website_url: https://opencv.org
+docs_url: https://docs.opencv.org/4.x
+install_command: "pip install opencv-python"
+category: Other
+tags:
+  - computer-vision
+  - image-processing
+  - object-detection
+  - video-analysis
+  - deep-learning
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Building computer vision capabilities from scratch requires implementing complex algorithms for image filtering, feature detection, camera geometry, and neural network inference. Teams building AI applications with visual inputs need a comprehensive, optimized library that handles the entire vision pipeline without reinventing low-level image processing primitives."
+use_cases:
+  - "Detect and track objects in real-time video streams using deep learning models (YOLO, SSD) or classical computer vision techniques"
+  - "Preprocess and augment image datasets for training vision models — resizing, color space conversion, filtering, and geometric transforms"
+  - "Extract text from images and documents through OCR pipelines using scene text detection and recognition modules"


### PR DESCRIPTION
## Add scikit-learn, OpenCV, and XGBoost to catalog

### scikit-learn (tools/dev-tools/scikit-learn.yaml)
- **Category:** Dev Tools
- **GitHub:** scikit-learn/scikit-learn (66,241★)
- **License:** BSD-3-Clause
- Machine learning in Python — classification, regression, clustering

### OpenCV (tools/other/opencv.yaml)
- **Category:** Other
- **GitHub:** opencv/opencv (87,770★)
- **License:** Apache-2.0
- Open-source computer vision and image processing library

### XGBoost (tools/data/xgboost.yaml)
- **Category:** Data
- **GitHub:** dmlc/xgboost (28,442★)
- **License:** Apache-2.0
- Optimized gradient boosting for machine learning

### Validation checklist
- [x] YAML files created in correct category directories
- [x] Local validation passes for all three files
- [x] Required fields present: name, description, problem_solved, use_cases, github_url
- [x] problem_solved > 50 chars each
- [x] use_cases >= 3 items, each >= 10 chars
- [x] No duplicate names in catalog (verified with find + grep)
