### PR TITLE
Add Optuna, AutoGluon, and Taipy to catalog

### DIFF
--- a/tools/dev-tools/autogluon.yaml
+++ b/tools/dev-tools/autogluon.yaml
@@ -1,0 +1,24 @@
+name: AutoGluon
+description: AutoGluon is an open-source AutoML framework for automating machine learning workflows. It trains, tunes, and stacks multiple models with ensembling to achieve state-of-the-art predictive performance with minimal code. For AI/ML practitioners, AutoGluon handles tabular data, text, image, and multimodal problems with automatic data preprocessing, model selection, hyperparameter tuning, and ensemble construction.
+tagline: AutoML framework for automated machine learning with ensembling
+
+github_url: https://github.com/autogluon/autogluon
+website_url: https://auto.gluon.ai/
+docs_url: https://auto.gluon.ai/stable/
+
+install_command: pip install autogluon
+
+category: Dev Tools
+tags: [automl, machine-learning, ensemble, tabular-data, multimodal, python, deep-learning]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building high-performance machine learning models requires extensive expertise in data preprocessing, model selection, hyperparameter tuning, and ensemble construction — a time-consuming process even for experienced data scientists. AutoGluon automates the entire ML pipeline, using multi-layer stack ensembling and repeated k-fold bagging to produce models that often match or exceed manually tuned solutions with just a few lines of code.
+
+use_cases:
+  - "Build production-grade tabular ML models with automatic preprocessing, ensembling, and tuning"
+  - "Automate multimodal ML pipelines combining text, image, and tabular features"
+  - "Rapidly prototype baseline models for classification, regression, and time series forecasting"
+  - "Generate high-quality ensemble models for Kaggle competitions or internal benchmarks"

--- a/tools/dev-tools/optuna.yaml
+++ b/tools/dev-tools/optuna.yaml
@@ -1,0 +1,24 @@
+name: Optuna
+description: Optuna is an open-source hyperparameter optimization framework designed for automating the search for optimal machine learning model parameters. It features define-by-run API, efficient pruning of unpromising trials, and distributed parallel optimization. For AI/ML workflows, Optuna integrates with PyTorch, TensorFlow, and scikit-learn to automatically tune hyperparameters for training pipelines, LLM fine-tuning configurations, and agent system parameters.
+tagline: Hyperparameter optimization framework for machine learning
+
+github_url: https://github.com/optuna/optuna
+website_url: https://optuna.org/
+docs_url: https://optuna.readthedocs.io/
+
+install_command: pip install optuna
+
+category: Dev Tools
+tags: [hyperparameter-optimization, automl, hyperparameter-tuning, python, mlops, bayesian-optimization]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Machine learning models have many tunable hyperparameters that significantly affect performance, but manual tuning is slow and grid search is computationally wasteful. Optuna automates this process with advanced sampling and pruning algorithms (TPE, CMA-ES, Median Pruner), integrates seamlessly with popular ML frameworks, and runs trials in parallel across distributed workers to find optimal configurations efficiently.
+
+use_cases:
+  - "Automatically tune hyperparameters for deep learning models in PyTorch, TensorFlow, or Keras"
+  - "Optimize LLM fine-tuning hyperparameters like learning rate, batch size, and LoRA rank"
+  - "Tune agentic system parameters such as temperature, max tokens, and retrieval chunk sizes"
+  - "Run distributed hyperparameter searches across multiple GPUs or compute nodes in parallel"

--- a/tools/dev-tools/taipy.yaml
+++ b/tools/dev-tools/taipy.yaml
@@ -1,0 +1,24 @@
+name: Taipy
+description: Taipy is an open-source Python framework for building production-ready data and AI applications. It combines a reactive frontend with backend pipeline orchestration, enabling developers to create full-stack ML applications — from data pipelines and model training to interactive dashboards and scenario management — without needing separate frontend or backend teams.
+tagline: Build production-grade data and AI applications in Python
+
+github_url: https://github.com/Avaiga/taipy
+website_url: https://www.taipy.io/
+docs_url: https://docs.taipy.io/
+
+install_command: pip install taipy
+
+category: Dev Tools
+tags: [python, dashboard, web-framework, data-pipelines, data-science, visualization, mlops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Data scientists and ML engineers often struggle to turn Jupyter notebooks or Python scripts into production-ready web applications with interactive dashboards, data pipelines, and scenario management. Taipy bridges this gap by providing a unified framework for building multi-page data and AI apps with a reactive Python frontend, integrated pipeline orchestration, and versioned scenario execution — all without requiring separate frontend engineering expertise.
+
+use_cases:
+  - "Build interactive dashboards for monitoring ML model performance and data pipelines in production"
+  - "Create scenario management tools that allow users to run what-if analyses with different model configurations"
+  - "Develop full-stack data applications with reactive visualizations, filtering, and real-time updates"
+  - "Rapidly prototype and deploy internal tools for data exploration and AI model interaction"


### PR DESCRIPTION
Add Optuna, AutoGluon, and Taipy to the tool catalog.

## Tools added

### Optuna (Dev Tools)
Hyperparameter optimization framework with define-by-run API, pruning, and distributed parallel trials. Integrates with PyTorch, TensorFlow, and scikit-learn for automatic ML tuning.

### AutoGluon (Dev Tools)
AutoML framework that trains, tunes, and stacks multiple models with multi-layer ensembling. Handles tabular, text, image, and multimodal problems with minimal code.

### Taipy (Dev Tools)
Python framework for building production-ready data and AI applications with reactive frontends, pipeline orchestration, and scenario management.

## Validation
- [x] All three YAML files pass local validation
- [x] Category: Dev Tools
