### PR TITLE
Add Krea AI, Clipdrop, Oracle Cloud AI, IBM watsonx.ai, NVIDIA NIM to catalog

### DIFF
--- a/tools/llm/ibm-watsonx-ai.yaml
+++ b/tools/llm/ibm-watsonx-ai.yaml
@@ -1,0 +1,25 @@
+name: IBM watsonx.ai
+description: |-
+  IBM watsonx.ai is an enterprise-grade AI platform for building, training, tuning, deploying, and operating AI models at scale. It provides access to foundation models including Llama, Mistral, and Granite through a unified API, with tools for prompt engineering, model fine-tuning, synthetic data generation, and AI governance — all integrated with IBM Cloud's enterprise security and compliance framework.
+tagline: Enterprise AI platform for building, tuning, and deploying AI models
+
+website_url: https://www.ibm.com/watsonx
+docs_url: https://cloud.ibm.com/apidocs/watsonx-ai
+github_url: https://github.com/IBM/watsonx-ai-python-sdk
+
+install_command: pip install ibm-watsonx-ai
+
+category: LLM
+tags: [llm, enterprise, ibm, model-training, model-deployment, ai-governance, foundation-models]
+pricing: paid
+is_open_source: false
+
+problem_solved: |-
+  Regulated enterprises need to build AI applications using large language models while complying with industry-specific governance, data residency, and audit requirements — but most LLM platforms lack the governance tooling that financial services, healthcare, and government organizations require. IBM watsonx.ai solves this by combining foundation model access (Llama, Mistral, Granite) with built-in AI governance, model risk management, prompt engineering studios, and fine-tuning capabilities — all deployable on IBM Cloud with enterprise-grade security, data isolation, and audit trails.
+
+use_cases:
+  - "Access and compare multiple foundation models through a unified API for text generation, chat, and code generation workloads"
+  - "Fine-tune large language models on proprietary datasets using prompt tuning or full fine-tuning with IBM's managed infrastructure"
+  - "Govern AI applications with built-in model risk management, bias detection, and compliance monitoring across the model lifecycle"
+  - "Generate synthetic data for training and testing AI models when real data is scarce or privacy-constrained"
+  - "Build RAG applications that ground LLM responses in enterprise knowledge bases with IBM's document retrieval and embedding services"

--- a/tools/llm/oracle-cloud-ai.yaml
+++ b/tools/llm/oracle-cloud-ai.yaml
@@ -1,0 +1,25 @@
+name: Oracle Cloud AI
+description: |-
+  Oracle Cloud AI (OCI Generative AI) is Oracle's fully managed enterprise AI platform for building, deploying, and governing AI applications. It provides access to frontier models from Llama and Cohere, built-in agent development tools, managed context retention, vector stores, and enterprise controls including IAM, data residency, and private networking — all integrated with Oracle Cloud Infrastructure.
+tagline: Enterprise-grade generative AI on Oracle Cloud Infrastructure
+
+website_url: https://www.oracle.com/artificial-intelligence/generative-ai/
+docs_url: https://docs.oracle.com/en-us/iaas/Content/generative-ai/home.htm
+github_url: https://github.com/oracle/oci-python-sdk
+
+install_command: pip install oci
+
+category: LLM
+tags: [llm, generative-ai, oci, enterprise, managed-service, oracle, foundation-models]
+pricing: paid
+is_open_source: false
+
+problem_solved: |-
+  Enterprises running on Oracle Cloud Infrastructure need secure, compliant access to large language models for building AI applications, but stitching together third-party model APIs with OCI's IAM, networking, and data residency requirements creates integration complexity. Oracle Cloud AI solves this by providing managed access to frontier models (including Llama and Cohere) through the OCI ecosystem with unified IAM, private network endpoints, data residency controls, and built-in agent development tooling — all billed through existing OCI commitments.
+
+use_cases:
+  - "Access frontier LLMs like Llama and Cohere through OCI's managed inference endpoints with enterprise-grade security and compliance"
+  - "Build RAG applications using OCI Generative AI's integrated vector store and document retrieval capabilities"
+  - "Develop autonomous AI agents with managed context retention, memory, and tool-use orchestration on OCI infrastructure"
+  - "Deploy AI applications with strict data residency requirements using OCI's regional private network endpoints"
+  - "Integrate generative AI into existing Oracle Cloud workflows using the OCI Python SDK and familiar IAM authentication"

--- a/tools/other/clipdrop.yaml
+++ b/tools/other/clipdrop.yaml
@@ -1,0 +1,23 @@
+name: Clipdrop
+description: |-
+  Clipdrop is an AI-powered image editing and generation platform (formerly by Stability AI, now part of Jasper) offering APIs for background removal, text removal, image upscaling, uncropping, packshot compositing, and more. It provides creative professionals and developers with automated image processing capabilities through a simple REST API.
+tagline: AI-powered image editing and generation API
+
+website_url: https://clipdrop.co
+docs_url: https://clipdrop.co/apis/docs
+github_url: https://github.com/initml/clipdrop-api-samples
+
+category: Other
+tags: [image-editing, background-removal, generative-ai, api, creative-tools, image-processing]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |-
+  Professional image editing tasks like background removal, text removal, and image upscaling traditionally require manual work in Photoshop or similar tools, which doesn't scale for developers building image-processing pipelines. Clipdrop solves this by providing a simple REST API that automates these editing tasks — developers send an image and receive the edited result, enabling e-commerce catalog processing, content creation workflows, and automated image enhancement at scale.
+
+use_cases:
+  - "Remove backgrounds from product photos at scale for e-commerce catalogs and marketplace listings"
+  - "Clean up images by removing unwanted text, objects, or imperfections with a single API call"
+  - "Upscale low-resolution images for print-ready output or high-resolution display requirements"
+  - "Generate packshot-style product images with automated compositing and background replacement"
+  - "Create automated image processing pipelines for content moderation, social media, and marketing workflows"

