### PR TITLE
Add RisingWave, StarRocks, and Distilabel to catalog

### DIFF
--- a/tools/data/risingwave.yaml
+++ b/tools/data/risingwave.yaml
@@ -1,0 +1,20 @@
+name: RisingWave
+description: Event streaming platform for agentic AI that continuously ingests, transforms, and serves event streams in real time using SQL.
+tagline: Streaming SQL for agentic AI
+problem_solved: >
+  AI agents and applications need real-time access to streaming data from Kafka, databases, and webhooks, but traditional streaming infrastructure is complex to set up and maintain. RisingWave provides a developer-friendly streaming SQL platform that ingests, transforms, and serves event streams with PostgreSQL-compatible interfaces and real-time materialized views.
+category: Data
+github_url: https://github.com/risingwavelabs/risingwave
+website_url: https://risingwave.com
+docs_url: https://docs.risingwave.com
+install_command: |
+  curl -L https://risingwave.com/sh | sh
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+tags: [stream-processing, event-streaming, real-time, kafka, sql, materialized-views, data-ingestion]
+
+use_cases:
+  - "Real-time AI features: serve streaming features to AI models and agents with sub-second latency using materialized views"
+  - "Event-driven architecture: ingest and transform event streams from Kafka, databases, and webhooks for AI pipelines"
+  - "Data transformation: use SQL to join, filter, and aggregate streaming data for real-time analytics and monitoring"

--- a/tools/data/starrocks.yaml
+++ b/tools/data/starrocks.yaml
@@ -1,0 +1,21 @@
+name: StarRocks
+description: World's fastest open query engine for sub-second analytics on and off the data lakehouse, with support for real-time and ad-hoc queries.
+tagline: High-performance analytics database
+problem_solved: >
+  Analytics workloads on large datasets are slow and expensive with traditional databases, especially for real-time and ad-hoc queries across data lakehouses. StarRocks delivers best-in-class performance for multi-dimensional analytics, real-time queries, and high-concurrency workloads with a MySQL-compatible interface and support for data lake analytics.
+category: Data
+github_url: https://github.com/StarRocks/starrocks
+website_url: https://starrocks.io
+docs_url: https://docs.starrocks.io
+install_command: |
+  curl -sSOL https://download.starrocks.io/starrocks/StarRocks-3.3.0.tar.gz
+  tar -xzf StarRocks-3.3.0.tar.gz
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+tags: [analytics, olap, data-warehouse, real-time, lakehouse, sql, big-data]
+
+use_cases:
+  - "Real-time analytics: query streaming data with sub-second latency for dashboards, monitoring, and AI applications"
+  - "Data lakehouse analytics: query data directly on data lakes (Iceberg, Hudi, Delta Lake) without moving or copying data"
+  - "High-concurrency BI: serve thousands of concurrent dashboard and reporting queries with consistent low latency"

--- a/tools/fine-tuning/distilabel.yaml
+++ b/tools/fine-tuning/distilabel.yaml
@@ -1,0 +1,19 @@
+name: Distilabel
+description: AI feedback and synthetic data framework for building high-quality datasets for fine-tuning and evaluating LLMs using verified research techniques.
+tagline: Synthetic data and AI feedback for LLMs
+problem_solved: >
+  Creating high-quality training data for fine-tuning LLMs requires complex pipelines combining human feedback, synthetic data generation, and model evaluation. Distilabel provides a scalable framework for building AI feedback pipelines that generate, filter, and refine datasets using techniques from verified research papers, enabling faster and more reliable fine-tuning workflows.
+category: Fine-tuning
+github_url: https://github.com/argilla-io/distilabel
+website_url: https://distilabel.argilla.io
+docs_url: https://distilabel.argilla.io
+install_command: pip install distilabel
+pricing: free
+is_open_source: true
+license: Apache-2.0
+tags: [synthetic-data, fine-tuning, ai-feedback, data-pipeline, llm, training-data, dataset-creation]
+
+use_cases:
+  - "Synthetic data generation: create high-quality training datasets using LLM-as-a-judge and self-instruct techniques"
+  - "AI feedback pipelines: build scalable pipelines for annotation, preference collection, and model evaluation"
+  - "Fine-tuning data curation: filter, deduplicate, and refine datasets for supervised fine-tuning and RLHF workflows"


### PR DESCRIPTION
## Summary

Adding 3 new tools to the Agentic AI For Good catalog:

### RisingWave (Data)
- **Category:** Data
- **Description:** Event streaming platform for agentic AI that continuously ingests, transforms, and serves event streams in real time using SQL
- **Pricing:** Freemium
- **License:** Apache-2.0
- **Install:** `curl -L https://risingwave.com/sh | sh`

### StarRocks (Data)
- **Category:** Data
- **Description:** World's fastest open query engine for sub-second analytics on and off the data lakehouse
- **Pricing:** Freemium
- **License:** Apache-2.0
- **Install:** Download tarball from starrocks.io

### Distilabel (Fine-tuning)
- **Category:** Fine-tuning
- **Description:** AI feedback and synthetic data framework for building high-quality datasets for fine-tuning and evaluating LLMs
- **Pricing:** Free
- **License:** Apache-2.0
- **Install:** `pip install distilabel`

## Validation Checklist
- [x] YAML files created in correct category directories
- [x] Local validation passes (`npx tsx scripts/validate-tool.ts`) for all 3 files
- [x] All required fields present and valid
- [x] No duplicate entries found in catalog
- [x] GitHub repos verified active and not archived
- [x] Install commands verified against PyPI/GitHub
