### PR TITLE
Add ECC, TradingAgents, and NVIDIA SkillSpector to catalog

### DIFF
--- a/tools/agent-frameworks/tradingagents.yaml
+++ b/tools/agent-frameworks/tradingagents.yaml
@@ -1,0 +1,39 @@
+name: TradingAgents
+description: >
+  TradingAgents is a multi-agent LLM framework for financial trading that
+  mirrors the dynamics of real-world trading firms. It deploys specialized
+  LLM-powered agents — fundamental analysts, sentiment experts, technical
+  analysts, traders, risk managers, and portfolio managers — that collaboratively
+  evaluate market conditions, engage in structured debates to identify optimal
+  strategies, and make informed trading decisions.
+problem_solved: >
+  Financial trading requires synthesizing diverse signals from fundamentals,
+  market sentiment, technical indicators, macroeconomic news, and risk metrics
+  — then making coordinated decisions under uncertainty. Traditional
+  algorithmic trading systems struggle to incorporate qualitative analysis and
+  multi-perspective debate. TradingAgents solves this by deploying specialized
+  LLM-powered agents that mirror a real trading firm's hierarchy, collaborating
+  through structured debates to evaluate risks, balance bullish and bearish
+  perspectives, and determine optimal trading strategies.
+tagline: Multi-Agent LLM Financial Trading Framework
+use_cases:
+  - "Deploy multi-agent trading teams that collaboratively evaluate market conditions and make informed decisions"
+  - "Synthesize fundamental analysis, technical indicators, and sentiment signals into coordinated trading strategies"
+  - "Backtest LLM-driven trading strategies across historical market data with configurable risk parameters"
+  - "Research multi-agent debate architectures for financial decision-making under uncertainty"
+  - "Integrate with multiple LLM providers (OpenAI, Gemini, Claude, Grok, DeepSeek, Qwen) for diversified agent reasoning"
+category: Agents
+tags:
+  - agents
+  - finance
+  - trading
+  - llm
+  - multi-agent
+  - python
+  - research
+pricing: free
+is_open_source: true
+license: Apache-2.0
+github_url: https://github.com/TauricResearch/TradingAgents
+docs_url: https://arxiv.org/abs/2412.20138
+install_command: pip install tradingagents

--- a/tools/dev-tools/ecc.yaml
+++ b/tools/dev-tools/ecc.yaml
@@ -1,0 +1,42 @@
+name: ECC
+description: >
+  ECC is a harness-native agent operating system that brings skills, instincts,
+  memory optimization, security scanning, and research-first development to AI
+  coding assistants. It works across Claude Code, Codex, Cursor, OpenCode,
+  Gemini CLI, GitHub Copilot, and other agent harnesses, providing a unified
+  system of shared skills, hooks, rules, MCP configurations, and continuous
+  learning capabilities evolved from intensive daily use building real products.
+problem_solved: >
+  AI coding assistants each have their own incompatible conventions for skills,
+  hooks, MCP configurations, and security features. Teams and power users who
+  switch between harnesses (Claude Code, Codex, Cursor, OpenCode, Gemini CLI)
+  lose productivity re-implementing the same capabilities in each ecosystem.
+  ECC provides a harness-native operator system that works consistently across
+  all major AI coding assistants, with shared skills, memory optimization,
+  security scanning, and continuous learning — eliminating the fragmentation
+  of the multi-harness AI development workflow.
+tagline: Harness-native agent operating system for AI coding assistants
+use_cases:
+  - "Manage skills, hooks, and rules consistently across Claude Code, Codex, Cursor, and other AI coding assistant harnesses"
+  - "Optimize agent memory and context windows with instinct-based pruning patterns for reduced token usage"
+  - "Scan agent skills for security vulnerabilities before installation across multiple harnesses"
+  - "Implement research-first development workflows with continuous learning loops that persist across sessions"
+  - "Set up cross-harness MCP servers and configurations with a single shared system"
+category: Dev Tools
+tags:
+  - ai-agents
+  - claude-code
+  - codex
+  - cursor
+  - opencode
+  - mcp
+  - developer-tools
+  - skills
+  - security
+  - agent-harness
+pricing: freemium
+is_open_source: true
+license: MIT
+github_url: https://github.com/affaan-m/ECC
+website_url: https://ecc.tools
+install_command: npm install -g ecc-universal

