### PR TITLE
Add Fixpoint, Codegen, Greptile, Ellipsis, PearAI to catalog

### DIFF
--- a/tools/agent-frameworks/fixpoint.yaml
+++ b/tools/agent-frameworks/fixpoint.yaml
@@ -1,0 +1,41 @@
+name: Fixpoint
+description: >-
+  Fixpoint is an open-source platform for building stateful, multi-step AI workflows
+  with memory, human-in-the-loop, and agent orchestration. It provides the infrastructure
+  to build and deploy AI agents and workflows that remember conversation history, can
+  pause for human approval, and coordinate multiple agents working together on complex tasks.
+tagline: Open-source infrastructure for stateful AI agent workflows
+
+github_url: https://github.com/gofixpoint/amika
+website_url: https://fixpoint.co
+docs_url: https://docs.fixpoint.co
+
+install_command: pip install fixpoint
+
+category: Agents
+tags:
+  - agent-orchestration
+  - workflows
+  - stateful-agents
+  - human-in-the-loop
+  - python
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |-
+  Building reliable AI agent workflows is difficult because most LLM integrations are
+  stateless — they lose context between turns, can't handle multi-step processes that
+  require human approval, and have no built-in durability. Fixpoint solves this by
+  providing open-source infrastructure for stateful, multi-step AI workflows with
+  persistent memory, human-in-the-loop checkpoints, and agent orchestration. Teams
+  can build agents that remember past interactions, pause for human review, and
+  coordinate across multiple specialized agents — all without building custom
+  state management, retry logic, or coordination infrastructure.
+
+use_cases:
+  - "Build customer support agents that maintain conversation state across multiple turns and can escalate to humans when needed"
+  - "Create document processing pipelines where agents extract, validate, and summarize data with human review at each stage"
+  - "Deploy multi-agent workflows where a orchestrator agent delegates sub-tasks to specialized agents and synthesizes results"
+  - "Automate research workflows that require persistent memory across sessions, web searches, and iterative refinement"
+  - "Build AI-powered data enrichment pipelines that combine multiple data sources with human verification checkpoints"

--- a/tools/dev-tools/codegen.yaml
+++ b/tools/dev-tools/codegen.yaml
@@ -1,0 +1,43 @@
+name: Codegen
+description: >-
+  Codegen is a Python SDK and API for running code modification agents at scale. It
+  provides sandboxed execution environments, codebase understanding, and tool integrations
+  for building reliable code agents that can read, understand, and modify codebases
+  autonomously — with built-in telemetry, error handling, and safety controls for
+  enterprise deployments.
+tagline: Build and deploy code agents at scale
+
+github_url: https://github.com/codegen-sh/codegen
+website_url: https://codegen.com
+docs_url: https://docs.codegen.com
+
+install_command: pip install codegen
+
+category: Dev Tools
+tags:
+  - code-agents
+  - code-generation
+  - agent-sdk
+  - python
+  - developer-tools
+  - sandbox
+pricing: paid
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |-
+  Building reliable code agents that can safely read, modify, and test real codebases
+  is notoriously hard. Most agent frameworks lack the necessary safety guards, sandboxed
+  execution, codebase indexing, and error recovery needed for production use. Codegen
+  provides a purpose-built Python SDK and API for running code agents at scale: it
+  handles sandboxed execution, code understanding through indexing, integration with
+  version control, and built-in telemetry so developers can build and deploy code agents
+  that actually work in production environments without building all the infrastructure
+  from scratch.
+
+use_cases:
+  - "Automate large-scale code migrations and refactors across hundreds of repositories with reliable, tested changes"
+  - "Build code review agents that understand codebase context and generate meaningful, actionable reviews"
+  - "Deploy automated dependency update agents that fix breaking changes and validate compatibility"
+  - "Create documentation agents that read source code and generate accurate, up-to-date documentation"
+  - "Build testing agents that identify untested code paths, generate test cases, and validate output"

--- a/tools/dev-tools/ellipsis.yaml
+++ b/tools/dev-tools/ellipsis.yaml
@@ -1,0 +1,44 @@
+name: Ellipsis
+description: >-
+  Ellipsis is a platform for deploying, managing, and observing AI coding agents
+  in the cloud. Define agents as YAML — with prompts, models, triggers, tools, and
+  spend caps in a single config file — and deploy them with git push. Each agent
+  runs in an isolated sandbox with full observability, permission boundaries, and
+  budget controls. Built for teams that want to run coding agents safely and
+  transparently alongside human developers.
+tagline: The platform for deploying AI software engineers
+
+github_url: https://github.com/ellipsis-dev
+website_url: https://www.ellipsis.dev
+docs_url: https://docs.ellipsis.dev
+
+install_command: brew install ellipsis-dev/cli/agent
+
+category: Dev Tools
+tags:
+  - coding-agents
+  - developer-tools
+  - agent-management
+  - devops
+  - automation
+  - code-automation
+pricing: paid
+is_open_source: false
+license: Proprietary
+
+problem_solved: |-
+  Running AI coding agents in production is risky and hard to manage — agents can run
+  up large bills, access sensitive code without guardrails, and operate as black boxes
+  that nobody on the team can observe. Ellipsis solves this by providing a platform where
+  teams define coding agents as version-controlled YAML files — with explicit permission
+  scopes, tool allow-lists, and budget caps per agent. Every agent run is recorded with
+  full traces of the agent's thinking, tool calls, and diffs. The platform handles
+  sandboxed execution, observability, and governance so teams can deploy coding agents
+  confidently alongside human developers.
+
+use_cases:
+  - "Deploy automated PR agents that review code, fix bugs, and generate tests across entire repositories"
+  - "Run daily standup agents that summarize merged PRs, pending reviews, and failing CI in Slack"
+  - "Create migration guard agents that automatically review PRs for breaking database schema changes"
+  - "Build on-call assistant agents that triage issues, investigate logs, and propose fixes autonomously"
+  - "Deploy multiple specialized agents across teams with centralized governance, permissions, and cost tracking"

