### PR TITLE
Add Crusoe Cloud, VoltAgent, Omnigent, OpenAgentsControl, Rocket Ride to catalog

### DIFF
--- a/tools/agent-frameworks/omnigent.yaml
+++ b/tools/agent-frameworks/omnigent.yaml
@@ -1,0 +1,32 @@
+name: Omnigent
+description: Open-source meta-harness that provides a common orchestration layer over multiple AI coding agents — Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, and custom agents. Lets you swap or combine harnesses without rewriting, enforce policies and sandboxing, and collaborate from terminal, browser, phone, or desktop app.
+tagline: The meta-harness for all your AI agents
+
+github_url: https://github.com/omnigent-ai/omnigent
+website_url: https://omnigent.ai
+docs_url: https://docs.omnigent.ai
+
+install_command: pip install omnigent
+
+category: Agents
+tags: [agents, orchestration, multi-agent, sandbox, policies, collaboration, meta-harness]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Teams using multiple AI coding agents — Claude Code, Codex, Cursor, Hermes — face a fragmented
+  experience: each agent has its own CLI, configuration, sandboxing, and session model, making it
+  hard to switch between them, combine their strengths, or enforce consistent governance policies.
+  Omnigent solves this by acting as a meta-harness that wraps all these agents under a single
+  orchestration layer: agents can be swapped or combined without rewriting, policies (spend caps,
+  approval gates, tool restrictions) apply uniformly, sandbox execution is managed in cloud
+  providers, and sessions sync across devices so work started on a terminal can be continued on
+  a phone or desktop app.
+
+use_cases:
+  - Supervise multiple coding agents (Claude Code, Codex, Cursor) in the same session with coordinated task orchestration
+  - Enforce consistent governance policies across all agents — spend caps, approval before risky actions, tool restrictions
+  - Run agents in disposable cloud sandboxes (Modal, E2B, CoreWeave) without managing infrastructure
+  - Collaborate with teammates by sharing agent sessions, watching work in real-time, or forking conversations
+  - Access and manage AI agent sessions from any device — terminal, browser, mobile phone, or desktop app

--- a/tools/agent-frameworks/voltagent.yaml
+++ b/tools/agent-frameworks/voltagent.yaml
@@ -1,0 +1,32 @@
+name: VoltAgent
+description: End-to-end AI Agent Engineering Platform with an open-source TypeScript framework and a managed ops console. The framework provides memory, RAG, guardrails, tools, MCP support, voice, workflow orchestration, and multi-agent supervisors — all with full code control. The VoltOps console adds observability, evals, deployment automation, and prompt management.
+tagline: Open-source TypeScript framework for production AI agents
+
+github_url: https://github.com/VoltAgent/voltagent
+website_url: https://voltagent.dev
+docs_url: https://voltagent.dev/docs
+
+install_command: npm install @voltagent/core
+
+category: Agents
+tags: [typescript, agents, framework, multi-agent, rag, memory, guardrails, mcp, workflow, orchestration]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Building production-ready AI agents requires wiring together memory, RAG pipelines, tool
+  execution, guardrails, voice, and observability — without a unified framework, each project
+  reinvents this stack from scratch. VoltAgent solves this by providing a modular open-source
+  TypeScript framework that bundles all these capabilities as interchangeable packages: agents
+  with typed roles and tools, multi-step workflow engines, supervisor-coordinated sub-agent
+  teams, durable memory adapters, and built-in guardrails. The developer writes application
+  logic while VoltAgent handles the agent infrastructure, and the optional VoltOps console
+  adds evals, deployment, and observability for production.
+
+use_cases:
+  - Build multi-agent systems where specialized agents collaborate under supervisor coordination for complex tasks
+  - Create production chatbots and assistants with durable memory, RAG, and guardrails for safety
+  - Orchestrate multi-step AI workflows with resumable streaming and error recovery
+  - Connect agents to external tools and APIs via MCP servers with lifecycle hooks and cancellation
+  - Monitor, evaluate, and iterate on agent performance with the VoltOps observability and evals console

--- a/tools/dev-tools/open-agents-control.yaml
+++ b/tools/dev-tools/open-agents-control.yaml
@@ -1,0 +1,31 @@
+name: OpenAgentsControl
+description: AI agent framework for plan-first development workflows with approval-based execution. Agents learn and follow your team's coding patterns, propose plans before implementing, and execute incrementally with validation. Multi-language support across TypeScript, Python, Go, and Rust.
+tagline: AI agents that learn your coding patterns and follow your team's standards
+
+github_url: https://github.com/darrenhinde/OpenAgentsControl
+website_url: https://opencode.ai
+docs_url: https://github.com/darrenhinde/OpenAgentsControl
+
+install_command: npm install -g open-agents-control
+
+category: Dev Tools
+tags: [coding, agent, code-generation, development-workflow, approval-gates, patterns, team-standards]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI coding agents typically generate generic code that doesn't match a team's established
+  patterns, architecture, or security requirements — wasting time on rewrites and introducing
+  inconsistencies across the codebase. OpenAgentsControl solves this by adopting a plan-first
+  workflow where agents learn your specific coding patterns upfront, propose structured plans
+  with approval gates, then execute incrementally with per-step validation. It supports
+  TypeScript, Python, Go, and Rust, and is model-agnostic, so teams enforce consistent coding
+  standards no matter which LLM powers the agent.
+
+use_cases:
+  - Train AI agents on your team's coding patterns so generated code matches existing architecture from day one
+  - Implement approval gates that require developer sign-off before agents execute risky operations
+  - Run plan-first development workflows where agents propose plans, get reviewed, then implement incrementally
+  - Enforce consistent code quality across a team with shared pattern definitions and agent behavior profiles
+  - Support multi-language codebases (TypeScript, Python, Go, Rust) with a single agent workflow framework