--- a/tools/other/krea-ai.yaml
+++ b/tools/other/krea-ai.yaml
@@ -1,0 +1,22 @@
+name: Krea AI
+description: |-
+  Krea AI is a creative AI suite for generating, editing, and enhancing images, videos, and 3D assets. It provides access to 40+ production-ready AI models through an intuitive web interface and a developer API with serverless GPU inference, simple per-generation pricing, and no charge for failed jobs.
+tagline: Creative AI suite for images, video, and 3D generation
+
+website_url: https://www.krea.ai
+docs_url: https://docs.krea.ai
+
+category: Other
+tags: [image-generation, video-generation, ai-art, creative-tools, api, 3d, generative-ai]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |-
+  Building applications with generative AI image and video models typically requires stitching together multiple model providers, managing GPU infrastructure, and dealing with unpredictable API pricing where failed requests are still charged. Krea AI solves this by curating 40+ production-ready models under a single API, handling GPU inference on serverless infrastructure, and only charging for successful generations — with an intuitive web UI for creative exploration and an API for programmatic integration.
+
+use_cases:
+  - "Generate high-quality images from text prompts using state-of-the-art models like Flux, Stable Diffusion, and SDXL through a single API"
+  - "Create and edit videos with AI video generation models, including text-to-video and image-to-video workflows"
+  - "Upscale and enhance images with AI super-resolution models for print-quality output from low-resolution sources"
+  - "Edit images programmatically with inpainting, outpainting, and style transfer via the developer API"
+  - "Explore and iterate on creative concepts rapidly using the web UI before moving to API-based production workflows"

--- a/tools/other/nvidia-nim.yaml
+++ b/tools/other/nvidia-nim.yaml
@@ -1,0 +1,22 @@
+name: NVIDIA NIM
+description: |-
+  NVIDIA NIM (NVIDIA Inference Microservices) provides prebuilt, optimized inference microservices for deploying the latest AI models on any NVIDIA-accelerated infrastructure — cloud, data center, workstation, and edge. Each NIM microservice is a containerized inference engine with GPU-optimized runtimes, supporting models for LLMs, vision, speech, and more with NVIDIA's TensorRT and Triton Inference Server optimizations.
+tagline: Prebuilt, optimized inference microservices for AI model deployment
+
+website_url: https://www.nvidia.com/en-us/ai-data-science/products/nim-microservices/
+docs_url: https://docs.nvidia.com/nim
+
+category: Other
+tags: [inference, deployment, gpu, microservices, containers, nvidia, model-serving, optimization]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |-
+  Deploying AI models for production inference requires significant engineering effort to set up GPU-optimized inference stacks, manage dependencies, and achieve low-latency performance — often requiring teams to build custom Docker containers with TensorRT, Triton, and CUDA toolchains. NVIDIA NIM solves this by providing prebuilt, GPU-optimized container images for popular AI models that work out of the box on any NVIDIA GPU infrastructure, with automatic TensorRT optimization, dynamic batching, and multi-GPU scaling included.
+
+use_cases:
+  - "Deploy LLMs for production inference with prebuilt container images optimized for NVIDIA GPUs using TensorRT-LLM"
+  - "Run vision AI models including object detection, segmentation, and image classification at low latency on edge or data center GPUs"
+  - "Build multi-model inference pipelines with NVIDIA Triton Inference Server's request batching, model ensemble, and dynamic routing"
+  - "Deploy speech AI models for real-time transcription and text-to-speech with GPU-accelerated inference containers"
+  - "Scale model inference across multi-GPU and multi-node deployments with built-in load balancing and auto-scaling configurations"


### PR DESCRIPTION
## Tools Added

| Tool | Category | Description |
|------|----------|-------------|
| **Krea AI** | Other | Creative AI suite for generating, editing, and enhancing images, videos, and 3D assets with 40+ models and a developer API. |
| **Clipdrop** | Other | AI-powered image editing and generation platform offering APIs for background removal, text removal, upscaling, and compositing. |
| **Oracle Cloud AI** | LLM | Oracle's fully managed enterprise AI platform providing access to Llama and Cohere models through OCI with IAM and data residency controls. |
| **IBM watsonx.ai** | LLM | Enterprise AI platform for building, training, tuning, deploying, and operating AI models with built-in governance and compliance tooling. |
| **NVIDIA NIM** | Other | Prebuilt, GPU-optimized inference microservices for deploying AI models on any NVIDIA-accelerated infrastructure. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new catalog entries for IBM watsonx.ai, Oracle Cloud AI, Clipdrop, Krea AI, and NVIDIA NIM.
  * Expanded the available AI/tool listings with descriptions, links, pricing details, and supported use cases.
  * Improved discoverability of services across creative media, cloud AI, and model deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->