### PR TITLE
Add KAG, GPTCache, text-extract-api, agentUniverse, edgequake to catalog

### DIFF
--- a/tools/agent-frameworks/agentuniverse.yaml
+++ b/tools/agent-frameworks/agentuniverse.yaml
@@ -1,0 +1,33 @@
+name: agentUniverse
+description: agentUniverse is an LLM multi-agent framework that enables developers to easily build multi-agent applications. It provides a domain-driven design approach with reusable agent patterns, service-oriented tool integration, and enterprise-grade production readiness.
+tagline: Build production-ready multi-agent systems with domain-driven design
+
+github_url: https://github.com/agentuniverse-ai/agentUniverse
+website_url: https://agentuniverse.readthedocs.io
+docs_url: https://agentuniverse.readthedocs.io
+
+install_command: pip install agentUniverse
+
+category: Agents
+tags: [agents, multi-agent, framework, python, llm, domain-driven-design, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building multi-agent systems that work reliably in production requires more
+  than just orchestrating LLM calls — you need agent patterns (reflection,
+  tool use, planning, multi-agent debate), service integration, knowledge
+  management, and observability. Most agent frameworks are too low-level,
+  forcing teams to reinvent patterns for every project. agentUniverse provides
+  a domain-driven multi-agent framework with reusable agent patterns,
+  service-oriented tool integration, knowledge base management, and built-in
+  monitoring. It treats agents as domain objects, making complex multi-agent
+  architectures manageable and production-ready.
+
+use_cases:
+  - Build a multi-agent research system where specialized agents gather, analyze, and synthesize information from multiple sources
+  - Create a customer service platform with agents that triage queries, retrieve knowledge, and escalate to human agents
+  - Deploy a code review assistant with agents specializing in security, performance, and best practices
+  - Implement a financial analysis pipeline where agents collect market data, run models, and generate reports
+  - Orchestrate a content production workflow with agents for research, drafting, editing, and publishing

--- a/tools/data/text-extract-api.yaml
+++ b/tools/data/text-extract-api.yaml
@@ -1,0 +1,30 @@
+name: text-extract-api
+description: A self-hosted API service that converts PDFs, Word documents, PPTX files, and images into structured Markdown or JSON using state-of-the-art OCR and LLMs. Supports PII redaction, table extraction, math formulas, and Ollama integration for fully local processing.
+tagline: Self-hosted document extraction API with OCR + LLM
+
+github_url: https://github.com/CatchTheTornado/text-extract-api
+website_url: https://github.com/CatchTheTornado/text-extract-api
+
+category: Data
+tags: [data, document-processing, ocr, pdf, extraction, markdown, json, self-hosted]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Extracting clean, structured text from PDFs, scanned documents, and Office
+  files is a persistent pain point for RAG pipelines and LLM data ingestion.
+  Existing parsers either lose tabular structure, fail on scanned documents
+  without OCR, or require complex multi-tool pipelines. text-extract-api solves
+  this with a single Docker-deployable API that uses modern OCR (EasyOCR +
+  PyTorch) and optional LLM enhancement (via Ollama) to convert any document or
+  image into clean Markdown or structured JSON. It handles tables, math
+  formulas, multi-column layouts, and includes built-in PII redaction — all
+  with a simple HTTP endpoint.
+
+use_cases:
+  - Deploy a self-hosted document processing pipeline that converts PDFs and scanned docs to LLM-ready Markdown
+  - Extract structured JSON data from invoices, receipts, and forms using OCR + LLM correction
+  - Build a document ingestion API for RAG systems that handles PDF, DOCX, PPTX, and images through one endpoint
+  - Anonymize sensitive documents with built-in PII redaction before sending them to LLM pipelines
+  - Process batch document conversions with async task queues (Celery + Redis) for high-throughput workloads

--- a/tools/llm/gptcache.yaml
+++ b/tools/llm/gptcache.yaml
@@ -1,0 +1,33 @@
+name: GPTCache
+description: A semantic caching layer for LLM applications that reduces response time, lowers API costs, and improves throughput by storing and reusing semantically similar LLM responses instead of making redundant API calls.
+tagline: Semantic cache for LLMs — cut costs, speed up responses
+
+github_url: https://github.com/zilliztech/GPTCache
+website_url: https://gptcache.readthedocs.io
+docs_url: https://gptcache.readthedocs.io
+
+install_command: pip install gptcache
+
+category: LLM
+tags: [llm, caching, semantic-cache, cost-optimization, performance, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Every LLM API call costs money and takes hundreds of milliseconds — yet many
+  queries are semantically identical to previous ones (e.g. "What's the
+  capital of France?" and "Tell me the capital of France"). Traditional
+  exact-match caches miss these because small wording changes produce different
+  text. GPTCache solves this with semantic caching: it embeds incoming queries
+  and retrieves cached responses for semantically similar requests. This
+  reduces latency from seconds to milliseconds, cuts API costs by reusing
+  responses, and handles eviction, embedding, and similarity search out of the
+  box. Integrated with LangChain, LlamaIndex, and OpenAI.
+
+use_cases:
+  - Cache LLM responses in a FAQ chatbot so identical or similar questions return instantly without API calls
+  - Reduce API costs in a high-volume application by caching semantically equivalent user queries
+  - Speed up batch data processing pipelines that repeatedly query LLMs with similar prompts
+  - Build a hybrid cache for agentic workflows where tool calls produce repeatable results
+  - Deploy as a sidecar cache layer alongside any OpenAI-compatible API endpoint

--- a/tools/rag/edgequake.yaml
+++ b/tools/rag/edgequake.yaml
@@ -1,0 +1,31 @@
+name: edgequake
+description: EdgeQuake is a high-performance, Rust-native GraphRAG framework that transforms documents into lineage-aware knowledge graphs for superior retrieval and generation. Achieves 10x faster ingestion than Python-based alternatives with six retrieval modes and native PostgreSQL storage.
+tagline: Rust-native GraphRAG — 10x faster ingestion, six retrieval modes
+
+github_url: https://github.com/raphaelmansuy/edgequake
+website_url: https://edgequake.com
+docs_url: https://edgequake.com/docs
+
+category: RAG
+tags: [rag, graphrag, knowledge-graph, rust, high-performance, retrieval, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  GraphRAG pipelines built in Python are slow — document ingestion and
+  knowledge graph construction can take hours for large document sets, making
+  iterative development impractical. EdgeQuake solves this by implementing
+  the entire GraphRAG pipeline in Rust, achieving 10x faster ingestion than
+  Python-based alternatives (LightRAG, etc.). It builds lineage-aware knowledge
+  graphs that track document provenance, supports six retrieval modes (from
+  simple keyword to complex graph traversal), and uses PostgreSQL for mature,
+  production-grade storage. The result is a GraphRAG system that's fast enough
+  for iterative development and robust enough for production.
+
+use_cases:
+  - Ingest hundreds of documents into a knowledge graph in minutes instead of hours for rapid prototyping
+  - Build a lineage-aware RAG system that traces each answer back to its source document and section
+  - Deploy a production GraphRAG pipeline with PostgreSQL persistence, six retrieval modes, and high throughput
+  - Power a knowledge discovery tool that lets users explore document relationships through graph traversal
+  - Replace Python-based GraphRAG with a Rust-native alternative when ingestion speed is a bottleneck

--- a/tools/rag/kag.yaml
+++ b/tools/rag/kag.yaml
@@ -1,0 +1,33 @@
+name: KAG
+description: KAG is a logical form-guided reasoning and retrieval framework based on knowledge graphs and LLMs. Built on Alibaba's OpenSPG engine, it uses bidirectional enhancement between LLMs and knowledge graphs to overcome the ambiguity of traditional vector RAG and the noise of OpenIE-based GraphRAG.
+tagline: Knowledge-augmented generation with logical reasoning
+
+github_url: https://github.com/OpenSPG/KAG
+website_url: https://openspg.alibaba.com
+docs_url: https://openspg.alibaba.com/docs
+
+install_command: pip install openspg-kag
+
+category: RAG
+tags: [rag, knowledge-graph, graphrag, reasoning, knowledge-base, llm, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Traditional RAG performs shallow vector similarity search that misses
+  cross-document logical relationships and struggles with multi-hop reasoning.
+  GraphRAG approaches using OpenIE introduce noise from automatic triple
+  extraction. KAG solves this with a logical form-guided retrieval framework
+  that models document knowledge as structured SPG (Semantic Property Graph)
+  and performs bidirectional enhancement between LLMs and KGs. It supports
+  logical reasoning, multi-hop Q&A, and factual querying over professional
+  domain knowledge bases — achieving significantly higher precision on complex
+  knowledge tasks than both vector RAG and naive GraphRAG.
+
+use_cases:
+  - Build a domain-specific Q&A system over legal, medical, or financial knowledge bases with logical reasoning
+  - Create a knowledge graph-powered RAG pipeline that handles multi-hop questions requiring cross-document inference
+  - Power an enterprise knowledge assistant that answers factual queries with traceable evidence from structured knowledge
+  - Implement a hybrid retrieval system combining vector search with knowledge graph traversal for maximum accuracy
+  - Replace naive vector RAG in scenarios where answer precision and logical consistency are critical


### PR DESCRIPTION
This PR adds 5 new tools to the catalog:

- **KAG** (RAG) — Logical form-guided reasoning and retrieval framework built on Alibaba's OpenSPG. Bidirectional enhancement between LLMs and knowledge graphs. 8,881★ on GitHub.
- **GPTCache** (LLM) — Semantic caching layer for LLM applications that reduces latency and API costs by reusing semantically similar responses. 8,091★ on GitHub.
- **text-extract-api** (Data) — Self-hosted document extraction API converting PDFs, Word, PPTX, and images to structured Markdown/JSON using OCR + LLMs. 3,136★ on GitHub.
- **agentUniverse** (Agents) — Domain-driven multi-agent framework for building production-ready multi-agent applications with reusable patterns. 2,295★ on GitHub.
- **edgequake** (RAG) — High-performance Rust-native GraphRAG framework with 10x faster ingestion and six retrieval modes. 2,031★ on GitHub.

All entries validated locally with `scripts/validate-tool.ts`.
