### PR TITLE
Add NebulaGraph, ArangoDB, CrateDB, Dgraph, Memgraph to catalog

### DIFF
--- a/tools/vector-databases/arangodb.yaml
+++ b/tools/vector-databases/arangodb.yaml
@@ -1,0 +1,39 @@
+name: ArangoDB
+description: A native multi-model database combining document, graph, and key-value models with built-in vector search via ArangoSearch. Supports storing and querying vector embeddings alongside traditional data in a single system, ideal for hybrid AI retrieval pipelines.
+tagline: Multi-model database with vector search for hybrid AI retrieval
+
+github_url: https://github.com/arangodb/arangodb
+website_url: https://arangodb.com
+docs_url: https://docs.arangodb.com/
+
+install_command: |-
+  docker run -p 8529:8529 arangodb/arangodb
+
+category: Vector DB
+tags:
+  - multi-model
+  - graph-database
+  - document-database
+  - vector-search
+  - ArangoSearch
+  - AQL
+  - docker
+  - enterprise
+pricing: freemium
+is_open_source: true
+license: NOASSERTION
+
+problem_solved: |
+  AI applications often need to query across different data models —
+  documents for content, graphs for relationships, vectors for semantic
+  similarity — requiring multiple databases. ArangoDB solves this with
+  a single multi-model engine featuring ArangoSearch for vector and
+  full-text search, allowing developers to combine document retrieval,
+  graph traversal, and vector similarity in one query language (AQL).
+
+use_cases:
+  - Build a hybrid search system that combines vector similarity, full-text search, and graph traversal in a single query
+  - Create a unified data layer for AI agents that stores documents, relationships, and embeddings in one database
+  - Implement a recommendation engine using collaborative filtering over graphs combined with semantic vector search
+  - Power a knowledge management application with flexible schema supporting both structured data and embeddings
+  - Develop a geospatial AI application combining location data, document content, and vector similarity

--- a/tools/vector-databases/cratedb.yaml
+++ b/tools/vector-databases/cratedb.yaml
@@ -1,0 +1,39 @@
+name: CrateDB
+description: A distributed SQL database with native vector search for AI-powered analytics and real-time applications. Combines PostgreSQL-compatible queries with full-text search, time-series, and vector embeddings support, all in a horizontally scalable cluster.
+tagline: Distributed SQL database with vector search for real-time AI analytics
+
+github_url: https://github.com/crate/crate
+website_url: https://cratedb.com
+docs_url: https://cratedb.com/docs
+
+install_command: |-
+  docker run --publish=4200:4200 --publish=5432:5432 crate -Cnetwork.host=0.0.0.0
+
+category: Vector DB
+tags:
+  - sql
+  - distributed
+  - vector-search
+  - time-series
+  - full-text-search
+  - postgresql-compatible
+  - real-time
+  - docker
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI applications often need to combine vector similarity search with
+  traditional SQL analytics, time-series data, and full-text search —
+  requiring separate systems that increase complexity. CrateDB solves
+  this by providing a single distributed SQL database that natively
+  supports vector embeddings alongside relational tables, time-series
+  data, and full-text search, all queryable through standard SQL.
+
+use_cases:
+  - Build a real-time AI analytics dashboard combining vector similarity with SQL aggregations on streaming data
+  - Create a hybrid search pipeline that blends semantic vector search with structured SQL filtering and sorting
+  - Implement a time-series monitoring system with vector-based anomaly detection on IoT sensor data
+  - Power a recommendation engine that uses SQL for business logic and vector search for semantic matching
+  - Develop a log analytics platform that searches both log text and embedding vectors in a single query

--- a/tools/vector-databases/dgraph.yaml
+++ b/tools/vector-databases/dgraph.yaml
@@ -1,0 +1,40 @@
+name: Dgraph
+description: A high-performance, distributed graph database with built-in vector search, designed for real-time AI and GraphRAG workloads. Supports GraphQL and DQL for querying graph relationships alongside vector embeddings, making it a powerful engine for knowledge graph-powered AI.
+tagline: High-performance graph database with vector search for real-time GraphRAG
+
+github_url: https://github.com/dgraph-io/dgraph
+website_url: https://dgraph.io
+docs_url: https://dgraph.io/docs
+
+install_command: |-
+  docker run -p 8080:8080 -p 9080:9080 dgraph/standalone:latest
+
+category: Vector DB
+tags:
+  - graph-database
+  - distributed
+  - graphql
+  - vector-search
+  - graph-rag
+  - knowledge-graph
+  - real-time
+  - docker
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Real-time AI applications need low-latency graph queries combined with
+  vector similarity search, but most graph databases either lack vector
+  support or are not designed for high-throughput production workloads.
+  Dgraph solves this with a distributed graph database that natively
+  indexes and searches vector embeddings alongside graph relationships,
+  delivering millisecond-latency queries for GraphRAG and knowledge
+  graph-powered AI at scale.
+
+use_cases:
+  - Build a real-time GraphRAG system that queries both graph relationships and vector similarity in milliseconds
+  - Create a knowledge graph for AI agents with native support for semantic search over entity embeddings
+  - Implement a fraud detection platform analyzing relationship patterns and entity similarity simultaneously
+  - Power a recommendation engine using GraphQL queries that mix graph traversal with vector search results
+  - Develop a social network analysis tool that combines connection graphs with content-based semantic search

