### PR TITLE
Add Trigger.dev, Restate, Nango, DeepInfra, OctoAI to catalog

### DIFF
--- a/tools/agent-frameworks/nango.yaml
+++ b/tools/agent-frameworks/nango.yaml
@@ -1,0 +1,44 @@
+name: Nango
+description: >-
+  Nango is an open-source platform for building product integrations with AI. It
+  supports 800+ third-party APIs and works with any backend language, AI coding
+  tool, and agent SDK. Developers write integration logic as TypeScript functions
+  (or let AI generate them), and Nango handles authentication, execution, scaling,
+  and observability. Built for products and AI agents that need to connect to
+  external services reliably.
+tagline: Build product integrations with AI
+
+github_url: https://github.com/NangoHQ/nango
+website_url: https://nango.dev
+docs_url: https://docs.nango.dev
+
+install_command: npm install @nangohq/nango
+
+category: Agents
+tags:
+  - integrations
+  - api-connectivity
+  - typescript
+  - open-source
+  - ai-agents
+  - developer-tools
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |-
+  Every AI agent and SaaS product needs to connect to external APIs — CRM, email,
+  calendar, Slack, GitHub — but building and maintaining these integrations is a
+  major engineering burden. Each API has different auth schemes, rate limits, data
+  formats, and error handling. Nango solves this by providing an open-source
+  platform with 800+ pre-built API integrations. Developers write integration
+  logic as TypeScript functions (or use AI to generate them), and Nango handles
+  OAuth token management, rate limiting, pagination, error handling, scaling, and
+  observability — reducing integration development from weeks to hours.
+
+use_cases:
+  - "Connect AI agents to 800+ third-party APIs with automatic OAuth management and token refresh"
+  - "Generate integration code from natural language descriptions with AI-powered integration generation"
+  - "Build product integrations that sync data between your app and external services reliably at scale"
+  - "Deploy integrations across multiple tenants with isolated auth, rate limits, and configuration per customer"
+  - "Monitor integration health, error rates, and sync status with built-in observability dashboards"

--- a/tools/agent-frameworks/restate.yaml
+++ b/tools/agent-frameworks/restate.yaml
@@ -1,0 +1,44 @@
+name: Restate
+description: >-
+  Restate is an open-source platform for building resilient applications with
+  durable execution. It provides a runtime for durable AI agents, workflows-as-code,
+  microservice orchestration, event processing, and async tasks — with automatic
+  state persistence, retry, and recovery built in. Restate's key innovation is its
+  Virtual Object model, which gives every entity durable state and ensures execution
+  continues exactly where it left off after any failure.
+tagline: Durable execution platform for resilient applications
+
+github_url: https://github.com/restatedev/restate
+website_url: https://restate.dev
+docs_url: https://docs.restate.dev
+
+install_command: npm install @restatedev/restate-sdk
+
+category: Agents
+tags:
+  - durable-execution
+  - workflow-orchestration
+  - microservices
+  - typescript
+  - open-source
+  - ai-agents
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |-
+  Building resilient AI agent workflows that survive failures, network outages, and
+  infrastructure disruptions requires complex infrastructure — manual state
+  persistence, retry logic, and error recovery. Restate solves this with its Virtual
+  Object model, where every entity (agent, workflow, or service) has built-in
+  durable state. AI agents built on Restate automatically persist their execution
+  state at every step, so they resume exactly where they left off after any failure
+  — without manual checkpointing or external state management. This makes it natural
+  to build long-running, stateful AI agents that need reliable execution.
+
+use_cases:
+  - "Build durable AI agents that automatically persist state and resume after any infrastructure failure"
+  - "Create long-running AI workflows with human-in-the-loop pauses that survive process restarts"
+  - "Orchestrate multi-step AI pipelines with Virtual Objects providing guaranteed state persistence"
+  - "Build event-driven AI services that process incoming events with durable, recoverable handlers"
+  - "Implement saga compensation patterns for AI workflows that need transactional rollback on failure"

--- a/tools/agent-frameworks/trigger-dev.yaml
+++ b/tools/agent-frameworks/trigger-dev.yaml
@@ -1,0 +1,44 @@
+name: Trigger.dev
+description: >-
+  Trigger.dev is an open-source platform for building AI workflows and background
+  tasks in TypeScript. It provides long-running tasks with automatic retries,
+  queue management, observability, and elastic scaling — designed for AI agent
+  workflows that need durable, stateful execution. Tasks can be triggered by
+  schedules, webhooks, events, or directly from your application code, with
+  built-in support for fan-out, rate limiting, and error recovery.
+tagline: Open-source platform for AI workflows and background tasks
+
+github_url: https://github.com/triggerdotdev/trigger.dev
+website_url: https://trigger.dev
+docs_url: https://trigger.dev/docs
+
+install_command: npm install @trigger.dev/sdk
+
+category: Agents
+tags:
+  - workflow-orchestration
+  - background-jobs
+  - typescript
+  - open-source
+  - ai-agents
+  - task-queues
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |-
+  AI agent workflows often need reliable background execution — retries after
+  failures, scheduled runs, fan-out to multiple processors, and state persistence
+  across long-running operations. Building this infrastructure from scratch is
+  complex and error-prone. Trigger.dev solves this by providing an open-source
+  platform where you define AI workflows as TypeScript functions with built-in
+  retries, queue management, and elastic scaling. Tasks can chain together,
+  pause for human input, and resume seamlessly — all with full observability into
+  execution and cost.
+
+use_cases:
+  - "Build durable AI agent workflows that retry on failure, persist state across steps, and handle long-running operations"
+  - "Create scheduled AI tasks that run on cron schedules — daily reports, data processing, model inference"
+  - "Fan out AI processing to multiple parallel workers and aggregate results with built-in queue management"
+  - "Build event-driven AI pipelines that trigger on webhooks, database changes, or application events"
+  - "Deploy background AI tasks with automatic rate limiting, error recovery, and execution observability"

