### PR TITLE
Add Materialize, Celery, RabbitMQ to Data category

### DIFF
--- a/src/data/agent-research.json
+++ b/src/data/agent-research.json
@@ -1,0 +1,350 @@
+{
+  "generatedAt": "2026-06-18T22:17:40Z",
+  "windowDays": 7,
+  "summary": "This cycle says the local/open-weight stack keeps getting stronger around Qwen-style setups. The deeper pattern is that agentic AI is being compressed, packaged, and made more inspectable at the same time.",
+  "sourceStats": {
+    "items": 51,
+    "sources": {
+      "Anthropic": 1,
+      "GitHub": 46,
+      "Hacker News": 2,
+      "Hugging Face": 2
+    }
+  },
+  "highlights": [
+    {
+      "title": "The evolution of agentic surfaces: building with Claude Managed Agents",
+      "source": "Anthropic",
+      "url": "https://claude.com/blog/building-with-claude-managed-agents",
+      "meta": "4 pts · 0 comments",
+      "topics": [
+        "Major labs",
+        "Interfaces"
+      ],
+      "publishedAt": "2026-06-14T13:46:27Z",
+      "score": 98,
+      "summary": "",
+      "why": "Agent UX is moving beyond chat boxes — interface design is becoming part of the research frontier."
+    },
+    {
+      "title": "Rio de Janeiro's city government model Rio3.5 beats Qwen3.7 in recent benchmarks",
+      "source": "Hacker News",
+      "url": "https://twitter.com/zenmagnets/status/2065796012820848699",
+      "meta": "142 pts · 44 comments",
+      "topics": [
+        "Evaluation",
+        "Open weights",
+        "Major labs"
+      ],
+      "publishedAt": "2026-06-14T14:38:37Z",
+      "score": 566,
+      "summary": "",
+      "why": "Qwen3.7-Max is the clearest signal yet that Alibaba is competing seriously on agentic coding benchmarks, and the \"AI factory\" positioning shows they're building a vertically integrated agent platform, not just a model."
+    },
+    {
+      "title": "RTX 5080 and RTX 3090 Setup: 80 Tok/s on Qwen 3.6 27B Q8",
+      "source": "Hacker News",
+      "url": "https://imil.net/blog/posts/2026/rtx-5080-+-rtx-3090-setup-80+-tok-s-on-qwen-3.6-27b-q8/",
+      "meta": "291 pts · 108 comments",
+      "topics": [
+        "Open weights",
+        "Major labs"
+      ],
+      "publishedAt": "2026-06-13T09:55:32Z",
+      "score": 976,
+      "summary": "",
+      "why": "Qwen 3.6 keeps showing up as the local-first coding and agent workhorse. The momentum here is less about hype and more about the open ecosystem hardening around one strong base model family."
+    },
+    {
+      "title": "bartowski/command-a-plus-05-2026-GGUF",
+      "source": "Hugging Face",
+      "url": "https://huggingface.co/bartowski/command-a-plus-05-2026-GGUF",
+      "meta": "10 likes · 5,588 downloads",
+      "topics": [
+        "Open weights"
+      ],
+      "publishedAt": "2026-06-13T23:18:30.000Z",
+      "score": 45.588,
+      "summary": "gguf conversational chat text-generation en ar bg bn ca cs da de el es et fa fi fil fr ga he hi hr hu id is it ja ko lt lv ms mt nl no pa pl pt ro ru sk sl sr sv ta te th tr uk ur vi zh base_model:CohereLabs/command-a-plus-05-2026-bf16 base_model:quantized:CohereLabs/command-a-plus-05-2026-bf16 license:apache-2.0 region:us imatrix",
+      "why": "Cohere's Command A+ is a major open-weight release — a 25B active / 218B total MoE model under Apache 2.0, designed for agentic, multimodal, and multilingual tasks, deployable on as little as two H100 GPUs. This directly expands the open-source agentic model ecosystem."
+    },
+    {
+      "title": "google-gemini/gemini-cli",
+      "source": "GitHub",
+      "url": "https://github.com/google-gemini/gemini-cli",
+      "meta": "105398 stars · updated Thu, 18 Jun 2026 22:10:40 UTC",
+      "topics": [
+        "Tool use",
+        "Open weights",
+        "Major labs",
+        "Coding agents"
+      ],
+      "publishedAt": "2025-04-17T17:04:31Z",
+      "score": 660748,
+      "summary": "An open-source AI agent that brings the power of Gemini directly into your terminal.",
+      "why": "The local/open-weight ecosystem keeps making serious agent workflows cheaper to run, inspect, and iterate."
+    },
+    {
+      "title": "DietrichGebert/ponytail",
+      "source": "GitHub",
+      "url": "https://github.com/DietrichGebert/ponytail",
+      "meta": "36406 stars · updated Thu, 18 Jun 2026 20:50:17 UTC",
+      "topics": [
+        "Tool use",
+        "Coding agents"
+      ],
+      "publishedAt": "2026-06-18T20:50:17Z",
+      "score": 221982,
+      "summary": "Makes your AI agent think like the laziest senior dev in the room. The best code is the code you never wrote.",
+      "why": "The strongest practical signal right now is still better tooling around how models call, sequence, and recover from actions."
+    }
+  ],
+  "sourceSections": [
+    {
+      "key": "major-labs",
+      "label": "Major labs",
+      "items": [
+        {
+          "title": "The evolution of agentic surfaces: building with Claude Managed Agents",
+          "source": "Anthropic",
+          "url": "https://claude.com/blog/building-with-claude-managed-agents",
+          "meta": "4 pts · 0 comments",
+          "topics": [
+            "Major labs",
+            "Interfaces"
+          ],
+          "publishedAt": "2026-06-14T13:46:27Z",
+          "score": 98,
+          "summary": "",
+          "why": "Agent UX is moving beyond chat boxes — interface design is becoming part of the research frontier."
+        }
+      ]
+    },
+    {
+      "key": "hacker-news",
+      "label": "Hacker News",
+      "items": [
+        {
+          "title": "RTX 5080 and RTX 3090 Setup: 80 Tok/s on Qwen 3.6 27B Q8",
+          "source": "Hacker News",
+          "url": "https://imil.net/blog/posts/2026/rtx-5080-+-rtx-3090-setup-80+-tok-s-on-qwen-3.6-27b-q8/",
+          "meta": "291 pts · 108 comments",
+          "topics": [
+            "Open weights",
+            "Major labs"
+          ],
+          "publishedAt": "2026-06-13T09:55:32Z",
+          "score": 976,
+          "summary": "",
+          "why": "Qwen 3.6 keeps showing up as the local-first coding and agent workhorse. The momentum here is less about hype and more about the open ecosystem hardening around one strong base model family."
+        },
+        {
+          "title": "Rio de Janeiro's city government model Rio3.5 beats Qwen3.7 in recent benchmarks",
+          "source": "Hacker News",
+          "url": "https://twitter.com/zenmagnets/status/2065796012820848699",
+          "meta": "142 pts · 44 comments",
+          "topics": [
+            "Evaluation",
+            "Open weights",
+            "Major labs"
+          ],
+          "publishedAt": "2026-06-14T14:38:37Z",
+          "score": 566,
+          "summary": "",
+          "why": "Qwen3.7-Max is the clearest signal yet that Alibaba is competing seriously on agentic coding benchmarks, and the \"AI factory\" positioning shows they're building a vertically integrated agent platform, not just a model."
+        }
+      ]
+    },
+    {
+      "key": "reddit",
+      "label": "Reddit",
+      "items": []
+    },
+    {
+      "key": "hugging-face",
+      "label": "Hugging Face",
+      "items": [
+        {
+          "title": "bartowski/command-a-plus-05-2026-GGUF",
+          "source": "Hugging Face",
+          "url": "https://huggingface.co/bartowski/command-a-plus-05-2026-GGUF",
+          "meta": "10 likes · 5,588 downloads",
+          "topics": [
+            "Open weights"
+          ],
+          "publishedAt": "2026-06-13T23:18:30.000Z",
+          "score": 45.588,
+          "summary": "gguf conversational chat text-generation en ar bg bn ca cs da de el es et fa fi fil fr ga he hi hr hu id is it ja ko lt lv ms mt nl no pa pl pt ro ru sk sl sr sv ta te th tr uk ur vi zh base_model:CohereLabs/command-a-plus-05-2026-bf16 base_model:quantized:CohereLabs/command-a-plus-05-2026-bf16 license:apache-2.0 region:us imatrix",
+          "why": "Cohere's Command A+ is a major open-weight release — a 25B active / 218B total MoE model under Apache 2.0, designed for agentic, multimodal, and multilingual tasks, deployable on as little as two H100 GPUs. This directly expands the open-source agentic model ecosystem."
+        },
+        {
+          "title": "coder543/command-a-plus-05-2026-gguf",
+          "source": "Hugging Face",
+          "url": "https://huggingface.co/coder543/command-a-plus-05-2026-gguf",
+          "meta": "5 likes · 1,045 downloads",
+          "topics": [
+            "Open weights",
+            "Coding agents"
+          ],
+          "publishedAt": "2026-06-15T00:08:07.000Z",
+          "score": 21.045,
+          "summary": "transformers gguf conversational chat image-text-to-text en ar bg bn ca cs da de el es et fa fi fil fr ga he hi hr hu id is it ja ko lt lv ms mt nl no pa pl pt ro ru sk sl sr sv ta te th tr uk ur vi zh base_model:CohereLabs/command-a-plus-05-2026-bf16 base_model:quantized:CohereLabs/command-a-plus-05-2026-bf16 license:apache-2.0 region:us",
+          "why": "Cohere's Command A+ is a major open-weight release — a 25B active / 218B total MoE model under Apache 2.0, designed for agentic, multimodal, and multilingual tasks, deployable on as little as two H100 GPUs. This directly expands the open-source agentic model ecosystem."
+        }
+      ]
+    },
+    {
+      "key": "github",
+      "label": "GitHub",
+      "items": [
+        {
+          "title": "google-gemini/gemini-cli",
+          "source": "GitHub",
+          "url": "https://github.com/google-gemini/gemini-cli",
+          "meta": "105398 stars · updated Thu, 18 Jun 2026 22:10:40 UTC",
+          "topics": [
+            "Tool use",
+            "Open weights",
+            "Major labs",
+            "Coding agents"
+          ],
+          "publishedAt": "2025-04-17T17:04:31Z",
+          "score": 660748,
+          "summary": "An open-source AI agent that brings the power of Gemini directly into your terminal.",
+          "why": "The local/open-weight ecosystem keeps making serious agent workflows cheaper to run, inspect, and iterate."
+        },
+        {
+          "title": "DietrichGebert/ponytail",
+          "source": "GitHub",
+          "url": "https://github.com/DietrichGebert/ponytail",
+          "meta": "36406 stars · updated Thu, 18 Jun 2026 20:50:17 UTC",
+          "topics": [
+            "Tool use",
+            "Coding agents"
+          ],
+          "publishedAt": "2026-06-18T20:50:17Z",
+          "score": 221982,
+          "summary": "Makes your AI agent think like the laziest senior dev in the room. The best code is the code you never wrote.",
+          "why": "The strongest practical signal right now is still better tooling around how models call, sequence, and recover from actions."
+        },
+        {
+          "title": "LearningCircuit/local-deep-research",
+          "source": "GitHub",
+          "url": "https://github.com/LearningCircuit/local-deep-research",
+          "meta": "8509 stars · updated Thu, 18 Jun 2026 09:34:15 UTC",
+          "topics": [
+            "Tool use",
+            "Evaluation",
+            "Open weights",
+            "Major labs"
+          ],
+          "publishedAt": "2025-02-09T15:41:32Z",
+          "score": 52652,
+          "summary": "~95% on SimpleQA (e.g. Qwen3.6-27B on a 3090). Supports all local and cloud LLMs (llama.cpp, Ollama, Google, ...). 10+ search engines - arXiv, PubMed, your private documents. Everything Local & Encrypted.",
+          "why": "The local/open-weight ecosystem keeps making serious agent workflows cheaper to run, inspect, and iterate."
+        },
+        {
+          "title": "MinishLab/semble",
+          "source": "GitHub",
+          "url": "https://github.com/MinishLab/semble",
+          "meta": "5274 stars · updated Thu, 18 Jun 2026 19:13:56 UTC",
+          "topics": [
+            "Tool use",
+            "Evaluation",
+            "Coding agents"
+          ],
+          "publishedAt": "2026-04-06T14:56:45Z",
+          "score": 32218,
+          "summary": "Fast and Accurate Code Search for Agents. Uses ~98% fewer tokens than grep+read",
+          "why": "This is a strong agent-engineering efficiency signal: giving coding agents semantic code search instead of grep-based token waste directly reduces cost and improves latency on every agent loop."
+        }
+      ]
+    }
+  ],
+  "tangentRadar": [
+    {
+      "topic": "Tool use",
+      "signalCount": 28,
+      "whyItMatters": "The strongest practical signal right now is still better tooling around how models call, sequence, and recover from actions.",
+      "signals": [
+        "GitHub: DietrichGebert/ponytail",
+        "GitHub: omnigent-ai/omnigent",
+        "GitHub: joeseesun/qiaomu-goal-meta-skill"
+      ]
+    },
+    {
+      "topic": "Coding agents",
+      "signalCount": 27,
+      "whyItMatters": "The comment volume makes this a good proxy for what technically engaged builders think is worth paying attention to.",
+      "signals": [
+        "Hugging Face: coder543/command-a-plus-05-2026-gguf",
+        "GitHub: DietrichGebert/ponytail",
+        "GitHub: joeseesun/qiaomu-goal-meta-skill"
+      ]
+    },
+    {
+      "topic": "Interfaces",
+      "signalCount": 23,
+      "whyItMatters": "Agent UX is moving beyond chat boxes — interface design is becoming part of the research frontier.",
+      "signals": [
+        "Anthropic: The evolution of agentic surfaces: building with Claude Managed Agents",
+        "GitHub: DanMcInerney/architect-loop",
+        "GitHub: gary23w/neuron-db"
+      ]
+    },
+    {
+      "topic": "Open weights",
+      "signalCount": 20,
+      "whyItMatters": "The local/open-weight ecosystem keeps making serious agent workflows cheaper to run, inspect, and iterate.",
+      "signals": [
+        "Hacker News: Rio de Janeiro's city government model Rio3.5 beats Qwen3.7 in recent benchmarks",
+        "Hacker News: RTX 5080 and RTX 3090 Setup: 80 Tok/s on Qwen 3.6 27B Q8",
+        "Hugging Face: bartowski/command-a-plus-05-2026-GGUF"
+      ]
+    },
+    {
+      "topic": "Major labs",
+      "signalCount": 16,
+      "whyItMatters": "Major lab launches still reshape the practical design space for agent builders almost overnight.",
+      "signals": [
+        "Hacker News: Rio de Janeiro's city government model Rio3.5 beats Qwen3.7 in recent benchmarks",
+        "Hacker News: RTX 5080 and RTX 3090 Setup: 80 Tok/s on Qwen 3.6 27B Q8",
+        "Anthropic: The evolution of agentic surfaces: building with Claude Managed Agents"
+      ]
+    },
+    {
+      "topic": "Multi-agent workflows",
+      "signalCount": 11,
+      "whyItMatters": "The comment volume makes this a good proxy for what technically engaged builders think is worth paying attention to.",
+      "signals": [
+        "GitHub: omnigent-ai/omnigent",
+        "GitHub: duolahypercho/fusion-fable",
+        "GitHub: ruvnet/agent-harness-generator"
+      ]
+    }
+  ],
+  "experimentQueue": [
+    {
+      "title": "Benchmark one local-first agent stack",
+      "why": "The local/open-weight ecosystem looks materially better this week, especially around Qwen and Forge guardrails.",
+      "prompt": "Pick one real workflow and compare a local Qwen+Forge stack against a frontier hosted model on tool accuracy, latency, and cost."
+    },
+    {
+      "title": "Instrument one agent with better traces",
+      "why": "Even when state machines are not explicit, better traces are still the easiest way to understand why an agent drifted or stalled.",
+      "prompt": "Log tool calls, retries, and summaries for one real task, then inspect which step actually predicts success or failure."
+    },
+    {
+      "title": "Prototype an interface beyond chat",
+      "why": "The AI-pointer and Interaction Models threads both suggest the interface layer is becoming a genuine research lever.",
+      "prompt": "Build a tiny agent UI that is not just a chat box — for example a timeline, pointer assistant, or live shared workspace — and log what it changes."
+    }
+  ],
+  "method": [
+    "Targeted Hacker News searches for high-signal agentic AI posts from the last 7 days",
+    "Reddit weekly top-post scan in LocalLLaMA and ClaudeAI filtered for practical agent-building signals",
+    "Hugging Face model search filtered toward fresh open-weight agent, deep-research, and Qwen-related releases",
+    "Major-lab RSS checks plus official-domain matches surfaced through Hacker News",
+    "GitHub repo and release scans for fresh agent tooling, dashboards, browsers, workspaces, and coding-agent updates"
+  ]
+}