--- a/tools/dev-tools/rocket-ride.yaml
+++ b/tools/dev-tools/rocket-ride.yaml
@@ -1,0 +1,33 @@
+name: Rocket Ride
+description: Open-source AI pipeline engine with a high-performance C++ runtime and 85+ pipeline nodes spanning 13 LLM providers, 8 vector databases, OCR, NER, and more. Pipelines are composed visually in VS Code or defined as portable JSON, executed by a multithreaded C++ engine, and integrated via Python, TypeScript, or MCP SDKs.
+tagline: Open-source AI pipeline engine for production workflows
+
+github_url: https://github.com/rocketride-org/rocketride-server
+website_url: https://rocketride.org
+docs_url: https://docs.rocketride.org
+
+install_command: |-
+  pip install rocketride
+  npm install rocketride
+
+category: Dev Tools
+tags: [pipeline, llm, workflow, data-processing, vs-code, python, cpp, ai-engineering]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Building production AI workflows that chain together LLM calls, vector search, document
+  processing, and custom logic typically requires stitching together disparate libraries and
+  managing complex infrastructure. Rocket Ride solves this by providing a visual pipeline
+  builder (VS Code extension), a high-performance C++ runtime, and SDKs for Python, TypeScript,
+  and MCP — all in one open-source platform. Its 85+ pre-built nodes cover LLM providers,
+  vector databases, OCR, NER, chunking, embeddings, and more, all composable as portable JSON
+  pipelines that run on your own infrastructure with no vendor lock-in.
+
+use_cases:
+  - Build multi-step RAG pipelines that chain document ingestion, chunking, embedding, and LLM querying
+  - Create production data processing workflows with OCR, NER, PII anonymization, and structured extraction
+  - Orchestrate multi-agent AI workflows combining CrewAI and LangChain agents within pipeline nodes
+  - Deploy AI pipelines as callable tools via MCP server for AI assistant integration
+  - Run high-throughput batch inference and embedding jobs on the multithreaded C++ runtime

--- a/tools/other/crusoe-cloud.yaml
+++ b/tools/other/crusoe-cloud.yaml
@@ -1,0 +1,31 @@
+name: Crusoe Cloud
+description: Carbon-negative GPU cloud platform purpose-built for AI and machine learning workloads. Offers NVIDIA H100 and A100 instances powered by clean energy, with Kubernetes-native orchestration, high-performance interconnects, and competitive pricing for compute-intensive training and inference.
+tagline: Carbon-negative GPU cloud for AI and ML
+
+github_url: https://github.com/crusoecloud/cli
+website_url: https://crusoecloud.com
+docs_url: https://docs.crusoecloud.com
+
+install_command: brew install crusoecloud/cli/crusoe
+
+category: Other
+tags: [gpu, cloud, infrastructure, green-computing, sustainable, training, inference, h100]
+pricing: paid
+is_open_source: false
+license: MIT
+
+problem_solved: |
+  AI workloads powered by traditional cloud data centers produce significant carbon emissions,
+  yet most GPU cloud providers offer no transparency or mitigation for their environmental
+  impact. Crusoe Cloud solves this by powering its GPU infrastructure with clean energy and
+  capturing methane from stranded gas wells that would otherwise be flared into the atmosphere.
+  The result is carbon-negative compute for AI training and inference — competitive pricing
+  on NVIDIA H100 and A100 clusters with Kubernetes-native orchestration and no performance
+  compromise versus conventional GPU providers.
+
+use_cases:
+  - Train large language and diffusion models on carbon-negative H100 GPU clusters
+  - Serve production LLM inference with Kubernetes autoscaling and sustainable infrastructure
+  - Run batch rendering and simulation workloads with clean energy and reduced carbon footprint
+  - Deploy and manage GPU workloads using familiar Kubernetes tooling and CLI
+  - Offload compute-intensive AI training to infrastructure with verifiable carbon-negative credentials


### PR DESCRIPTION
## New tools added to catalog

This PR adds 5 new tools across Agents, Dev Tools, and Other categories:

- **Crusoe Cloud** (Other) — Carbon-negative GPU cloud for AI/ML workloads
- **VoltAgent** (Agents) — Open-source TypeScript AI agent engineering platform
- **Omnigent** (Agents) — Meta-harness for orchestrating multiple AI coding agents
- **OpenAgentsControl** (Dev Tools) — Plan-first development workflow with approval gates
- **Rocket Ride** (Dev Tools) — Open-source AI pipeline engine with C++ runtime

All entries validated locally with `npx tsx scripts/validate-tool.ts`.
