### PR TITLE
Add Hadoop, Cassandra, and Prometheus to catalog

### DIFF
--- a/tools/data/hadoop.yaml
+++ b/tools/data/hadoop.yaml
@@ -1,0 +1,24 @@
+name: Apache Hadoop
+description: Apache Hadoop is an open-source framework for distributed storage (HDFS) and distributed processing (MapReduce/YARN) of massive datasets across clusters of commodity hardware. For AI and agentic workflows, Hadoop provides the foundational data layer for storing and preprocessing large-scale training datasets, logs, and telemetry that feed machine learning pipelines.
+tagline: Distributed storage and processing for big data and AI pipelines
+
+github_url: https://github.com/apache/hadoop
+website_url: https://hadoop.apache.org/
+docs_url: https://hadoop.apache.org/docs/stable/
+
+install_command: brew install hadoop
+
+category: Data
+tags: [big-data, distributed-storage, hdfs, mapreduce, yarn, data-processing, batch-processing]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI and agentic systems need to store, manage, and process petabytes of distributed data (training corpora, logs, telemetry) across clusters. Hadoop solves reliable, fault-tolerant distributed storage and large-scale batch processing on commodity hardware without expensive proprietary infrastructure, enabling teams to build scalable data pipelines for ML training and inference.
+
+use_cases:
+  - "Store and manage petabyte-scale training datasets for LLM fine-tuning across distributed HDFS clusters"
+  - "Batch preprocess and transform raw web-crawl data into clean training corpora using MapReduce jobs"
+  - "Archive and serve agent interaction logs and telemetry for downstream analytics and model improvement"
+  - "Run distributed Spark ML training jobs on data stored in HDFS for production AI pipelines"

--- a/tools/monitoring/prometheus.yaml
+++ b/tools/monitoring/prometheus.yaml
@@ -1,0 +1,26 @@
+name: Prometheus
+description: Prometheus is an open-source systems monitoring and alerting toolkit built at SoundCloud. It collects and stores metrics as time-series data with a powerful PromQL query language. For AI/ML systems, Prometheus tracks model inference latency, throughput, GPU utilization, request rates, and data pipeline health across distributed AI agent ecosystems and model serving infrastructure.
+tagline: Open-source monitoring and alerting for metrics and time-series data
+
+github_url: https://github.com/prometheus/prometheus
+website_url: https://prometheus.io/
+docs_url: https://prometheus.io/docs/
+
+install_command: |
+  docker run -d --name prometheus -p 9090:9090 prom/prometheus:v3.12.0
+
+category: Monitoring
+tags: [monitoring, metrics, alerting, time-series, observability, promql, ml-monitoring, ai-infrastructure]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI and agentic systems generate vast amounts of metrics from distributed components — model inference endpoints, agent microservices, GPU/TPU resources, and data pipelines — but traditional monitoring tools struggle with the cardinality and dimensionality of these metrics. Prometheus provides a purpose-built pull-based metrics system with multi-dimensional labeling, powerful PromQL querying, and integrated alerting designed for ephemeral, horizontally-scaled infrastructure common in ML deployments.
+
+use_cases:
+  - "Monitor ML model inference latency and throughput across multiple serving endpoints"
+  - "Track GPU/TPU utilization and resource metrics for training and inference workloads"
+  - "Observe AI agent request rates, error rates, and response time distributions in real time"
+  - "Alert on data pipeline health, feature store freshness, and model drift in production"
+  - "Instrument multi-agent systems with custom metrics for end-to-end observability"

--- a/tools/vector-databases/cassandra.yaml
+++ b/tools/vector-databases/cassandra.yaml
@@ -1,0 +1,24 @@
+name: Apache Cassandra
+description: Apache Cassandra is an open-source distributed NoSQL database with native vector search capabilities via Storage-Attached Indexes (SAI), added in Cassandra 5.0. It combines linear scalability and proven fault-tolerance with ANN similarity search on high-dimensional embedding vectors, enabling AI workloads like semantic search and RAG pipelines on commodity hardware.
+tagline: Scalable NoSQL database with native vector search for AI workloads
+
+github_url: https://github.com/apache/cassandra
+website_url: https://cassandra.apache.org/
+docs_url: https://cassandra.apache.org/doc/latest/cassandra/vector-search/overview.html
+
+install_command: docker pull cassandra:latest
+
+category: Vector DB
+tags: [nosql, vector-search, distributed-database, ann, similarity-search, sai, embeddings]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Traditional databases lack native similarity search on unstructured data, forcing teams to maintain separate vector stores alongside operational databases. Cassandra bridges this gap by combining linearly scalable, fault-tolerant distributed storage with native ANN vector search via SAI indexes. This eliminates data duplication, reduces operational complexity, and enables production-grade semantic search and AI/ML similarity comparisons on embedding vectors at global scale.
+
+use_cases:
+  - "Power semantic search and RAG pipelines by combining vector similarity with structured metadata queries"
+  - "Run real-time AI similarity matching for product recommendations and content personalization at scale"
+  - "Build enterprise knowledge bases with natural language querying and distributed fault-tolerance across regions"
+  - "Perform multi-modal search across text and images using SAI ANN indexes with configurable similarity functions"


### PR DESCRIPTION
Add Apache Hadoop, Apache Cassandra, and Prometheus to the tool catalog.

## Tools added

### Apache Hadoop (Data)
Distributed storage and processing for big data and AI pipelines. HDFS provides the foundational data layer for storing training datasets, logs, and telemetry at petabyte scale.

### Apache Cassandra (Vector DB)
Distributed NoSQL database with native vector search via Storage-Attached Indexes (SAI), added in Cassandra 5.0. Combines fault-tolerant distributed storage with ANN similarity search for AI workloads.

### Prometheus (Monitoring)
Open-source monitoring and alerting toolkit for metrics and time-series data. Tracks ML model inference latency, GPU utilization, and AI agent health across distributed infrastructure.

## Validation
- [x] YAML files validated locally with `npx tsx scripts/validate-tool.ts`
- [x] All three pass validation
- [x] Category directories match existing convention


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration metadata for Apache Hadoop, enabling data processing tool integration.
  * Added configuration metadata for Prometheus, enabling metrics monitoring tool integration.
  * Added configuration metadata for Apache Cassandra, enabling vector database tool integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->