--- a/tools/dev-tools/greptile.yaml
+++ b/tools/dev-tools/greptile.yaml
@@ -1,0 +1,40 @@
+name: Greptile
+description: >-
+  Greptile is an AI code review platform that automatically reviews every pull request
+  with full codebase understanding. It indexes your entire repository — dependencies,
+  test patterns, and architectural conventions — to provide context-aware PR reviews
+  that catch real bugs, not just style issues. It also offers TREX, an autonomous testing
+  agent that writes and runs tests for every PR in a sandboxed environment.
+tagline: AI code review with full codebase understanding
+
+website_url: https://www.greptile.com
+docs_url: https://docs.greptile.com
+
+category: Dev Tools
+tags:
+  - code-review
+  - pull-requests
+  - ai-assistant
+  - developer-tools
+  - code-quality
+  - automated-testing
+pricing: paid
+is_open_source: false
+license: Proprietary
+
+problem_solved: |-
+  Code review is a bottleneck for most engineering teams — human reviewers are slow,
+  inconsistent, and miss bugs in unfamiliar parts of the codebase. Traditional AI code
+  review tools only check surface-level patterns without understanding project context.
+  Greptile solves this by indexing your entire codebase — dependencies, tests, commit
+  history, and architectural conventions — and using that full context to review every
+  PR. It catches logical bugs, security vulnerabilities, and edge cases that would slip
+  past both human reviewers and shallow AI tools. TREX extends this by writing and
+  running tests autonomously for every PR to catch regressions before merge.
+
+use_cases:
+  - "Automatically review every PR with full codebase context, catching bugs that only manifest across multiple files"
+  - "Deploy TREX agents that write and run tests for every PR in a sandboxed environment to catch regressions"
+  - "Enforce team coding standards with custom rules expressed in plain English"
+  - "Reduce review cycle time from hours to seconds while catching more bugs before they reach production"
+  - "Onboard new team members faster by providing consistent, high-quality AI reviews on every contribution"

--- a/tools/dev-tools/pearai.yaml
+++ b/tools/dev-tools/pearai.yaml
@@ -1,0 +1,46 @@
+name: PearAI
+description: >-
+  PearAI is an open-source, AI-powered code editor forked from VS Code that deeply
+  integrates LLMs into the editing experience. It combines AI autocomplete, inline
+  code generation, chat-based codebase understanding, and agentic code editing in a
+  single editor, with the PearAI Submodule (forked from Continue) powering the AI
+  interactions. Built for developers who want a native, integrated AI coding experience
+  without leaving their editor.
+tagline: The open-source AI-powered code editor
+
+github_url: https://github.com/trypear/pearai-app
+website_url: https://pearai.ai
+docs_url: https://docs.pearai.ai
+
+install_command: |-
+  brew install --cask pearai
+
+category: Dev Tools
+tags:
+  - ide
+  - code-editor
+  - vscode-fork
+  - ai-coding
+  - autocomplete
+  - code-generation
+  - open-source
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |-
+  Developers want an AI coding experience that's deeply integrated into their editor
+  — not a separate chat window or plugin that feels bolted on. Existing AI code tools
+  either lack deep editor integration (web-based chatbots) or are closed-source with
+  limited customization. PearAI solves this by providing a fully open-source AI-powered
+  code editor forked from VS Code, with AI built into every surface: autocomplete that
+  understands project context, inline code generation, natural language codebase chat,
+  and agentic multi-file edits — all running in a familiar VS Code environment that
+  supports existing extensions and workflows.
+
+use_cases:
+  - "Get AI-powered code completions that understand your project's context, patterns, and conventions"
+  - "Generate entire functions, classes, and files from natural language prompts without leaving the editor"
+  - "Ask questions about your codebase in natural language and get accurate, context-aware answers"
+  - "Perform multi-file refactors and code changes with a single AI-powered command"
+  - "Debug issues by asking PearAI to trace through the codebase, identify root causes, and propose fixes"


### PR DESCRIPTION
Add 5 new tools to the catalog:

- **Fixpoint** (Agents) — Open-source infrastructure for stateful, multi-step AI workflows with memory, human-in-the-loop, and agent orchestration. `pip install fixpoint`
- **Codegen** (Dev Tools) — Python SDK and API for running code modification agents at scale with sandboxed execution and built-in telemetry. `pip install codegen`
- **Greptile** (Dev Tools) — AI code review platform with full codebase understanding that catches bugs across the entire repository, plus autonomous PR testing via TREX.
- **Ellipsis** (Dev Tools) — Platform for deploying AI coding agents as version-controlled YAML with sandboxed execution, observability, and budget controls. `brew install ellipsis-dev/cli/agent`
- **PearAI** (Dev Tools) — Open-source AI-powered code editor forked from VS Code with deep LLM integration, autocomplete, and agentic multi-file editing. `brew install --cask pearai`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new catalog entries for several AI coding and developer tools, including metadata, links, installation details, and usage examples.
  * Expanded the tools directory with clearer descriptions of what each product offers and how it can help with coding, review, editing, and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->