### PR TITLE
Add Apache Hudi, TensorFlow.js, and WebLLM to catalog

### DIFF
--- a/tools/data/apache-hudi.yaml
+++ b/tools/data/apache-hudi.yaml
@@ -1,0 +1,29 @@
+name: Apache Hudi
+description: A data lake management platform that enables incremental data processing, upserts, and deletes on big data, providing ACID transactions and time-travel queries on data lakes.
+tagline: Incremental data processing for data lakes
+
+github_url: https://github.com/apache/hudi
+website_url: https://hudi.apache.org/
+
+install_command: |
+  # Via Spark packages:
+  spark-shell --packages org.apache.hudi:hudi-spark-bundle:0.15.0
+  # Via Maven:
+  # Add hudi-spark-bundle to pom.xml
+
+category: Data
+tags: [data-lake, big-data, spark, apache, java, data-processing, incremental, etl]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Traditional data lakes lack ACID transactions and cannot efficiently handle incremental updates, deletions, or point-in-time queries. Apache Hudi solves this by bringing database-style upserts, deletes, and incremental pull capabilities to data lakes — enabling real-time ingestion, streaming ETL, and time-travel queries on object stores like S3 and HDFS with existing Spark and Flink pipelines.
+
+use_cases:
+  - "Streaming data ingestion: upsert real-time event streams into data lakes with ACID guarantees and no data loss"
+  - "Change data capture (CDC): capture and apply database changelogs to data lakes for analytics without full recomputes"
+  - "Data lake de-duplication: remove duplicate records from large-scale data lakes without reprocessing entire datasets"
+  - "Time-travel queries: query historical versions of data for audit trails, regulatory compliance, and debugging"
+  - "Incremental ETL: process only changed records since the last pipeline run, reducing compute costs by orders of magnitude"
+  - "Unified batch and streaming: run both batch and streaming workloads on the same dataset with consistent guarantees"

--- a/tools/dev-tools/tensorflow-js.yaml
+++ b/tools/dev-tools/tensorflow-js.yaml
@@ -1,0 +1,25 @@
+name: TensorFlow.js
+description: A WebGL-accelerated JavaScript library for training and deploying machine learning models directly in the browser or Node.js, supporting both inference and training from scratch.
+tagline: ML in the browser and Node.js
+
+github_url: https://github.com/tensorflow/tfjs
+website_url: https://js.tensorflow.org
+
+install_command: npm install @tensorflow/tfjs
+
+category: Dev Tools
+tags: [javascript, machine-learning, browser, webgl, tensorflow, deep-learning, nodejs, inference]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  ML models traditionally run on servers or specialized hardware, requiring developers to manage infrastructure, handle network latency for inference requests, and navigate privacy concerns with sending data to external servers. TensorFlow.js solves this by running ML models directly in the browser or Node.js environment — enabling zero-latency inference, offline-capable applications, and privacy-preserving AI that never sends user data to a server.
+
+use_cases:
+  - "In-browser inference: run pre-trained ML models directly in the browser for real-time predictions with zero server latency"
+  - "Privacy-preserving AI: process sensitive user data (images, audio, text) entirely on-device without sending anything to servers"
+  - "Transfer learning in the browser: retrain existing models on user-specific data client-side for personalized experiences"
+  - "Offline-first applications: build ML-powered apps that work without internet connectivity using client-side models"
+  - "Node.js deployment: serve ML models from Node.js backends without Python dependencies, enabling full-stack JS ML"
+  - "Educational ML demos: create interactive, in-browser ML demonstrations that run entirely on the user's device"

--- a/tools/dev-tools/webllm.yaml
+++ b/tools/dev-tools/webllm.yaml
@@ -1,0 +1,26 @@
+name: WebLLM
+description: A high-performance in-browser LLM inference engine that runs large language models directly in the browser via WebGPU, enabling private, offline, and serverless AI chat and completion.
+tagline: High-performance LLM inference in the browser
+
+github_url: https://github.com/mlc-ai/web-llm
+website_url: https://webllm.mlc.ai
+docs_url: https://webllm.mlc.ai/docs
+
+install_command: npm install @mlc-ai/web-llm
+
+category: Dev Tools
+tags: [llm, webgpu, browser, inference, javascript, typescript, webassembly, mlc-ai]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Running LLMs typically requires powerful cloud GPUs or dedicated local hardware, creating dependency on server infrastructure, introducing latency, and raising data privacy concerns. WebLLM solves this by leveraging WebGPU to run full LLMs directly in the browser at near-native speed — enabling completely private, offline-capable AI chat, completion, and agent capabilities that never send data to external servers and require zero server-side infrastructure.
+
+use_cases:
+  - "Private AI chat: run LLM-powered chat applications entirely in-browser with no data ever leaving the user's device"
+  - "Offline AI assistant: provide AI assistance in air-gapped environments, remote locations, or on personal devices without internet"
+  - "Serverless AI applications: build LLM-powered web apps that need no backend infrastructure for inference, reducing hosting costs"
+  - "Educational demos: create interactive browser demos of LLM capabilities that work instantly without API keys or setup"
+  - "Privacy-sensitive workflows: process confidential documents and queries with AI on-device for regulated industries"
+  - "Edge computing: deploy LLM-powered tools to edge devices where cloud connectivity is unreliable or expensive"


### PR DESCRIPTION
## Add Apache Hudi, TensorFlow.js, and WebLLM to catalog

### Apache Hudi (Data)
- Data lake management with ACID transactions, upserts, and incremental pulls
- 6k+ stars, Apache-2.0 license
- Install via Spark packages
- Use cases: streaming ingestion, CDC, de-duplication, time-travel queries, incremental ETL

### TensorFlow.js (Dev Tools)
- WebGL-accelerated ML library for browser and Node.js
- 19k+ stars, Apache-2.0 license
- Install: `npm install @tensorflow/tfjs`
- Use cases: in-browser inference, privacy-preserving AI, transfer learning, offline-first apps

### WebLLM (Dev Tools)
- High-performance in-browser LLM inference via WebGPU
- 18k+ stars, Apache-2.0 license
- Install: `npm install @mlc-ai/web-llm`
- Use cases: private AI chat, offline AI assistant, serverless AI apps, privacy-sensitive workflows

### Validation Checklist
- [x] YAML files created in correct category directories (`tools/data/`, `tools/dev-tools/`)
- [x] Local validation passes for all three files
- [x] Only tools/ files modified
