### PR TITLE
Add Lambda Cloud, Paperspace Gradient, Vast.ai, CoreWeave to catalog

### DIFF
--- a/tools/other/coreweave.yaml
+++ b/tools/other/coreweave.yaml
@@ -1,0 +1,28 @@
+name: CoreWeave
+description: Specialized GPU cloud provider built for AI and machine learning workloads, offering high-performance NVIDIA H100, A100, and L40S instances with Kubernetes-native orchestration. Designed from the ground up for compute-intensive AI workloads rather than repurposed general-purpose cloud infrastructure.
+tagline: The cloud for AI, built on Kubernetes
+
+github_url: https://github.com/coreweave/kubernetes-cloud
+website_url: https://coreweave.com
+docs_url: https://docs.coreweave.com
+
+category: Other
+tags: [gpu, cloud, kubernetes, infrastructure, training, inference, h100, mlops]
+pricing: paid
+is_open_source: false
+license: Apache-2.0
+
+problem_solved: |
+  General-purpose cloud providers optimize for web workloads (bursty, short-lived, low-bandwidth),
+  making them inefficient and expensive for continuous GPU-intensive AI training and inference.
+  CoreWeave solves this by building cloud infrastructure specifically for compute — with dense
+  GPU packing, high-bandwidth interconnects, Kubernetes-native orchestration, and competitive
+  pricing. Teams can provision GPU clusters in minutes using familiar Kubernetes tooling without
+  fighting provider quotas or paying for unused CPU overhead.
+
+use_cases:
+  - Train large language and diffusion models on H100 and A100 clusters with InfiniBand interconnects
+  - Serve production LLM inference with Kubernetes GPU autoscaling and competitive pricing
+  - Run high-throughput batch rendering and 3D simulation workloads across hundreds of GPUs
+  - Deploy and scale ML model serving endpoints using standard Kubernetes manifests
+  - Offload compute-intensive CI/CD pipelines for AI products to purpose-built GPU infrastructure

--- a/tools/other/lambda-cloud.yaml
+++ b/tools/other/lambda-cloud.yaml
@@ -1,0 +1,29 @@
+name: Lambda Cloud
+description: GPU cloud platform offering on-demand NVIDIA H100, A100, and RTX 6000 instances for AI training and inference. Provides pre-configured deep learning AMIs, fast provisioning, and pay-as-you-go pricing without requiring long-term reservations or complex cloud contracts.
+tagline: On-demand NVIDIA GPU instances for AI development
+
+website_url: https://lambdal.com
+docs_url: https://lambdal.com/docs
+
+install_command: pip install lambda-cloud
+
+category: Other
+tags: [gpu, cloud, infrastructure, training, inference, deep-learning, nvidia, h100]
+pricing: paid
+is_open_source: false
+license: Proprietary
+
+problem_solved: |
+  Provisioning GPU instances on mainstream cloud providers involves navigating complex
+  configurations, long provisioning times, and unpredictable pricing. Lambda Cloud solves this
+  by offering purpose-built GPU instances with pre-installed deep learning stacks that provision
+  in minutes, transparent hourly pricing with no hidden costs, and direct access to the latest
+  NVIDIA hardware including H100s — so teams can start training models immediately without
+  becoming cloud infrastructure experts.
+
+use_cases:
+  - Train and fine-tune large language models on H100 or A100 GPUs without managing cloud infrastructure
+  - Run high-throughput batch inference jobs on pre-configured deep learning AMIs
+  - Prototype and iterate on ML models with fast instance provisioning and pay-as-you-go billing
+  - Scale distributed training workloads across multiple GPU nodes with InfiniBand networking
+  - Host production inference endpoints on reliable GPU infrastructure with predictable pricing