--- a/tools/vector-databases/memgraph.yaml
+++ b/tools/vector-databases/memgraph.yaml
@@ -1,0 +1,39 @@
+name: Memgraph
+description: An in-memory graph database optimized for real-time AI, GraphRAG, agentic memory, and graph analytics. Combines Cypher query language with vector search support, enabling ultra-low-latency graph traversal and semantic similarity in a single platform.
+tagline: In-memory graph database for real-time AI, GraphRAG, and agentic memory
+
+github_url: https://github.com/memgraph/memgraph
+website_url: https://memgraph.com
+docs_url: https://memgraph.com/docs
+
+install_command: |-
+  docker run -p 7687:7687 memgraph/memgraph-platform:latest
+
+category: Vector DB
+tags:
+  - graph-database
+  - in-memory
+  - vector-search
+  - graph-rag
+  - cypher
+  - real-time
+  - streaming
+  - docker
+pricing: freemium
+is_open_source: true
+license: NOASSERTION
+
+problem_solved: |
+  AI agents and real-time applications need sub-millisecond graph queries
+  combined with vector search, but traditional disk-based graph databases
+  cannot deliver the low latency required for interactive AI experiences.
+  Memgraph solves this with an in-memory graph engine featuring vector
+  search support, Cypher query compatibility, and streaming data ingestion
+  for real-time GraphRAG and agentic memory applications.
+
+use_cases:
+  - Build an agentic memory layer that stores agent experiences as a graph with vector-searchable semantic context
+  - Create a real-time GraphRAG pipeline that ingests streaming data and performs sub-millisecond semantic graph queries
+  - Implement a fraud detection system analyzing transaction patterns in real time with graph traversal and similarity search
+  - Power a conversational AI with an in-memory knowledge graph that tracks conversation state and entity relationships
+  - Develop a recommendation engine that delivers instant results by combining in-memory graph access with vector similarity

--- a/tools/vector-databases/nebulagraph.yaml
+++ b/tools/vector-databases/nebulagraph.yaml
@@ -1,0 +1,38 @@
+name: NebulaGraph
+description: A distributed, horizontally scalable graph database with vector search capabilities for AI applications. Designed for large-scale graph workloads with native support for similarity search on embeddings, enabling GraphRAG and knowledge graph-powered AI systems.
+tagline: Distributed graph database with vector search for GraphRAG at scale
+
+github_url: https://github.com/vesoft-inc/nebula
+website_url: https://www.nebula-graph.io/
+docs_url: https://docs.nebula-graph.io/
+
+install_command: |-
+  docker run -it vesoft/nebula-graph
+
+category: Vector DB
+tags:
+  - graph-database
+  - distributed
+  - vector-search
+  - graph-rag
+  - knowledge-graph
+  - nGQL
+  - docker
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Traditional vector databases treat all data points as independent vectors,
+  losing the rich relationships between entities in AI applications.
+  NebulaGraph solves this by combining a distributed graph database with
+  vector search, enabling GraphRAG architectures that traverse both
+  semantic similarity and graph relationships at scale across billions
+  of nodes and edges.
+
+use_cases:
+  - Build a large-scale GraphRAG system that traverses entity relationships across billions of nodes
+  - Implement a fraud detection pipeline that analyzes transaction graphs alongside semantic entity similarity
+  - Power a recommendation engine combining collaborative filtering with graph traversal and vector embeddings
+  - Create a knowledge graph memory layer for LLM agents that supports both relationship and similarity queries
+  - Build an enterprise knowledge management system with distributed graph storage and semantic search


### PR DESCRIPTION
Adds five graph databases with vector search capabilities to the Vector DB category:

- **NebulaGraph** — Distributed graph database (12.2k★) with vector search for GraphRAG at scale
- **ArangoDB** — Multi-model database (14.2k★) with ArangoSearch for hybrid AI retrieval
- **CrateDB** — Distributed SQL database (4.4k★) with native vector search and full-text search
- **Dgraph** — High-performance graph database (21.7k★) with built-in vector search and GraphQL
- **Memgraph** — In-memory graph database (4.2k★) optimized for real-time AI, GraphRAG, and agentic memory

All five are well-established, active open-source projects with strong communities and vector search capabilities essential for modern AI/GraphRAG workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ArangoDB, CrateDB, Dgraph, Memgraph, and NebulaGraph to the vector database catalog.
  * Included descriptions, tags, licensing and pricing details, documentation links, and practical use cases.
  * Added Docker-based installation commands for each database.
  * Highlighted support for vector search, graph workloads, GraphRAG, hybrid SQL, and knowledge graph applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->