### PR TITLE
Add Cognee, MindsDB, Vocode, Observable Framework, Steel to catalog

### DIFF
--- a/tools/agent-frameworks/steel.yaml
+++ b/tools/agent-frameworks/steel.yaml
@@ -1,0 +1,32 @@
+name: Steel
+description: |-
+  An open-source browser sandbox API for AI agents and apps that provides
+  a batteries-included headless browser environment with session management,
+  stealth anti-detection, and scalable infrastructure for web automation.
+tagline: Open-source browser API for AI agents
+
+github_url: https://github.com/steel-dev/steel-browser
+website_url: https://steel.dev
+docs_url: https://docs.steel.dev
+install_command: npm install @steel-dev/steel-sdk
+
+category: Agents
+tags: [javascript, browser, web-automation, agents, headless-browser, scraping, puppeteer]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |-
+  AI agents that need to interact with websites face multiple challenges: managing
+  headless browser sessions, avoiding bot detection, handling CAPTCHAs, and
+  scaling infrastructure across concurrent sessions. Steel wraps Playwright into
+  a managed browser sandbox with built-in stealth mode for anti-detection, session
+  persistence, and parallel execution. Developers get a simple API for browser
+  automation without managing browser infrastructure or fighting detection systems.
+
+use_cases:
+  - Deploy AI agents that can log into web apps, navigate UIs, and extract data autonomously
+  - Build web scraping pipelines that avoid bot detection with built-in stealth anti-detection
+  - Run parallel browser sessions for multi-account testing and automation at scale
+  - Create AI assistants that complete multi-step web tasks like form filling and checkout
+  - Automate SaaS workflows that require login, navigation, and data extraction from web portals

--- a/tools/agent-frameworks/vocode.yaml
+++ b/tools/agent-frameworks/vocode.yaml
@@ -1,0 +1,32 @@
+name: Vocode
+description: |-
+  An open-source library for building voice-based LLM agents that can make and
+  receive phone calls, transcribe speech in real-time, generate spoken responses,
+  and handle complex conversational flows with configurable endpoints.
+tagline: Build voice-based LLM agents that make and receive phone calls
+
+github_url: https://github.com/vocodedev/vocode-python
+website_url: https://vocode.dev
+docs_url: https://docs.vocode.dev
+install_command: pip install vocode
+
+category: Agents
+tags: [python, voice, agents, telephony, speech, stt, tts, conversation-ai]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |-
+  Building voice-enabled AI agents requires integrating speech-to-text, large language
+  models, text-to-speech, and telephony — each with its own API, latency, and failure
+  modes. Vocode provides a unified abstraction for real-time voice agents, handling
+  bidirectional audio streaming, endpointing, and conversational state management. It
+  plugs into any LLM provider, speech engine, and telephony carrier (Twilio, Vonage,
+  or web-based) so developers can ship voice agents without telephony expertise.
+
+use_cases:
+  - Build outbound sales agents that make phone calls and qualify leads autonomously
+  - Create voice-based customer support agents that handle inbound calls with natural conversation
+  - Deploy AI receptionists that screen calls, take messages, and route to human agents
+  - Integrate voice conversation capabilities into existing chatbot workflows
+  - Build multilingual voice agents that detect and respond in the caller's language

--- a/tools/data/cognee.yaml
+++ b/tools/data/cognee.yaml
@@ -1,0 +1,31 @@
+name: Cognee
+description: |-
+  An open-source AI memory platform for agents that provides persistent long-term
+  memory across sessions using a self-hosted knowledge graph engine, enabling
+  agents to remember, reason, and recall information over time.
+tagline: Persistent long-term memory for AI agents
+
+github_url: https://github.com/topoteretes/cognee
+website_url: https://cognee.ai
+docs_url: https://docs.cognee.ai
+
+category: Data
+tags: [python, memory, knowledge-graph, agents, vector-db, rag, long-term-memory]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+install_command: pip install cognee
+
+problem_solved: |-
+  AI agents lose context between sessions, forcing users to repeat information
+  and preventing long-running autonomous workflows. Cognee gives agents persistent
+  memory by storing structured knowledge as a knowledge graph that can be queried,
+  updated, and shared across sessions. Agents can recall past interactions, maintain
+  user preferences, and build up domain knowledge over time without external databases.
+
+use_cases:
+  - Give AI agents persistent memory that persists across chat sessions and API calls
+  - Store and retrieve structured knowledge as a knowledge graph for agentic reasoning
+  - Build customer support agents that remember user history and preferences across conversations
+  - Enable autonomous agents to recall past decisions and outcomes for better long-term planning
+  - Create research agents that accumulate domain knowledge over multiple research sessions

