### PR TITLE
Add Apache Druid, Apache Beam, Apache Pinot to catalog

### DIFF
--- a/tools/data/apache-beam.yaml
+++ b/tools/data/apache-beam.yaml
@@ -1,0 +1,24 @@
+name: Apache Beam
+description: Apache Beam is a unified programming model for defining and executing batch and streaming data processing pipelines. It provides portable SDKs in Python, Java, and Go, and runs on multiple runners including Apache Flink, Spark, and Google Cloud Dataflow.
+tagline: Unified batch and stream processing framework
+
+github_url: https://github.com/apache/beam
+website_url: https://beam.apache.org/
+docs_url: https://beam.apache.org/documentation/
+
+install_command: pip install apache-beam
+
+category: Data
+tags: [stream-processing, batch-processing, etl, big-data, apache, python, java, go, data-pipeline]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Machine learning and data engineering teams often need to process data in both batch and streaming modes but end up maintaining separate codebases with different APIs. Apache Beam solves this by providing a single, portable programming model for both batch and stream processing, with the same pipeline code running on any execution engine. This eliminates duplicate logic, simplifies pipeline maintenance, and enables teams to transition seamlessly from batch to real-time as their use cases evolve.
+
+use_cases:
+  - "Build unified ETL pipelines that process historical batch data and streaming data with the same codebase and APIs"
+  - "Run machine learning inference pipelines on streaming data with exactly-once processing semantics"
+  - "Port data processing pipelines across execution engines (Flink, Spark, Dataflow) without rewriting application code"
+  - "Create feature engineering pipelines that compute training features from both batch backfills and live streams"

--- a/tools/data/apache-druid.yaml
+++ b/tools/data/apache-druid.yaml
@@ -1,0 +1,26 @@
+name: Apache Druid
+description: Apache Druid is a high-performance real-time analytics database designed for OLAP queries on large datasets. It excels at ingesting streaming and batch data with sub-second query latency, supporting SQL, time-series analysis, and interactive dashboards at scale.
+tagline: Real-time OLAP database for high-performance analytics
+
+github_url: https://github.com/apache/druid
+website_url: https://druid.apache.org/
+docs_url: https://druid.apache.org/docs/latest/
+
+install_command: |
+  curl -O https://dlcdn.apache.org/druid/37.0.0/apache-druid-37.0.0-bin.tar.gz
+  tar -xzf apache-druid-37.0.0-bin.tar.gz
+
+category: Data
+tags: [database, olap, analytics, real-time, big-data, apache, java, time-series]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Data teams building real-time analytics applications often struggle with query latency on large-scale time-series and event data using traditional databases. Apache Druid solves this by providing a purpose-built OLAP database that ingests streaming data in real time, automatically partitions and indexes data for sub-second queries, and supports interactive exploration across billions of rows — enabling AI monitoring dashboards, user-facing analytics, and operational intelligence at scale.
+
+use_cases:
+  - "Power real-time analytics dashboards for AI monitoring systems tracking model performance and inference metrics"
+  - "Ingest and query streaming event data for operational intelligence, anomaly detection, and user behavior analytics"
+  - "Run high-concurrency OLAP queries with sub-second latency on large-scale time-series datasets"
+  - "Build user-facing analytics applications with interactive filtering, drill-downs, and aggregations on billions of rows"

--- a/tools/data/apache-pinot.yaml
+++ b/tools/data/apache-pinot.yaml
@@ -1,0 +1,26 @@
+name: Apache Pinot
+description: Apache Pinot is a real-time distributed OLAP datastore built for delivering instant analytics on large-scale, high-throughput data. It supports low-latency ingestion from streaming sources like Kafka and serves queries with sub-second response times, making it ideal for user-facing analytics and business intelligence.
+tagline: Real-time distributed OLAP datastore for instant analytics
+
+github_url: https://github.com/apache/pinot
+website_url: https://pinot.apache.org/
+docs_url: https://docs.pinot.apache.org/
+
+install_command: |
+  docker pull apachepinot/pinot:latest
+  docker run -p 9000:9000 apachepinot/pinot:latest QuickStart -type batch
+
+category: Data
+tags: [database, olap, analytics, real-time, big-data, apache, java, streaming, kafka]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Organizations building user-facing analytics and real-time dashboards often struggle with high query latency and low ingestion throughput when handling large-scale event data in traditional databases. Apache Pinot solves this by providing a horizontally scalable OLAP datastore that ingests from streaming sources with millisecond-level freshness, automatically indexes and compresses data for efficient storage, and serves complex aggregation queries with sub-second latency at high concurrency.
+
+use_cases:
+  - "Serve real-time analytics dashboards for AI model monitoring, user-facing metrics, and operational intelligence"
+  - "Ingest and query high-throughput streaming event data from Kafka for instant business insights and anomaly detection"
+  - "Power interactive OLAP workloads with sub-second query response times on multi-billion-row datasets"
+  - "Build customer-facing analytics features that require high concurrency and low latency on real-time data"


### PR DESCRIPTION
## Summary

Adds 3 data infrastructure tools to the catalog:

### Apache Druid
A high-performance real-time analytics database for OLAP queries on large datasets. Powers interactive dashboards, user-facing analytics, and operational intelligence with sub-second query latency across billions of rows.

**Category:** Data
**GitHub:** github.com/apache/druid (14k★)
**License:** Apache-2.0

### Apache Beam
A unified programming model for batch and streaming data processing pipelines with portable SDKs in Python, Java, and Go. Runs on multiple runners including Flink, Spark, and Dataflow.

**Category:** Data
**GitHub:** github.com/apache/beam (8.6k★)
**License:** Apache-2.0

### Apache Pinot
A real-time distributed OLAP datastore built for instant analytics on high-throughput data. Ingests from Kafka with sub-second freshness and serves complex aggregation queries at high concurrency.

**Category:** Data
**GitHub:** github.com/apache/pinot (6.1k★)
**License:** Apache-2.0

### Validation Checklist
- [ ] YAML files created in correct category directory (tools/data/)
- [ ] Required fields present: name, description, problem_solved, use_cases, github_url
- [ ] problem_solved ≥ 50 chars each
- [ ] use_cases has ≥ 3 items each
- [ ] Local validation passed: `npx tsx scripts/validate-tool.ts` — all 3 valid


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apache Beam, Apache Druid, and Apache Pinot to the tools catalog, providing access to three new big data and analytics platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->