### PR TITLE
Add Databricks, Notion, and PostHog to catalog

### DIFF
--- a/tools/data/databricks.yaml
+++ b/tools/data/databricks.yaml
@@ -1,0 +1,19 @@
+name: Databricks
+description: Unified data analytics and AI platform for data engineering, data science, and machine learning workloads on a lakehouse architecture.
+tagline: Unified data analytics and AI platform
+problem_solved: >
+  Data teams struggle to manage disparate data systems for ETL, analytics, and ML workloads across multiple clouds. Databricks provides a unified lakehouse platform combining data lake flexibility with warehouse performance, featuring integrated MLflow, Delta Lake, and collaborative notebooks for end-to-end data and AI workflows.
+category: Data
+github_url: https://github.com/databricks/databricks-sdk-py
+website_url: https://databricks.com
+docs_url: https://docs.databricks.com
+install_command: pip install databricks-sdk
+pricing: paid
+is_open_source: false
+license: Proprietary
+tags: [data, analytics, spark, machine-learning, lakehouse, etl, delta-lake, mlflow]
+
+use_cases:
+  - "Data engineering: build and orchestrate ETL pipelines at scale with Delta Lake and Apache Spark"
+  - "Machine learning: train, track, and deploy models with integrated MLflow and feature stores"
+  - "Collaborative analytics: use Databricks notebooks for ad-hoc analysis and data science workflows"

--- a/tools/monitoring/posthog.yaml
+++ b/tools/monitoring/posthog.yaml
@@ -1,0 +1,19 @@
+name: PostHog
+description: Open-source product analytics and feature flag platform that helps teams understand user behavior, run experiments, and build better products.
+tagline: Open-source product analytics platform
+problem_solved: >
+  Product teams lack actionable insights into user behavior and struggle with feature rollout management. PostHog provides self-hosted product analytics, session recordings, feature flags, and A/B testing in a single platform with AI-powered analysis capabilities for data-driven product decisions.
+category: Monitoring
+github_url: https://github.com/PostHog/posthog
+website_url: https://posthog.com
+docs_url: https://posthog.com/docs
+install_command: pip install posthog
+pricing: freemium
+is_open_source: true
+license: MIT
+tags: [product-analytics, feature-flags, experimentation, session-recordings, self-hosted, ab-testing]
+
+use_cases:
+  - "Product analytics: track user behavior, funnels, retention, and revenue with self-serve dashboards"
+  - "Feature management: roll out features gradually with feature flags targeting specific user segments"
+  - "AI-powered insights: use PostHog's AI features to analyze user sessions and generate actionable intelligence"

--- a/tools/other/notion.yaml
+++ b/tools/other/notion.yaml
@@ -1,0 +1,21 @@
+name: Notion
+description: All-in-one workspace for docs, wikis, project management, and AI-powered knowledge management with a rich API ecosystem.
+tagline: All-in-one workspace with AI and API
+problem_solved: >
+  Teams often juggle multiple tools for documentation, project management, and knowledge bases, causing context-switching and fragmented information. Notion provides a unified workspace with hierarchical docs, databases, AI writing assistant, and a powerful API that enables AI agents to read, write, and search structured content programmatically.
+category: Other
+github_url: https://github.com/makenotion/notion-sdk-js
+website_url: https://notion.so
+docs_url: https://developers.notion.com
+install_command: |
+  npm install @notionhq/client
+  pip install notion-client
+pricing: freemium
+is_open_source: false
+license: Proprietary
+tags: [workspace, documentation, knowledge-base, collaboration, api, productivity]
+
+use_cases:
+  - "AI-powered knowledge management: build AI agents that read, write, and search Notion databases"
+  - "Documentation automation: programmatically create and update docs, wikis, and project trackers"
+  - "Content pipelines: use the Notion API to ingest, process, and publish structured content"


### PR DESCRIPTION
## Summary

Adding 3 new tools to the Agentic AI For Good catalog:

### Databricks (Data)
- **Category:** Data
- **Description:** Unified data analytics and AI platform for data engineering, data science, and ML workloads on a lakehouse architecture
- **Pricing:** Paid
- **Install:** `pip install databricks-sdk`

### Notion (Other)
- **Category:** Other
- **Description:** All-in-one workspace for docs, wikis, project management, and AI-powered knowledge management with a rich API ecosystem
- **Pricing:** Freemium
- **Install:** `npm install @notionhq/client` / `pip install notion-client`

### PostHog (Monitoring)
- **Category:** Monitoring
- **Description:** Open-source product analytics and feature flag platform for understanding user behavior and running experiments
- **Pricing:** Freemium
- **Install:** `pip install posthog`

## Validation Checklist
- [x] YAML files created in correct category directories
- [x] Local validation passes (`npx tsx scripts/validate-tool.ts`) for all 3 files
- [x] All required fields present and valid
- [x] No duplicate entries found in catalog
- [x] GitHub repos verified active and not archived
- [x] Install commands verified against PyPI/GitHub


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Three new tools now available: Databricks for data engineering, PostHog for monitoring and analytics, and Notion for knowledge management
  * Includes installation instructions, platform details, and comprehensive use-case examples for each tool

<!-- end of auto-generated comment: release notes by coderabbit.ai -->