--- a/tools/other/paperspace-gradient.yaml
+++ b/tools/other/paperspace-gradient.yaml
@@ -1,0 +1,29 @@
+name: Paperspace Gradient
+description: Managed cloud platform for machine learning that provides GPU-accelerated notebooks, workstations, and deployments with pay-as-you-go pricing. Combines Jupyter-based development environments, pre-configured ML containers, and one-click model deployment into a single workflow.
+tagline: Simple cloud ML with GPU notebooks and one-click deployment
+
+github_url: https://github.com/Paperspace/gradient-cli
+website_url: https://paperspace.com
+docs_url: https://docs.paperspace.com/gradient
+
+install_command: pip install gradient
+
+category: Other
+tags: [gpu, cloud, notebooks, jupyter, mlops, deployment, training, infrastructure]
+pricing: freemium
+is_open_source: false
+license: ISC
+
+problem_solved: |
+  Setting up a cloud ML environment typically requires configuring Docker, GPU drivers,
+  networking, and storage before writing a single line of model code. Paperspace Gradient
+  eliminates this overhead by providing browser-based Jupyter notebooks with pre-installed
+  ML frameworks, one-click GPU workstations, and CLI-based deployment — all with pay-as-you-go
+  pricing. Teams can move from zero to training on a GPU in minutes rather than days.
+
+use_cases:
+  - Train and experiment with ML models using GPU-accelerated Jupyter notebooks in the browser
+  - Deploy trained models as production API endpoints with auto-scaling and no DevOps work
+  - Spin up high-performance GPU workstations for data science and deep learning research
+  - Run batch inference jobs with pre-configured container environments and CLI automation
+  - Collaborate on ML projects with shared notebooks, datasets, and version-controlled experiments

--- a/tools/other/vast-ai.yaml
+++ b/tools/other/vast-ai.yaml
@@ -1,0 +1,31 @@
+name: Vast.ai
+description: Decentralized GPU cloud marketplace that lets you rent compute from distributed providers at competitive rates. Offers CLI and Python SDK for provisioning instances, attaching storage, and running containers on rented GPUs — often at 50-80% below traditional cloud GPU pricing.
+tagline: The world's largest marketplace for affordable GPU compute
+
+github_url: https://github.com/vast-ai/vast-python
+website_url: https://vast.ai
+docs_url: https://docs.vast.ai
+
+install_command: pip install vastai
+
+category: Other
+tags: [gpu, cloud, marketplace, decentralized, compute, infrastructure, cost-saving]
+pricing: paid
+is_open_source: false
+license: MIT
+
+problem_solved: |
+  GPU compute on mainstream cloud providers is expensive, often costing tens of thousands
+  of dollars per month for sustained training workloads. Vast.ai solves this by creating a
+  two-sided marketplace where GPU owners (individuals and data centers) offer their spare
+  capacity at competitive rates. The platform handles instance provisioning, container
+  orchestration, SSH access, and persistent storage, giving teams access to thousands of
+  GPUs — including H100s, A100s, and RTX 4090s — at a fraction of the cost of on-demand
+  cloud providers.
+
+use_cases:
+  - Rent GPU instances for LLM training at 50-80% below cloud provider pricing
+  - Run distributed batch inference jobs across a global pool of decentralized compute
+  - Execute containerized ML experiments with SSH access and persistent storage volumes
+  - Scale up temporary GPU capacity for Kaggle competitions or research sprints
+  - Compare and select from thousands of GPU listings with filters for price, memory, and interconnect


### PR DESCRIPTION
## New GPU Cloud entries

This PR adds four GPU cloud providers to the catalog:

- **Lambda Cloud** — On-demand NVIDIA H100/A100 instances for AI training
- **Paperspace Gradient** — Managed cloud ML platform with GPU notebooks and deployment
- **Vast.ai** — Decentralized GPU marketplace with competitive pricing
- **CoreWeave** — Kubernetes-native GPU cloud built for AI workloads

All entries have been validated locally with `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new provider listings for CoreWeave, Lambda Cloud, Paperspace Gradient, and Vast.ai.
  * Each listing now includes descriptions, helpful links, setup details, pricing and licensing info, and example use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->