--- a/tools/monitoring/nvidia-skillspector.yaml
+++ b/tools/monitoring/nvidia-skillspector.yaml
@@ -1,0 +1,42 @@
+name: NVIDIA SkillSpector
+description: >
+  NVIDIA SkillSpector is a security scanner for AI agent skills that detects
+  vulnerabilities, malicious patterns, and security risks before installation.
+  It supports scanning Git repos, URLs, zip files, directories, and single
+  files across 64 vulnerability patterns in 16 categories — including prompt
+  injection, data exfiltration, command injection, and credential leaks. Works
+  with skills from Claude Code, Codex CLI, Gemini CLI, and other AI coding
+  assistants.
+problem_solved: >
+  AI agent skills execute with implicit trust and minimal vetting. Research
+  shows that 26.1% of skills contain vulnerabilities and 5.2% show likely
+  malicious intent, yet developers have no standardized way to audit agent
+  skills before installing them from third-party sources. NVIDIA SkillSpector
+  fills this gap with a purpose-built security scanner that detects prompt
+  injection, data exfiltration, command injection, credential leaks, and other
+  attack patterns across AI agent skill formats from all major coding
+  assistants.
+tagline: Security scanner for AI agent skills
+use_cases:
+  - "Scan AI agent skills for vulnerabilities before installing from third-party sources or marketplaces"
+  - "Detect prompt injection, data exfiltration, and command injection patterns across 64 vulnerability signatures"
+  - "Audit skill repositories and CI/CD pipelines with automated multi-format scanning (Git repos, URLs, directories)"
+  - "Integrate security scanning into agent development workflows with LLM-powered analysis for false positive triage"
+  - "Enforce security policies for enterprise agent deployments across Claude Code, Codex CLI, and Gemini CLI skills"
+category: Monitoring
+tags:
+  - security
+  - ai-agents
+  - vulnerability-scanning
+  - claude-code
+  - codex
+  - prompt-injection
+  - nvidia
+pricing: free
+is_open_source: true
+license: Apache-2.0
+github_url: https://github.com/NVIDIA/skillspector
+docs_url: https://github.com/NVIDIA/skillspector/blob/main/docs/DEVELOPMENT.md
+install_command: |
+  git clone https://github.com/NVIDIA/skillspector.git
+  cd skillspector && make install


### PR DESCRIPTION
## Changes

Adding three new tools to the Agentic AI For Good catalog:

### ECC (Dev Tools) — 215k★
Harness-native agent operating system for AI coding assistants (Claude Code, Codex, Cursor, OpenCode, Gemini CLI). Provides shared skills, hooks, MCP configurations, memory optimization, and security scanning across all major agent harnesses.

**Category:** Dev Tools | **License:** MIT | **Install:** `npm install -g ecc-universal`

### TradingAgents (Agents) — 86k★
Multi-agent LLM framework for financial trading that mirrors real-world trading firms with specialized agents for fundamental analysis, sentiment analysis, technical analysis, risk management, and portfolio management.

**Category:** Agents | **License:** Apache-2.0 | **Install:** `pip install tradingagents`

### NVIDIA SkillSpector (Monitoring) — 5.3k★
Security scanner for AI agent skills that detects vulnerabilities, malicious patterns, and security risks across 64 patterns in 16 categories before installing skills from Claude Code, Codex CLI, Gemini CLI, and other coding assistants.

**Category:** Monitoring | **License:** Apache-2.0 | **Install:** git clone + make install

---

## Validation checklist
- [x] YAML files created in correct category directories
- [x] All three files pass local validation (`npx tsx scripts/validate-tool.ts`)
- [x] All required fields present (name, description, problem_solved, use_cases >=3)
- [x] problem_solved >= 50 characters for each entry
- [x] Each has at least one of github_url or website_url
- [x] No duplicate entries confirmed via cross-category search


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added TradingAgents multi-agent framework to the tools catalog
  * Added ECC development tool to the developer tools catalog
  * Added NVIDIA SkillSpector monitoring tool to the monitoring tools catalog

<!-- end of auto-generated comment: release notes by coderabbit.ai -->