--- a/tools/data/mindsdb.yaml
+++ b/tools/data/mindsdb.yaml
@@ -1,0 +1,31 @@
+name: MindsDB
+description: |-
+  An open-source AI database that enables developers to build, train, and deploy
+  machine learning models directly inside databases using standard SQL queries,
+  bringing AI-powered predictions to any data source with minimal code.
+tagline: Build and deploy ML models directly from your database with SQL
+
+github_url: https://github.com/mindsdb/mindsdb
+website_url: https://mindsdb.com
+docs_url: https://docs.mindsdb.com
+
+category: Data
+tags: [python, sql, machine-learning, database, ai, mlops, predictions, data-platform]
+pricing: freemium
+is_open_source: true
+license: MIT
+install_command: pip install mindsdb
+
+problem_solved: |-
+  Operationalizing machine learning typically requires moving data between databases,
+  notebooks, and ML platforms — a slow, brittle pipeline that data teams struggle to
+  maintain. MindsDB integrates ML models directly into databases via SQL. Data stays
+  in place; developers write SQL queries to train models, make predictions, and
+  automate time-series forecasting without learning ML frameworks or managing infrastructure.
+
+use_cases:
+  - Run time-series forecasts directly in SQL to predict sales, inventory, or server load
+  - Build real-time anomaly detection pipelines that alert when metrics deviate from predictions
+  - Create recommendation engines that surface products or content using SQL queries
+  - Automate data enrichment by predicting missing values in database columns
+  - Deploy ML models as virtual tables that update predictions as new data arrives

--- a/tools/data/observable-framework.yaml
+++ b/tools/data/observable-framework.yaml
@@ -1,0 +1,32 @@
+name: Observable Framework
+description: |-
+  A static site generator for building interactive data apps, dashboards, and reports
+  that combine JavaScript front-end visualizations with any back-end language for
+  data analysis, supporting live-updating views and rich client-side interactivity.
+tagline: Build interactive data dashboards and reports with code
+
+github_url: https://github.com/observablehq/framework
+website_url: https://observablehq.com/framework
+docs_url: https://observablehq.com/framework/getting-started
+install_command: npm install @observablehq/framework
+
+category: Data
+tags: [javascript, data-visualization, dashboard, data-analysis, static-site, interactive]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |-
+  Building data dashboards and interactive reports typically requires complex front-end
+  frameworks, separate data pipeline infrastructure, and manual deployment processes.
+  Observable Framework lets developers write data apps entirely in Markdown and
+  JavaScript with reactive cells that auto-update when data changes. It handles the
+  build pipeline, data loading, and deployment as a static site, so teams ship
+  interactive data products faster without learning separate dashboarding tools.
+
+use_cases:
+  - Build an interactive sales dashboard that updates automatically when new data is loaded
+  - Create a data report with live charts, maps, and tables that stakeholders can explore
+  - Publish an open data portal with searchable, filterable datasets and visualizations
+  - Generate per-client analytics reports from templated Markdown with embedded SQL queries
+  - Monitor real-time metrics with auto-refreshing dashboards deployed as static sites


### PR DESCRIPTION
Adds 5 tools to the catalog:

- **Cognee** — Open-source AI memory platform for agents with persistent knowledge graph memory (27.4k★, Apache-2.0)
- **MindsDB** — AI database that brings ML models to SQL for predictions and automation (39.4k★, MIT)
- **Vocode** — Open-source library for building voice-based LLM agents that make phone calls (3.8k★, MIT)
- **Observable Framework** — Static site generator for interactive data dashboards and reports (3.5k★, Apache-2.0)
- **Steel** — Open-source browser sandbox API for AI agents with stealth anti-detection (7.3k★, MIT)

All files validated locally with `npx tsx scripts/validate-tool.ts`.
