### PR TITLE
Add Gemma to catalog

### DIFF
--- a/tools/llm/gemma.yaml
+++ b/tools/llm/gemma.yaml
@@ -1,0 +1,24 @@
+name: Gemma
+description: Gemma is a family of lightweight, open-weight large language models from Google DeepMind, available in sizes from 2B to 27B parameters. Built from the same research and technology as Gemini, Gemma models run efficiently on consumer hardware and are designed for fine-tuning, deployment, and research.
+tagline: Open-weight LLM family by Google DeepMind
+
+github_url: https://github.com/google-deepmind/gemma
+website_url: https://ai.google.dev/gemma
+docs_url: https://gemma-llm.readthedocs.io
+
+install_command: pip install gemma
+
+category: LLM
+tags: [llm, text-generation, google, deepmind, open-weights, transformers, fine-tuning, python, jax]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Researchers and developers building custom AI applications often lack access to high-quality open-weight models that can run on affordable hardware without cloud dependencies. Gemma solves this by providing lightweight, pre-trained LLMs that are efficient enough to run on a single GPU or even CPU, yet perform competitively with much larger models. Combined with flexible fine-tuning support and permissive Apache 2.0 licensing, Gemma enables accessible AI development for research, experimentation, and production deployment.
+
+use_cases:
+  - "Fine-tune lightweight open-weight LLMs on domain-specific data for specialized NLP tasks and custom applications"
+  - "Run text generation and content creation models on consumer-grade hardware without cloud GPU dependencies"
+  - "Build chatbots and conversational AI with efficient small-to-medium sized language models"
+  - "Experiment with model interpretability, safety research, and alignment techniques using open weights"


### PR DESCRIPTION
## Summary

Adds **Gemma** to the catalog — Google DeepMind's family of lightweight open-weight LLMs.

### Gemma
A family of open-weight LLMs (2B–27B params) built from the same research as Gemini. Efficient on consumer hardware, Apache 2.0 licensed, with fine-tuning and deployment support.

**Category:** LLM
**GitHub:** github.com/google-deepmind/gemma (5.4k★)
**License:** Apache-2.0

### Validation Checklist
- [x] YAML file created in correct category directory (tools/llm/)
- [x] Required fields present: name, description, problem_solved, use_cases, github_url
- [x] problem_solved ≥ 50 chars
- [x] use_cases has ≥ 3 items
- [x] Local validation passed: `npx tsx scripts/validate-tool.ts` — gemma valid