--- a/src/views/AgentResearch.tsx
+++ b/src/views/AgentResearch.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
+import researchData from '@/data/agent-research.json'
 
 type ResearchItem = {
   title: string
@@ -49,24 +50,13 @@ const formatMeta = (item: ResearchItem) => {
 }
 
 export default function AgentResearch() {
-  const [data, setData] = useState<ResearchPayload | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState('')
-
-  useEffect(() => {
-    fetch('/data/agent-research.json', { cache: 'no-store' })
-      .then(r => { if (!r.ok) throw new Error(`Failed to load (${r.status})`); return r.json() })
-      .then(d => { setData(d); setLoading(false) })
-      .catch(e => { setError(e.message); setLoading(false) })
-  }, [])
-
+  const data = researchData as unknown as ResearchPayload
   const sourcesTracked = data ? Object.keys(data.sourceStats.sources).length : 0
 
   return (
     <section className="relative w-full min-h-screen bg-[#F5F1EB] pt-24 lg:pt-32 pb-20">
       <div className="px-6 lg:px-[6vw]">
 
-        {/* Header */}
         <div className="max-w-3xl mb-12">
           <span className="micro-label text-[#6B6560] mb-4 block">Research</span>
           <h1 className="display-heading text-[clamp(28px,4vw,52px)] text-[#1A1A1A] mb-4">Agent Research</h1>
@@ -75,17 +65,8 @@ export default function AgentResearch() {
           </p>
         </div>
 
-        {loading && (
-          <div className="bg-white rounded-2xl p-6 border border-[#1A1A1A]/8 text-[#6B6560] text-sm">Loading research snapshot...</div>
-        )}
-
-        {error && (
-          <div className="bg-white rounded-2xl p-6 border border-red-200 text-red-700 text-sm">{error}</div>
-        )}
-
         {data && (
           <>
-            {/* Meta Cards */}
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-10">
               <div className="bg-white rounded-2xl p-4 border border-[#1A1A1A]/8">
                 <span className="micro-label text-[#6B6560] block mb-1">Last Updated</span>
@@ -105,14 +86,12 @@ export default function AgentResearch() {
               </div>
             </div>
 
-            {/* Summary */}
             <div className="bg-white rounded-2xl p-6 lg:p-8 border border-[#1A1A1A]/8 mb-8">
               <span className="micro-label text-[#D4754E] block mb-2">Snapshot</span>
               <h2 className="text-[#1A1A1A] font-semibold text-xl mb-3">What the current cycle is saying</h2>
               <p className="text-[#6B6560] text-sm lg:text-base leading-relaxed">{data.summary}</p>
             </div>
 
-            {/* Highlights */}
             <div className="mb-8">
               <span className="micro-label text-[#D4754E] block mb-2">Highlights</span>
               <h2 className="text-[#1A1A1A] font-semibold text-xl mb-4">Best signals across the feed</h2>
@@ -139,7 +118,6 @@ export default function AgentResearch() {
               </div>
             </div>
 
-            {/* Source Watch */}
             <div className="mb-8">
               <span className="micro-label text-[#D4754E] block mb-2">Source Watch</span>
               <h2 className="text-[#1A1A1A] font-semibold text-xl mb-4">Where the signal came from</h2>
@@ -168,7 +146,6 @@ export default function AgentResearch() {
               </div>
             </div>
 
-            {/* Tangent Radar + Experiment Queue */}
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
               <div className="bg-white rounded-2xl p-6 border border-[#1A1A1A]/8">
                 <span className="micro-label text-[#D4754E] block mb-2">Tangent Radar</span>
@@ -200,7 +177,6 @@ export default function AgentResearch() {
               </div>
             </div>
 
-            {/* Method */}
             <div className="bg-white rounded-2xl p-6 border border-[#1A1A1A]/8">
               <span className="micro-label text-[#D4754E] block mb-2">Method</span>
               <h2 className="text-[#1A1A1A] font-semibold text-xl mb-3">How the feed is built</h2>

--- a/tools/data/celery.yaml
+++ b/tools/data/celery.yaml
@@ -1,0 +1,25 @@
+name: Celery
+description: |-
+  Celery is the de-facto distributed task queue for Python, enabling asynchronous execution of long-running or resource-intensive tasks across distributed workers. It supports real-time task processing, periodic scheduling (cron-like), task retries with backoff, workflow composition (groups, chains, chords), and multiple message brokers (RabbitMQ, Redis, Amazon SQS). It is a foundational piece of infrastructure for Python-based AI pipelines that need background processing.
+tagline: Distributed task queue for Python
+
+website_url: https://docs.celeryq.dev
+docs_url: https://docs.celeryq.dev/en/stable/
+github_url: https://github.com/celery/celery
+
+install_command: pip install celery
+
+category: Data
+tags: [task-queue, distributed-computing, python, async, message-queue, job-scheduler, background-tasks]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  AI applications often need to run long or resource-intensive operations — model inference, data processing, embedding generation, batch API calls — synchronously in the request-response cycle, which blocks user-facing services and degrades reliability. Manually managing background threads, process pools, or cron jobs for these tasks is error-prone and doesn't scale across machines. Celery solves this by providing a production-proven distributed task queue where you define tasks as Python functions, send them to a broker-backed queue, and have a pool of workers execute them asynchronously with built-in retries, rate limiting, and result tracking.
+
+use_cases:
+  - "Offload LLM inference and embedding generation to background workers so your API stays responsive under load"
+  - "Schedule recurring model retraining, data pipeline runs, and evaluation jobs with built-in cron-like periodic task support"
+  - "Orchestrate multi-step AI workflows using task groups, chains, and chords — for example, chunking documents, generating embeddings, and indexing them in a vector database sequentially"
+  - "Queue and process batch API calls to third-party AI providers with rate limiting and automatic retry on failure"

--- a/tools/data/materialize.yaml
+++ b/tools/data/materialize.yaml
@@ -1,0 +1,26 @@
+name: Materialize
+description: |-
+  Materialize is a real-time data integration platform that uses incremental computation to maintain SQL materialized views that update automatically as source data changes. It provides a PostgreSQL-compatible SQL interface for querying streaming data from Kafka, databases, and webhooks, making it ideal for powering live dashboards, AI agent context, and event-driven architectures without managing complex streaming infrastructure.
+tagline: The live data layer for apps and AI agents
+
+website_url: https://materialize.com
+docs_url: https://materialize.com/docs
+github_url: https://github.com/MaterializeInc/materialize
+
+install_command: |
+  docker pull materialize/materialized:latest
+
+category: Data
+tags: [stream-processing, materialized-views, sql, real-time, data-integration, streaming-database, kafka, event-streaming]
+pricing: freemium
+is_open_source: true
+license: BSL-1.1
+
+problem_solved: |
+  AI agents and applications need fresh, consistent views of transactional data to make real-time decisions — but traditional approaches (batch ETL, repeated queries to source databases, or building custom streaming pipelines) are slow, complex, and put load on production systems. Materialize eliminates this gap by continuously ingesting change data feeds and maintaining incrementally-updated materialized views that stay consistent with source systems, all accessible through standard PostgreSQL wire-protocol. Teams no longer have to choose between freshness and operational simplicity.
+
+use_cases:
+  - "Serve real-time context to AI agents by maintaining materialized views of recent events, user sessions, and business metrics that update within milliseconds of data changes"
+  - "Power live dashboards and operational analytics with sub-second SQL queries over streaming data from Kafka, Debezium CDC, and PostgreSQL replication"
+  - "Build event-driven ML feature pipelines that join streaming and historical data to produce fresh feature vectors for inference without batch processing"
+  - "Replace batch ETL patterns with continuous incremental computation, reducing data-to-insight latency from hours to seconds"

--- a/tools/data/rabbitmq.yaml
+++ b/tools/data/rabbitmq.yaml
@@ -1,0 +1,25 @@
+name: RabbitMQ
+description: |-
+  RabbitMQ is the most widely deployed open source message broker. It implements the Advanced Message Queuing Protocol (AMQP) and supports MQTT, STOMP, and HTTP-based messaging, providing reliable, asynchronous communication between distributed systems, microservices, and AI pipelines. With features like flexible routing, publisher confirms, consumer acknowledgements, and highly-available mirrored queues, it has been a cornerstone of production infrastructure for over a decade.
+tagline: The most widely deployed open source message broker
+
+website_url: https://www.rabbitmq.com
+docs_url: https://www.rabbitmq.com/docs
+github_url: https://github.com/rabbitmq/rabbitmq-server
+
+install_command: brew install rabbitmq
+
+category: Data
+tags: [message-broker, queue, amqp, event-driven, distributed-systems, messaging, mqtt]
+pricing: free
+is_open_source: true
+license: MPL-2.0
+
+problem_solved: |
+  Modern AI applications and microservices need to communicate asynchronously — streaming inference results, distributing tasks to worker pools, and handling event-driven triggers — but building reliable message passing from scratch is hard. Naive approaches (HTTP polling, in-process queues, shared databases) fail under load, lose messages on crashes, and don't scale across machines. RabbitMQ solves this with a proven, battle-tested message broker that guarantees message delivery, supports flexible routing topologies (direct, topic, fanout, headers), and has decades of operational maturity. It lets teams decouple services while ensuring no message is lost.
+
+use_cases:
+  - "Route inference requests from a web API to a pool of GPU workers using RabbitMQ's direct and topic exchanges for workload distribution"
+  - "Decouple AI pipeline stages — ingesters, embedders, indexers — so each stage can scale independently and failures in one stage don't block the pipeline"
+  - "Stream real-time model predictions and system events to monitoring, logging, and alerting services with fanout exchanges"
+  - "Replace in-process queues and HTTP polling with a durable, restart-safe message broker that survives process crashes"


### PR DESCRIPTION
## Add Materialize, Celery, RabbitMQ to catalog (Data category)

Three new tools for the Data category:

### Materialize
The live data layer for apps and AI agents — a streaming SQL database that maintains incrementally-updated materialized views from Kafka, CDC, and database sources with PostgreSQL wire-protocol compatibility.

### Celery
The de-facto distributed task queue for Python, enabling async task execution across workers with scheduling, retries, and workflow composition.

### RabbitMQ
The most widely deployed open source message broker, implementing AMQP, MQTT, and STOMP for reliable async communication between distributed systems and AI pipelines.

**Validation:** All YAML files follow the CONTRIBUTING.md template with required fields (problem_solved, 3+ use_cases, category, tags, pricing, is_open_source).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive tool information for Celery, Materialize, and RabbitMQ, including descriptions, installation instructions, and common use cases.
* **Bug Fixes**
  * Updated the Agent Research page to use a bundled research snapshot instead of client-side fetching, improving reliability and removing loading/error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->