### PR TITLE
Add Toonflow, SwarmVault, and 53AI Hub to catalog

### DIFF
--- a/tools/other/toonflow.yaml
+++ b/tools/other/toonflow.yaml
@@ -1,0 +1,24 @@
+name: Toonflow
+tagline: Open-source AI tool that turns stories and scripts into animated short dramas
+description: |-
+  Toonflow is an open-source AI short drama creation tool that transforms novels and scripts into animated short dramas. Features AI scriptwriting, intelligent storyboarding, character generation, and video production — all in a cross-platform desktop app. Integrates AI screenwriting, smart shot composition, role creation, and video generation for creators to batch-produce visual content at low cost.
+problem_solved: |-
+  Producing animated short dramas from written content traditionally requires expensive animation teams, complex workflows, and significant time investment. Toonflow solves this with an integrated AI pipeline that handles scriptwriting, storyboarding, character design, and video generation in a single desktop application — enabling independent creators to turn stories into animated content efficiently and affordably.
+github_url: https://github.com/HBAI-Ltd/Toonflow-app
+website_url: https://toonflow.hbai.ai
+category: Other
+tags:
+  - video-generation
+  - animation
+  - ai-content-creation
+  - desktop-app
+  - open-source
+pricing: free
+is_open_source: true
+license: Apache-2.0
+use_cases:
+  - Turning novels and scripts into animated short dramas with AI-generated visuals
+  - Creating storyboards and character designs automatically from written source material
+  - Producing batch video content for social media and short-video platforms
+  - Enabling indie creators to animate stories without professional animation skills
+  - Generating AI-driven animated content with cross-platform desktop deployment

--- a/tools/rag/53ai-hub.yaml
+++ b/tools/rag/53ai-hub.yaml
@@ -1,0 +1,24 @@
+name: 53AI Hub
+tagline: Open-source AI portal and knowledge base for enterprise agent management
+description: |-
+  53AI Hub is an open-source AI portal and knowledge base for managing enterprise knowledge, AI agents, prompts, and AI tools. It seamlessly integrates with Coze, Dify, FastGPT, and RAGFlow, providing a unified interface for deploying AI agents, managing user permissions, organizing prompt libraries, and operating AI tools at scale.
+problem_solved: |-
+  Enterprises deploying AI agents across multiple platforms (Coze, Dify, FastGPT) need a unified management portal for publishing agents, managing prompts, and controlling user access — typically requiring complex custom integrations. 53AI Hub solves this with a ready-to-deploy AI portal that integrates with major agent platforms and provides user management, usage analytics, and permission controls out of the box.
+github_url: https://github.com/53AI/53AIHub
+website_url: https://www.53ai.com/products/53AIHub
+docs_url: https://docs.53ai.com
+category: RAG
+tags:
+  - ai-portal
+  - knowledge-base
+  - agent-management
+  - enterprise
+  - prompt-management
+pricing: freemium
+is_open_source: true
+use_cases:
+  - Deploying an enterprise AI portal that unifies agents from Coze, Dify, FastGPT, and RAGFlow
+  - Managing AI agent publishing, user permissions, and usage analytics in one platform
+  - Building an organizational knowledge base with AI-powered search and retrieval
+  - Operating a prompt library with version control and team-wide sharing
+  - Providing self-service AI tool access to internal teams with SSO integration

--- a/tools/rag/swarmvault.yaml
+++ b/tools/rag/swarmvault.yaml
@@ -1,0 +1,27 @@
+name: SwarmVault
+tagline: Local-first LLM Wiki, knowledge graph builder, and RAG knowledge base for AI agents
+description: |-
+  SwarmVault is a local-first knowledge graph builder and RAG knowledge base that turns docs, code, transcripts, notes, and URLs into a durable markdown wiki plus a queryable knowledge graph. Provides CLI tools for ingestion, compilation, querying, and sharing — designed as an Obsidian alternative for personal knowledge management and durable AI agent memory.
+problem_solved: |-
+  AI agents lack durable, queryable memory and struggle to reference structured knowledge across sessions. SwarmVault solves this by building a local-first markdown wiki and knowledge graph from ingested documents — providing AI agents with persistent, queryable context that outlives individual sessions without relying on cloud services.
+github_url: https://github.com/swarmclawai/swarmvault
+website_url: https://www.swarmvault.ai
+docs_url: https://www.swarmvault.ai/docs
+install_command: npm install -g @swarmvaultai/cli
+category: RAG
+tags:
+  - knowledge-graph
+  - rag
+  - wiki
+  - knowledge-base
+  - cli
+  - agent-memory
+pricing: free
+is_open_source: true
+license: MIT
+use_cases:
+  - Building a local-first knowledge graph from code repos, documentation, and notes
+  - Providing durable, queryable memory for AI coding assistants like Claude Code and Codex
+  - Creating a personal LLM wiki from ingested documents with graph-based navigation
+  - Searching and querying knowledge graphs with natural language from the CLI
+  - Sharing compiled knowledge graphs as shareable markdown cards and visual artifacts


### PR DESCRIPTION
## Tools added

- **Toonflow** (Other) — Open-source AI tool that turns stories and scripts into animated short dramas. 11,290★, Apache-2.0.
- **SwarmVault** (RAG) — Local-first LLM Wiki, knowledge graph builder, and RAG knowledge base for AI agents. 602★, MIT.
- **53AI Hub** (RAG) — Open-source AI portal and knowledge base for enterprise agent management. 4,935★.
