### PR TITLE
Add APEX, FastChat, and OpenAI Evals to catalog

### DIFF
--- a/tools/fine-tuning/apex.yaml
+++ b/tools/fine-tuning/apex.yaml
@@ -1,0 +1,29 @@
+name: APEX
+description: A PyTorch Extension providing tools for easy mixed precision training, distributed training, and optimized CUDA kernels, enabling faster training of deep learning models on NVIDIA GPUs with minimal code changes.
+tagline: Mixed precision and distributed training tools for PyTorch
+
+github_url: https://github.com/NVIDIA/apex
+docs_url: https://nvidia.github.io/apex/
+install_command: |
+  git clone https://github.com/NVIDIA/apex
+  cd apex && pip install -v --no-build-isolation .
+
+category: Fine-tuning
+tags: [pytorch, mixed-precision, distributed-training, cuda, gpu, neural-networks, optimization, deep-learning]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Training large neural networks efficiently requires mixed precision computation and distributed
+  training capabilities, but configuring these features manually is error-prone and requires deep
+  CUDA expertise. APEX provides drop-in tools for automatic mixed precision (AMP), distributed
+  data parallel (DDP) training, and optimized CUDA extensions that give PyTorch developers
+  significant training speedups and memory savings without rewriting their model code.
+
+use_cases:
+  - Accelerate deep learning model training with automatic mixed precision (FP16) on NVIDIA GPUs
+  - Scale training across multiple GPUs and nodes using distributed data parallel patterns
+  - Use optimized fused CUDA kernels for faster attention, convolution, and normalization layers
+  - Train larger batch sizes and models by reducing GPU memory usage through mixed precision
+  - Smoothly transition from single-GPU to multi-GPU training with minimal code changes

--- a/tools/monitoring/openai-evals.yaml
+++ b/tools/monitoring/openai-evals.yaml
@@ -1,0 +1,27 @@
+name: OpenAI Evals
+description: A framework for evaluating large language models and LLM systems, providing standardized evaluation tasks, model-graded assessments, and composable test suites for measuring accuracy, safety, and quality.
+tagline: LLM evaluation framework from OpenAI
+
+github_url: https://github.com/openai/evals
+docs_url: https://cookbook.openai.com/examples/evaluate_with_evals
+install_command: pip install evals
+
+category: Monitoring
+tags: [evaluation, llm, testing, benchmarking, quality, safety, ai-evaluation, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Evaluating LLM outputs requires consistent, reproducible test methodologies, but teams often
+  rely on manual review or ad hoc scripts that don't scale across model versions or use cases.
+  OpenAI Evals provides a structured framework for defining evaluation tasks, running model-graded
+  assessments, and composing test suites that give developers confidence in model quality before
+  shipping to production.
+
+use_cases:
+  - Run standardized evaluation tasks to measure LLM accuracy, safety, and instruction-following
+  - Use model-graded evaluations for assessing open-ended outputs like summaries and translations
+  - Build custom evaluation suites for domain-specific use cases with composable test templates
+  - Compare model performance across versions or providers to inform deployment decisions
+  - Integrate evaluations into CI/CD pipelines for automated quality gates on model releases

--- a/tools/other/fastchat.yaml
+++ b/tools/other/fastchat.yaml
@@ -1,0 +1,26 @@
+name: FastChat
+description: An open platform for training, serving, and evaluating large language models, providing an optimized serving system, a web-based chat interface, and CLI tools compatible with hundreds of open-source and API-based models.
+tagline: Open platform for training, serving, and evaluating LLMs
+
+github_url: https://github.com/lm-sys/FastChat
+install_command: pip3 install "fschat[model_worker,webui]"
+
+category: Other
+tags: [llm, serving, inference, chat, vicuna, model-serving, open-source, python]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Deploying and serving large language models in production requires managing model workers,
+  handling concurrent requests, and providing a user interface — all tasks that demand
+  significant infrastructure work. FastChat gives teams a production-ready serving system with
+  model parallelism, OpenAI-compatible API endpoints, and a built-in web UI so they can deploy
+  LLMs for interactive use or API access without building custom serving infrastructure.
+
+use_cases:
+  - Serve open-source LLMs behind an OpenAI-compatible REST API for application integration
+  - Host multi-model chat platforms with concurrent users, model workers, and load balancing
+  - Evaluate and compare LLM outputs side-by-side through a web-based arena interface
+  - Fine-tune models using the built-in training scripts for domain-specific adaptation
+  - Run models with model parallelism across multiple GPUs for serving large parameter counts


### PR DESCRIPTION
## Add APEX, FastChat, and OpenAI Evals to catalog

### APEX (Fine-tuning)
- **Category:** Fine-tuning
- **Description:** PyTorch Extension for mixed precision and distributed training with optimized CUDA kernels
- **GitHub:** https://github.com/NVIDIA/apex — 8.9k ★, BSD-3-Clause
- **Install:** `git clone` + `pip install` from source

### FastChat (Other)
- **Category:** Other
- **Description:** Open platform for training, serving, and evaluating LLMs
- **GitHub:** https://github.com/lm-sys/FastChat — 39.4k ★, Apache-2.0
- **Install:** `pip3 install "fschat[model_worker,webui]"`

### OpenAI Evals (Monitoring)
- **Category:** Monitoring
- **Description:** Framework for evaluating LLMs and LLM systems through standardized tasks
- **GitHub:** https://github.com/openai/evals — 18.6k ★, MIT
- **Install:** `pip install evals`

### Validation
- [x] YAML files created in correct category directories
- [x] Local validation passed for all 3 files
- [x] All files independently valid

### Checklist
- [x] `tools/fine-tuning/apex.yaml` — valid
- [x] `tools/other/fastchat.yaml` — valid
- [x] `tools/monitoring/openai-evals.yaml` — valid
