### PR TITLE
Add Doccano and JAX to catalog

### DIFF
--- a/tools/data/doccano.yaml
+++ b/tools/data/doccano.yaml
@@ -1,0 +1,27 @@
+name: Doccano
+description: An open-source text annotation tool for machine learning practitioners, supporting text classification, sequence labeling, and sequence-to-sequence annotation tasks with a collaborative web interface.
+tagline: Open-source text annotation platform for NLP datasets
+
+github_url: https://github.com/doccano/doccano
+docs_url: https://doccano.github.io/doccano/
+install_command: pip install doccano
+
+category: Data
+tags: [annotation, data-labeling, nlp, text-classification, named-entity-recognition, sequence-labeling, open-source, python]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Building high-quality NLP datasets requires teams to annotate text with labels, entities, and
+  relationships, but most annotation workflows rely on spreadsheets, custom scripts, or expensive
+  proprietary tools. Doccano gives teams a free, web-based platform where they can upload data,
+  define labeling schemas, collaborate with annotators, and export labeled datasets without writing
+  any annotation infrastructure code.
+
+use_cases:
+  - Label named entities in text documents for training NER models with custom entity types
+  - Classify text passages by sentiment, topic, or intent to build text classification datasets
+  - Annotate sequence-to-sequence pairs for summarization, translation, or paraphrase training data
+  - Coordinate annotation projects across multiple human labelers with role-based project management
+  - Export annotated datasets in multiple formats for downstream machine learning pipelines

--- a/tools/dev-tools/jax.yaml
+++ b/tools/dev-tools/jax.yaml
@@ -1,0 +1,31 @@
+name: JAX
+description: A high-performance Python library for accelerator-oriented array computation and program transformation, enabling automatic differentiation, vectorization, and JIT compilation across CPUs, GPUs, and TPUs for machine learning research and production.
+tagline: Accelerated array computation and automatic differentiation for ML
+
+github_url: https://github.com/jax-ml/jax
+website_url: https://jax.readthedocs.io/en/latest/
+docs_url: https://docs.jax.dev/en/latest/
+install_command: |
+  pip install -U jax
+  pip install -U "jax[cuda13]"
+
+category: Dev Tools
+tags: [deep-learning, automatic-differentiation, jit, gpu, tpu, numpy, tensor, python, machine-learning]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Machine learning research and development requires fast, differentiable numerical computation
+  across diverse hardware. JAX unifies NumPy-style array programming with composable
+  transformations — autodiff, JIT compilation, vectorized mapping, and parallelization — that
+  run seamlessly on CPUs, GPUs, and TPUs. It eliminates the need to write separate forward and
+  backward passes, manage device transfers manually, or switch frameworks when moving from
+  research experiments to production training loops.
+
+use_cases:
+  - Train neural networks with automatic differentiation through complex control flow and recursive structures
+  - JIT-compile compute-intensive array operations for CPU, GPU, and TPU acceleration
+  - Build and optimize large-scale ML models with function transformations like vmap, pmap, and xmap
+  - Accelerate scientific computing and simulation workloads with GPU/TPU-backed NumPy array operations
+  - Implement custom training loops and optimizer logic without framework-imposed abstractions


### PR DESCRIPTION
## Add Doccano and JAX to the catalog

### Doccano (Data)
- **Category:** Data
- **Description:** Open-source text annotation tool for ML practitioners supporting text classification, sequence labeling, and sequence-to-sequence annotation
- **GitHub:** https://github.com/doccano/doccano — 10.6k ★, MIT license
- **Install:** `pip install doccano`

### JAX (Dev Tools)
- **Category:** Dev Tools
- **Description:** High-performance Python library for accelerator-oriented array computation and program transformation
- **GitHub:** https://github.com/jax-ml/jax — 35.7k ★, Apache-2.0 license
- **Install:** `pip install -U jax`

### Validation
- [x] YAML files created in correct category directories
- [x] Local validation passed: `npx tsx scripts/validate-tool.ts`
- [x] Both files independently valid

### Checklist
- [x] `tools/data/doccano.yaml` — valid
- [x] `tools/dev-tools/jax.yaml` — valid


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about Doccano, an open-source text annotation platform with capabilities for NER labeling, text classification, and collaborative annotation management.
  * Added information about JAX, an open-source development tool supporting JIT compilation, automatic differentiation, and accelerated execution across CPUs, GPUs, and TPUs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->