--- a/tools/llm/deepinfra.yaml
+++ b/tools/llm/deepinfra.yaml
@@ -1,0 +1,40 @@
+name: DeepInfra
+description: >-
+  DeepInfra is a serverless inference platform for open-source LLMs and image
+  generation models. It hosts leading open models — Llama, Mixtral, Qwen,
+  DeepSeek, Stable Diffusion, and more — behind OpenAI-compatible REST APIs with
+  per-token billing and no cold starts. Designed for developers who want to use
+  open-source models in production without managing GPU infrastructure.
+tagline: Serverless inference for open-source AI models
+
+website_url: https://deepinfra.com
+docs_url: https://deepinfra.com/docs
+
+category: LLM
+tags:
+  - llm-inference
+  - serverless
+  - open-source-models
+  - api
+  - gpu
+  - generative-ai
+pricing: paid
+is_open_source: false
+license: Proprietary
+
+problem_solved: |-
+  Running open-source LLMs in production requires significant GPU infrastructure,
+  DevOps effort, and capacity planning — making it hard for individual developers
+  and small teams to use models like Llama, Qwen, or DeepSeek without large cloud
+  budgets. DeepInfra solves this by providing a serverless inference platform where
+  you call open-source models via an OpenAI-compatible API and pay only for the
+  tokens you use. There are no cold starts, no GPU provisioning, and no minimum
+  commitments — making the best open-source models accessible to every developer
+  with the same API interface as proprietary providers.
+
+use_cases:
+  - "Access leading open-source LLMs via OpenAI-compatible APIs without managing any GPU infrastructure"
+  - "Run image generation models like Stable Diffusion and FLUX serverlessly with per-generation billing"
+  - "Switch between open-source and proprietary models without changing API code using compatible endpoints"
+  - "Prototype and deploy AI features with no cold starts, no GPU provisioning, and no minimum spend"
+  - "Scale AI inference from zero to production with automatic capacity management and no DevOps overhead"

--- a/tools/llm/octoai.yaml
+++ b/tools/llm/octoai.yaml
@@ -1,0 +1,40 @@
+name: OctoAI
+description: >-
+  OctoAI is an AI inference platform that provides fast, cost-effective access to
+  leading open-source foundation models — Llama, Mistral, Stable Diffusion, Whisper,
+  and more — via OpenAI-compatible REST APIs. It offers a serverless API for
+  on-demand inference, OctoStack for private VPC and on-premises deployment, and
+  tools for fine-tuning and optimizing models for production workloads.
+tagline: Fast, cost-effective AI inference platform
+
+website_url: https://octoai.cloud
+docs_url: https://docs.octoai.cloud
+
+category: LLM
+tags:
+  - llm-inference
+  - serverless
+  - open-source-models
+  - api
+  - fine-tuning
+  - generative-ai
+pricing: paid
+is_open_source: false
+license: Proprietary
+
+problem_solved: |-
+  Deploying open-source AI models in production involves complex infrastructure
+  decisions — GPU selection, model optimization, scaling, and cost management.
+  OctoAI solves this by providing an optimized inference platform that automatically
+  selects the best hardware for each model, delivers fast inference with minimal
+  latency, and offers both serverless API access for variable workloads and private
+  VPC deployment for enterprises with data sovereignty requirements. It also
+  provides fine-tuning and model optimization tools to improve performance and
+  reduce costs for production deployments.
+
+use_cases:
+  - "Access open-source LLMs and image models via fast, OpenAI-compatible APIs with automatic hardware optimization"
+  - "Deploy models in a private VPC or on-premises for applications with strict data residency requirements"
+  - "Fine-tune open-source models with optimized infrastructure that reduces training time and cost"
+  - "Run cost-efficient inference at scale with automatic GPU selection and model optimization"
+  - "Prototype and productionize AI features with a single API that scales from testing to enterprise workloads"


### PR DESCRIPTION
Add 5 tools to the catalog:

- **Trigger.dev** (Agents) — Open-source platform for AI workflows and background tasks in TypeScript with retries, queues, and elastic scaling. `npm install @trigger.dev/sdk`
- **Restate** (Agents) — Open-source durable execution platform for resilient AI agents, workflows, and microservices with Virtual Object model. `npm install @restatedev/restate-sdk`
- **Nango** (Agents) — Open-source platform for building product integrations with AI, supporting 800+ APIs with automatic auth and scaling. `npm install @nangohq/nango`
- **DeepInfra** (LLM) — Serverless inference platform for open-source LLMs and image models with OpenAI-compatible APIs and per-token billing.
- **OctoAI** (LLM) — Fast, cost-effective AI inference platform with serverless API, private VPC deployment, and fine-tuning capabilities.
