### PR TITLE
Add Core ML Tools, Tokenizers, SentencePiece to catalog

### DIFF
--- a/tools/dev-tools/coremltools.yaml
+++ b/tools/dev-tools/coremltools.yaml
@@ -1,0 +1,39 @@
+name: Core ML Tools
+description: Apple's model conversion tools for translating trained models from PyTorch, TensorFlow, and scikit-learn into the Core ML format — enabling on-device machine learning inference across iOS, macOS, watchOS, and tvOS.
+tagline: Convert ML models to Apple's Core ML format for on-device inference
+
+github_url: https://github.com/apple/coremltools
+website_url: https://coremltools.readme.io
+docs_url: https://apple.github.io/coremltools/docs-guides/
+install_command: pip install coremltools
+
+category: Dev Tools
+tags:
+  - apple
+  - ios
+  - model-conversion
+  - on-device
+  - coreml
+  - pytorch
+  - tensorflow
+  - mobile
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Deploying a PyTorch or TensorFlow model onto an iPhone or iPad requires converting
+  it to Apple's Core ML format — a process that involves graph translation, op mapping,
+  quantization, and platform-specific optimizations. Doing this manually is fragile and
+  time-consuming. Core ML Tools automates the entire conversion pipeline: it takes
+  trained models from the major frameworks, converts them to the Core ML package format
+  (.mlpackage), optimizes them for Apple Neural Engine and GPU compute, and validates
+  numerical accuracy against the original model. Without it, deploying ML on Apple devices
+  would require rewriting models from scratch in each platform's native API.
+
+use_cases:
+  - Convert a PyTorch image classifier to Core ML for real-time inference in an iOS camera app
+  - Deploy a TensorFlow object detection model on-device without network latency or cloud costs
+  - Quantize a large language model to FP16 for efficient inference on Apple Silicon Macs
+  - Integrate a scikit-learn regression model into a macOS application with zero network calls
+  - Validate converted model accuracy by comparing predictions against the original framework

--- a/tools/llm/sentencepiece.yaml
+++ b/tools/llm/sentencepiece.yaml
@@ -1,0 +1,39 @@
+name: SentencePiece
+description: Google's unsupervised text tokenizer and detokenizer for neural network text generation systems — implementing BPE and unigram language model subword algorithms with language-agnostic, purely data-driven tokenization.
+tagline: Unsupervised subword tokenization without language-specific preprocessing
+
+github_url: https://github.com/google/sentencepiece
+website_url: https://github.com/google/sentencepiece
+docs_url: https://github.com/google/sentencepiece#readme
+install_command: pip install sentencepiece
+
+category: LLM
+tags:
+  - tokenization
+  - nlp
+  - subword
+  - bpe
+  - unigram
+  - google
+  - llm
+  - text-generation
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Traditional tokenizers require language-specific pre-tokenization (splitting on spaces,
+  punctuation) which breaks for languages without clear word boundaries like Japanese,
+  Chinese, or Korean, and introduces complex pre-processing pipelines. SentencePiece
+  treats the input as a raw character stream — no language-specific pre-tokenization
+  needed — and learns subword units directly from the data using BPE or the unigram
+  language model. This makes it truly language-agnostic and enables purely end-to-end
+  neural network systems. It is the tokenizer backbone for models like T5, Gemma, Llama,
+  and many other major open-source LLMs.
+
+use_cases:
+  - Tokenize multilingual text (English, Japanese, Chinese, Korean) without language-specific preprocessing
+  - Train a custom BPE vocabulary for a domain-specific LLM (medical, legal, code) from raw text
+  - Use the unigram language model algorithm for better compression ratios on morphologically rich languages
+  - Integrate sentence-level tokenization into a production NLP pipeline for a search or translation system
+  - Pre-tokenize training data for a large language model with deterministic, reversible encoding

--- a/tools/llm/tokenizers.yaml
+++ b/tools/llm/tokenizers.yaml
@@ -1,0 +1,40 @@
+name: Tokenizers
+description: Hugging Face's state-of-the-art tokenization library built in Rust for blazing-fast training and inference — used by virtually every modern LLM for subword tokenization with BPE, WordPiece, and Unigram algorithms.
+tagline: Fast subword tokenization for modern LLMs
+
+github_url: https://github.com/huggingface/tokenizers
+website_url: https://huggingface.co/docs/tokenizers
+docs_url: https://huggingface.co/docs/tokenizers/index.html
+install_command: |
+  pip install tokenizers
+
+category: LLM
+tags:
+  - tokenization
+  - nlp
+  - huggingface
+  - subword
+  - bpe
+  - rust
+  - wordpiece
+  - llm
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Tokenization is the first step in any LLM pipeline — converting raw text into integer
+  token IDs — but naive Python implementations are painfully slow for production workloads.
+  Training a BPE vocabulary on a large corpus can take hours, and tokenizing at inference
+  time becomes a bottleneck. Tokenizers solves this with a Rust core that tokenizes a
+  gigabyte of text in under 20 seconds on a single CPU. It supports all major algorithms
+  (BPE, WordPiece, Unigram) with built-in pre-processing (truncation, padding, special
+  tokens) and alignment tracking that maps tokens back to their original characters.
+  It's the engine behind virtually every model on Hugging Face Hub.
+
+use_cases:
+  - Train a BPE tokenizer on a multilingual corpus for a custom LLM in minutes instead of hours
+  - Tokenize billions of tokens for a production LLM serving pipeline with sub-millisecond latency
+  - Convert between tokenizer formats (WordPiece → BPE) when switching model architectures
+  - Add padding and truncation to batches automatically for efficient GPU utilization
+  - Track token-to-character alignment for span-level tasks like NER and question answering


### PR DESCRIPTION
## Summary

Adds 3 tools to the Agentic AI For Good catalog:

### Core ML Tools (Dev Tools)
Apple's model conversion tools for translating trained models from PyTorch, TensorFlow, and scikit-learn into the Core ML format for on-device inference across Apple platforms.
- **Stars:** 5,278 · **License:** BSD-3-Clause
- **GitHub:** https://github.com/apple/coremltools
- **Install:** `pip install coremltools`

### Tokenizers (LLM)
Hugging Face's state-of-the-art tokenization library built in Rust for blazing-fast training and inference — BPE, WordPiece, and Unigram algorithms for LLM tokenization.
- **Stars:** 10,798 · **License:** Apache-2.0
- **GitHub:** https://github.com/huggingface/tokenizers
- **Install:** `pip install tokenizers`

### SentencePiece (LLM)
Google's unsupervised text tokenizer implementing BPE and unigram subword algorithms with purely data-driven, language-agnostic tokenization for neural text generation.
- **Stars:** 11,886 · **License:** Apache-2.0
- **GitHub:** https://github.com/google/sentencepiece
- **Install:** `pip install sentencepiece`

## Verification
- [x] YAML files created in correct category directories (dev-tools, llm)
- [x] Local validation passed (`npx tsx validate-tool.ts`) for all 3 files
- [x] Only `tools/` files modified
- [x] All required fields present (name, description, problem_solved, use_cases)
- [x] `problem_solved` ≥ 50 chars, `use_cases` ≥ 3 items
