### PR TITLE
Add Meetily and Open Generative AI to catalog

### DIFF
--- a/tools/other/meetily.yaml
+++ b/tools/other/meetily.yaml
@@ -1,0 +1,26 @@
+name: Meetily
+tagline: Privacy-first AI meeting assistant that runs 100% locally
+description: |-
+  Meetily is a privacy-first AI meeting assistant that captures, transcribes, and summarizes meetings entirely on your local machine. Works 100% offline with local AI models — no cloud dependency, no data leaves your computer. Supports real-time transcription with speaker diarization and AI-powered summaries using Ollama, Claude, Groq, or any OpenAI-compatible endpoint.
+problem_solved: |-
+  Meeting transcription tools typically send audio data to cloud servers, creating privacy and compliance risks for enterprises handling sensitive information. Meetily solves this by running all processing locally — transcription with Whisper/Parakeet and summarization with local LLMs — giving organizations complete data sovereignty without sacrificing accuracy or features.
+github_url: https://github.com/Zackriya-Solutions/meetily
+website_url: https://meetily.ai
+docs_url: https://github.com/Zackriya-Solutions/meetily#readme
+category: Other
+tags:
+  - meeting-assistant
+  - transcription
+  - speech-to-text
+  - privacy-focused
+  - offline-first
+  - rust
+pricing: freemium
+is_open_source: true
+license: MIT
+use_cases:
+  - "Transcribing meetings, interviews, and calls with speaker diarization — 100% local"
+  - "Generating AI meeting summaries with customizable LLM backends including local Ollama models"
+  - "Supporting compliance requirements by keeping all sensitive audio data on-premises"
+  - "Providing real-time captions for virtual meetings across Zoom, Teams, and Google Meet"
+  - "Running meeting intelligence offline without internet access for secure environments"

--- a/tools/other/open-generative-ai.yaml
+++ b/tools/other/open-generative-ai.yaml
@@ -1,0 +1,27 @@
+name: Open Generative AI
+tagline: Unrestricted open-source AI image and video generation studio
+description: |-
+  Open Generative AI is an unrestricted open-source alternative to AI video platforms providing free AI image and video generation with 200+ state-of-the-art models including Flux, Midjourney, Kling, Sora, Seedance, and Veo. No content filters, fully self-hosted, and MIT licensed. Features a unified studio for image, video, audio, lip sync, and motion generation in a single desktop or web application.
+problem_solved: |-
+  Commercial AI image and video platforms impose content filters, subscription fees, and limited model selection that restrict creative freedom and accessibility. Open Generative AI solves this by bundling 200+ state-of-the-art models into a free, open-source application with no content restrictions, supporting both self-hosted desktop use and cloud-hosted access without subscription lock-in.
+github_url: https://github.com/Anil-matcha/Open-Generative-AI
+website_url: https://muapi.ai/open-generative-ai
+docs_url: https://github.com/Anil-matcha/Open-Generative-AI#readme
+install_command: npm install
+category: Other
+tags:
+  - image-generation
+  - video-generation
+  - generative-ai
+  - open-source
+  - multi-model
+  - desktop-app
+pricing: free
+is_open_source: true
+license: MIT
+use_cases:
+  - Generating AI images and videos with 200+ models from a single unified interface
+  - Running unrestricted creative workflows without content filters or censorship
+  - Self-hosting a complete generative AI studio for team or personal use
+  - Experimenting across multiple model families (Flux, Midjourney, Sora, Kling, Veo) in one app
+  - Building automated media generation pipelines with the hosted API or CLI


### PR DESCRIPTION
## Tools added

- **Meetily** (Other) — Privacy-first AI meeting assistant that runs 100% locally. 22,168★ on GitHub, MIT license.
- **Open Generative AI** (Other) — Unrestricted open-source AI image and video generation studio. 22,930★ on GitHub, MIT license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new tool listings with detailed descriptions, links, tags, pricing, and use cases.
  * Included information for an offline, privacy-focused meeting assistant.
  * Added information for an open generative AI application, including install details and project resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->