### PR TITLE
Add Apache Flink, LightGBM, CatBoost to catalog

### DIFF
--- a/tools/data/apache-flink.yaml
+++ b/tools/data/apache-flink.yaml
@@ -1,0 +1,25 @@
+name: Apache Flink
+description: Apache Flink is a framework and distributed processing engine for stateful computations over unbounded and bounded data streams, with support for event-time processing, exactly-once semantics, and massive scalability across clusters.
+tagline: Stateful stream processing framework for real-time data pipelines
+
+github_url: https://github.com/apache/flink
+website_url: https://flink.apache.org/
+docs_url: https://nightlies.apache.org/flink/flink-docs-stable/
+
+install_command: |
+  pip install apache-flink
+
+category: Data
+tags: [stream-processing, real-time, etl, big-data, apache, python, scala, event-driven]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI and data teams building real-time ML pipelines often struggle with processing continuous data streams with exactly-once guarantees, event-time semantics, and fault tolerance. Apache Flink provides a unified stream-processing engine that handles both real-time and historical data with the same APIs, enabling feature computation, anomaly detection, and ML inference on live data at massive scale.
+
+use_cases:
+  - "Build real-time feature engineering pipelines that compute ML features on streaming data with exactly-once semantics"
+  - "Detect anomalies and patterns in real-time data streams for monitoring, fraud detection, and alerting systems"
+  - "Run continuous ETL pipelines that transform and enrich streaming data for AI model training and inference"
+  - "Process unbounded event-time data with built-in watermarks, triggers, and state management"

--- a/tools/data/catboost.yaml
+++ b/tools/data/catboost.yaml
@@ -1,0 +1,24 @@
+name: CatBoost
+description: CatBoost is a high-performance, open-source gradient boosting library with native support for categorical features, GPU and CPU training, and state-of-the-art prediction quality with minimal hyperparameter tuning required.
+tagline: Gradient boosting with native categorical feature support
+
+github_url: https://github.com/catboost/catboost
+website_url: https://catboost.ai
+docs_url: https://catboost.ai/en/docs/
+
+install_command: pip install catboost
+
+category: Data
+tags: [gradient-boosting, machine-learning, classification, regression, ranking, gpu, python, categorical-data]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Gradient boosting models often require extensive preprocessing to handle categorical features, missing values, and hyperparameter tuning, adding complexity to ML pipelines. CatBoost provides a gradient boosting library that natively handles categorical features without manual encoding, delivers state-of-the-art results with default parameters, and supports both CPU and GPU training—reducing pipeline complexity while maintaining high prediction quality.
+
+use_cases:
+  - "Train ML models on datasets with many categorical features without manual encoding or preprocessing"
+  - Build high-performance classification and regression models with minimal hyperparameter tuning using default parameters
+  - "Run gradient boosting on GPU for faster training on large datasets with built-in cross-validation"
+  - Deploy production ML pipelines with automatic handling of missing values, text features, and imbalanced data

--- a/tools/data/lightgbm.yaml
+++ b/tools/data/lightgbm.yaml
@@ -1,0 +1,24 @@
+name: LightGBM
+description: LightGBM is a fast, distributed, high-performance gradient boosting framework based on decision tree algorithms, optimized for speed and memory efficiency with histogram-based learning, GPU support, and native handling of categorical features.
+tagline: Fast gradient boosting framework with GPU and distributed training
+
+github_url: https://github.com/lightgbm-org/LightGBM
+website_url: https://lightgbm.readthedocs.io/en/latest/
+docs_url: https://lightgbm.readthedocs.io/en/latest/
+
+install_command: pip install lightgbm
+
+category: Data
+tags: [gradient-boosting, machine-learning, classification, regression, ranking, gpu, python, decision-trees]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Building high-performance ML models on large datasets often requires balancing prediction accuracy with training speed and memory usage. LightGBM provides a fast, memory-efficient gradient boosting framework that uses histogram-based learning and leaf-wise tree growth to deliver state-of-the-art results on classification, regression, and ranking tasks—training many times faster than traditional boosting implementations with GPU and distributed training support.
+
+use_cases:
+  - "Train classification and regression models on large tabular datasets with GPU-accelerated learning for faster iteration"
+  - "Build ranking models for search relevance, recommendation systems, and information retrieval"
+  - "Run distributed gradient boosting across multiple machines for petabyte-scale ML training"
+  - "Deploy lightweight, high-performance ML models for real-time inference in production systems"


### PR DESCRIPTION
Add Apache Flink, LightGBM, CatBoost to the Agentic AI For Good tool catalog.

## Tools added

### Apache Flink (Data)
- **Category:** Data
- **GitHub:** https://github.com/apache/flink (26k★)
- **Description:** Framework and distributed processing engine for stateful stream processing with exactly-once semantics
- **Install:** `pip install apache-flink`
- **License:** Apache-2.0

### LightGBM (Data)
- **Category:** Data
- **GitHub:** https://github.com/lightgbm-org/LightGBM (18.4k★)
- **Description:** Fast, distributed gradient boosting framework with GPU support and native categorical feature handling
- **Install:** `pip install lightgbm`
- **License:** MIT

### CatBoost (Data)
- **Category:** Data
- **GitHub:** https://github.com/catboost/catboost (8.9k★)
- **Description:** High-performance gradient boosting library with native categorical feature support and minimal tuning
- **Install:** `pip install catboost`
- **License:** Apache-2.0

## Validation checklist
- [x] YAML files created in correct category directory (Data → `tools/data/`)
- [x] Local validation passes for all 3 files (`npx tsx scripts/validate-tool.ts`)
- [x] All required fields present: name, description, problem_solved, use_cases (min 3), github_url
- [x] problem_solved fields exceed 50 char minimum
- [x] use_cases items exceed 10 char minimum
