### PR TITLE
Add Plandex, Genkit, and Rerankers to catalog

### DIFF
--- a/tools/dev-tools/genkit.yaml
+++ b/tools/dev-tools/genkit.yaml
@@ -1,0 +1,43 @@
+name: Genkit
+description: Genkit is Google's open-source framework for building AI-powered applications in JavaScript, Go, and Python. It provides a unified interface for generative AI workflows including agents, RAG, structured output, multi-modal processing, and tool calling — with a built-in developer UI, CLI, and production monitoring dashboard.
+tagline: Google's open-source framework for building AI-powered apps
+
+github_url: https://github.com/genkit-ai/genkit
+website_url: https://genkit.dev
+docs_url: https://firebase.google.com/docs/genkit
+
+install_command: |
+  npm install -g genkit
+  pip install genkit
+
+category: Dev Tools
+tags:
+  - ai-framework
+  - generative-ai
+  - agents
+  - rag
+  - multimodal
+  - llm
+  - typescript
+  - python
+  - go
+  - google
+pricing: free
+is_open_source: true
+license: Apache 2.0
+
+problem_solved: |
+  Building production AI applications requires stitching together multiple SDKs, prompt
+  management systems, model providers, and evaluation tools — often with inconsistent
+  APIs and no unified debugging experience. Genkit provides a single open-source
+  framework with a unified interface across models and providers, built-in prompt
+  templating, structured output, RAG pipelines, agent tool calling, a local developer
+  UI for debugging, and production monitoring — supporting JavaScript, Go, and Python
+  with a consistent API across all three languages.
+
+use_cases:
+  - "Build AI-powered chatbots and conversational agents with multi-provider model support and tool calling"
+  - Create RAG applications with vector search integration and structured output generation
+  - Develop multi-step AI workflows with type-safe data generation and validation
+  - Prototype and debug AI features rapidly with the built-in developer UI and CLI
+  - Deploy full-stack AI applications with web and mobile client SDKs for Next.js, React, Angular, iOS, and Android

--- a/tools/dev-tools/plandex.yaml
+++ b/tools/dev-tools/plandex.yaml
@@ -1,0 +1,39 @@
+name: Plandex
+description: Plandex is an open-source AI coding agent designed for large projects and real-world tasks. It features a 2M token effective context window, tree-sitter project maps that index 20M+ token codebases across 30+ languages, cumulative diff review sandboxes, and configurable autonomy from full auto to step-by-step control.
+tagline: Open source AI coding agent for large projects and real world tasks
+
+github_url: https://github.com/plandex-ai/plandex
+website_url: https://plandex.ai
+docs_url: https://docs.plandex.ai
+
+install_command: curl -sL https://plandex.ai/install.sh | bash
+
+category: Dev Tools
+tags:
+  - ai-coding-agent
+  - cli
+  - terminal
+  - developer-tools
+  - large-projects
+  - code-generation
+  - refactoring
+  - go
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI coding assistants often struggle with large codebases, limited context windows,
+  and opaque decision-making, making multi-file refactors and complex feature additions
+  error-prone and difficult to review. Plandex solves this with a 2M token effective
+  context window, tree-sitter project maps that understand code structure across 30+
+  languages, and a cumulative diff sandbox that keeps all changes isolated until approved
+  — enabling developers to safely tackle large-scale coding tasks with full visibility
+  into every change before it lands in the codebase.
+
+use_cases:
+  - "Build new applications from scratch with natural language prompts across full project scaffolding"
+  - Add complex multi-file features to existing codebases with automated change tracking
+  - Refactor and migrate code across dozens of files with cumulative diff review and rollback
+  - Debug build failures, test failures, and browser application issues with automated root cause analysis
+  - Compare AI model outputs by branching plans and running the same task with different providers

--- a/tools/rag/rerankers.yaml
+++ b/tools/rag/rerankers.yaml
@@ -1,0 +1,39 @@
+name: Rerankers
+description: Rerankers is a lightweight Python library that provides a unified API for using all common reranking and cross-encoder models — including cross-encoders, RankGPT, FlashRank (ONNX), ColBERT, Cohere, Jina, and more. It offers a single Reranker class with a consistent rank() interface across local and API-based models.
+tagline: A unified API for all common reranking and cross-encoder models
+
+github_url: https://github.com/AnswerDotAI/rerankers
+docs_url: https://github.com/AnswerDotAI/rerankers
+
+install_command: |
+  pip install "rerankers[transformers]"
+  pip install "rerankers[all]"
+
+category: RAG
+tags:
+  - reranking
+  - retrieval
+  - rag
+  - cross-encoder
+  - information-retrieval
+  - nlp
+  - python
+  - search
+pricing: free
+is_open_source: true
+license: Apache 2.0
+
+problem_solved: |
+  Reranking is a critical step in high-quality RAG pipelines, but each reranking method
+  — cross-encoders, RankGPT, FlashRank, Cohere API, ColBERT — has its own API,
+  dependencies, and deployment requirements. Rerankers eliminates this fragmentation
+  with a single Reranker class that provides a consistent rank() interface across 10+
+  reranking backends, allowing developers to easily experiment with, benchmark, and
+  switch between reranking strategies without changing application code.
+
+use_cases:
+  - "Rerank initial retrieval results from vector search or BM25 to improve RAG pipeline quality"
+  - Experiment with different reranking strategies (cross-encoder, RankGPT, FlashRank, ColBERT) using a single API
+  - Deploy CPU-friendly reranking with FlashRank ONNX models for low-latency production use
+  - Use API-based reranking from Cohere, Jina, or Voyage without managing local model infrastructure
+  - Benchmark and compare reranking approaches on custom datasets to select the best strategy for a given domain


### PR DESCRIPTION
## Add Plandex, Genkit, and Rerankers to catalog

### Tools added:

**Plandex** (Dev Tools) — Open-source AI coding agent designed for large projects with 2M token effective context window, tree-sitter project maps, and cumulative diff review sandboxes. 15.4K+ GitHub stars.
- Category: Dev Tools
- https://github.com/plandex-ai/plandex
- `curl -sL https://plandex.ai/install.sh | bash`

**Genkit** (Dev Tools) — Google's open-source framework for building AI-powered apps in JavaScript, Go, and Python. Supports agents, RAG, structured output, multi-modal, and tool calling. 6K+ GitHub stars.
- Category: Dev Tools
- https://github.com/genkit-ai/genkit
- `npm install -g genkit` or `pip install genkit`

**Rerankers** (RAG) — Lightweight Python library providing a unified API for 10+ reranking and cross-encoder models. Single `Reranker` class for local and API-based reranking. 1.6K+ GitHub stars.
- Category: RAG
- https://github.com/AnswerDotAI/rerankers
- `pip install "rerankers[all]"`

### Validation checklist:
- [x] YAML files created in correct category directories
- [x] Local validation passes — all three tools valid
- [x] All required fields included
- [x] problem_solved >= 50 chars for each entry
- [x] Each use_case >= 10 chars (>=3 per tool)
- [x] No existing tools with the same name in the catalog
