### PR TITLE
Add OpenKB, Arcade AI, NeuronDB to catalog

### DIFF
--- a/tools/agent-frameworks/arcade-ai.yaml
+++ b/tools/agent-frameworks/arcade-ai.yaml
@@ -1,0 +1,32 @@
+name: Arcade AI
+description: arcade-mcp is the Python framework for building Model Context Protocol servers and the tools that run inside them. It powers 7,500+ prebuilt tools across 81 MCP servers at Arcade.dev and is fully open-sourced so you can build, deploy, and scale custom MCP servers with OAuth, secrets management, and production tooling.
+tagline: The open-source MCP framework for building agent tools
+
+github_url: https://github.com/ArcadeAI/arcade-mcp
+website_url: https://arcade.dev
+docs_url: https://docs.arcade.dev
+
+install_command: pip install arcade-mcp
+
+category: Agents
+tags: [agents, mcp, framework, python, tools, oauth, server, open-source]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Building tools for AI agents is fragmented — every agent framework (OpenAI
+  Agents SDK, LangChain, Anthropic, etc.) has its own tool format, auth
+  mechanism, and deployment model. arcade-mcp solves this by providing a
+  unified Python framework for building MCP-compatible tool servers. You define
+  tools with a simple @tool decorator, wire up OAuth once, and the same server
+  works across any MCP-compatible agent. Arcade.dev hosts 7,500+ prebuilt
+  tools covering Gmail, Slack, GitHub, Notion, and more, or you can build
+  private tools for your own services with the same framework.
+
+use_cases:
+  - Build a custom MCP server that gives your AI agent access to internal APIs, databases, and SaaS tools
+  - Use Arcade's 7,500+ prebuilt tools to give an agent Gmail, Slack, GitHub, and Notion access in minutes
+  - Deploy a secure tool gateway with built-in OAuth so agents can act on behalf of users without exposing API keys
+  - Create a private tool catalog for your organization with usage tracking, rate limits, and access controls
+  - Prototype new agent capabilities by decorating a Python function with @tool and testing instantly

--- a/tools/rag/openkb.yaml
+++ b/tools/rag/openkb.yaml
@@ -1,0 +1,31 @@
+name: OpenKB
+description: OpenKB is an open-source CLI tool that compiles raw documents into a structured, interlinked wiki-style knowledge base using LLMs. Based on Karpathy's concept of persistent LLM knowledge, it uses vectorless reasoning-based retrieval to handle long documents without chunking, providing a continuously updated knowledge base for AI agents.
+tagline: Compile documents into a living wiki for your LLM
+
+github_url: https://github.com/VectifyAI/OpenKB
+
+install_command: pip install openkb
+
+category: RAG
+tags: [rag, knowledge-base, llm, cli, documents, wiki, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Traditional RAG chunks documents, embeds them into a vector database, and
+  re-embeds everything when documents change — a fragile pipeline that loses
+  cross-document context and wastes tokens re-processing stable knowledge.
+  OpenKB instead compiles raw documents (PDFs, Markdown, web pages) into a
+  structured, interlinked wiki of Markdown files using an LLM. The wiki captures
+  concepts, summaries, and relationships once, then stays persistent. Queries
+  use PageIndex's vectorless reasoning-based retrieval that can handle long
+  documents without chunking, making knowledge accumulation both cheaper and
+  more reliable than traditional RAG.
+
+use_cases:
+  - Compile a research library of 100+ PDFs into an interlinked wiki that your LLM can reference without re-embedding
+  - Build a continuously updated company knowledge base from Notion exports, Slack archives, and internal docs
+  - Create a personal second brain that accumulates and cross-references notes, bookmarks, and articles over time
+  - Power a customer-facing Q&A bot with a curated wiki that gets updated by adding files to a directory
+  - Replace traditional vector RAG in agentic workflows with a persistent, human-readable knowledge artifact

--- a/tools/vector-databases/neurondb.yaml
+++ b/tools/vector-databases/neurondb.yaml
@@ -1,0 +1,30 @@
+name: NeuronDB
+description: NeuronDB is an open-source PostgreSQL extension that adds vector similarity search (HNSW, IVFFlat), embedding generation, ML inference, and hybrid full-text + vector retrieval directly into your existing database. No separate vector DB, no ETL pipeline, no data sync — keep AI workloads on your live relational data with familiar SQL.
+tagline: AI-native vector search and ML inside PostgreSQL
+
+github_url: https://github.com/neurondb/neurondb
+website_url: https://neuron-db.com
+docs_url: https://docs.neuron-db.com
+
+category: Vector DB
+tags: [vector-database, postgresql, extension, embeddings, similarity-search, ml, hnsw, ivfflat]
+pricing: free
+is_open_source: true
+
+problem_solved: |
+  Adding AI capabilities like vector search, embeddings, and ML inference to an
+  application typically means running a separate vector database alongside your
+  relational database — doubling infrastructure, adding ETL pipelines, and
+  creating data consistency headaches. NeuronDB eliminates this by bringing
+  vector similarity search (HNSW, IVFFlat), embedding generation, and ML
+  inference directly into PostgreSQL as a native extension. Your vectors stay on
+  your live rows, you query with standard SQL, and you get the same backups,
+  replication, and security you already rely on. It also supports hybrid
+  full-text + vector search for production RAG pipelines.
+
+use_cases:
+  - Run semantic vector search on millions of rows without leaving PostgreSQL or managing a second database
+  - Build a production RAG pipeline with hybrid full-text + vector retrieval using a single SQL query
+  - Generate and store embeddings for text columns directly inside PostgreSQL with in-database inference
+  - Power recommendation engines with kNN similarity queries over user behavior vectors
+  - Run ML model training and prediction on live database rows without exporting data to a separate ML system


### PR DESCRIPTION
This PR adds 3 new tools to the catalog:

- **OpenKB** (RAG) — Open-source CLI that compiles raw documents into a structured wiki-style LLM knowledge base. Uses vectorless reasoning-based retrieval. 2,936★ on GitHub.
- **Arcade AI** (Agents) — Open-source Python framework for building MCP servers and agent tools. Powers 7,500+ tools across 81 MCP servers. 953★ on GitHub.
- **NeuronDB** (Vector DB) — Open-source PostgreSQL extension for vector similarity search (HNSW, IVFFlat), ML inference, and hybrid full-text + vector retrieval. Embeddings and ML directly in your existing database.

All entries validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new tool entries for Arcade AI, OpenKB, and NeuronDB.
  * Expanded the catalog with richer details like descriptions, tags, pricing/licensing info, links, and install instructions.
  * Included practical use-case summaries to help users quickly understand where each tool fits, including MCP workflows, knowledge bases, and vector search/retrieval scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->