### PR TITLE
Add JanusGraph, Manticore Search, MariaDB, SDV, Metaflow to catalog

### DIFF
--- a/tools/data/metaflow.yaml
+++ b/tools/data/metaflow.yaml
@@ -1,0 +1,39 @@
+name: Metaflow
+description: A human-centric framework for building, deploying, and managing real-world AI and ML systems. Created by Netflix, it simplifies the entire ML lifecycle — from prototyping and data processing to training, deployment, and monitoring — with a focus on developer productivity.
+tagline: ML lifecycle framework for building and deploying real-world AI systems
+
+github_url: https://github.com/Netflix/metaflow
+website_url: https://metaflow.org
+docs_url: https://docs.metaflow.org
+
+install_command: pip install metaflow
+
+category: Data
+tags:
+  - mlops
+  - pipeline
+  - workflow
+  - ai
+  - machine-learning
+  - python
+  - cloud
+  - netflix
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Taking an ML model from a Jupyter notebook to a production system
+  requires orchestration, data pipelines, versioning, and cloud
+  infrastructure — each requiring separate tools and engineering effort.
+  Metaflow solves this with a unified framework that lets data scientists
+  and ML engineers express their entire ML workflow in Python, from data
+  loading and processing to model training and deployment, with built-in
+  versioning, cloud execution, and observability.
+
+use_cases:
+  - Build an end-to-end ML pipeline from data ingestion through model training and deployment in a single Python script
+  - Orchestrate parallel data processing steps for large-scale AI training datasets with automatic version tracking
+  - Deploy ML training workflows to AWS or Kubernetes without managing infrastructure directly
+  - Implement experiment tracking and model lineage across hundreds of training runs with automatic artifact storage
+  - Create a reproducible ML research workflow that data scientists can run locally and then scale to the cloud

--- a/tools/data/sdv.yaml
+++ b/tools/data/sdv.yaml
@@ -1,0 +1,38 @@
+name: SDV
+description: A synthetic data generation library for creating high-quality, privacy-preserving tabular, relational, and time-series data. Uses deep learning models to learn the statistical patterns of real datasets and generate synthetic copies for testing, development, and AI training.
+tagline: Synthetic data generation for tabular, relational, and time-series data
+
+github_url: https://github.com/sdv-dev/SDV
+website_url: https://sdv.dev
+docs_url: https://docs.sdv.dev
+
+install_command: pip install sdv
+
+category: Data
+tags:
+  - synthetic-data
+  - data-generation
+  - privacy
+  - time-series
+  - tabular-data
+  - deep-learning
+  - python
+pricing: free
+is_open_source: true
+license: NOASSERTION
+
+problem_solved: |
+  Building AI applications requires large, representative datasets, but
+  real production data often contains sensitive information — PII, PHI,
+  financial records — that cannot be shared with developers or used in
+  testing. SDV solves this by learning the statistical patterns of real
+  data and generating synthetic copies that preserve relationships and
+  distributions without exposing actual records, enabling safe data
+  sharing for testing, development, and AI model training.
+
+use_cases:
+  - Generate synthetic tabular data for testing machine learning pipelines without exposing customer PII
+  - Create privacy-preserving synthetic datasets that match the statistical distribution of production data
+  - Build synthetic time-series data for developing and validating forecasting models
+  - Supplement small real datasets with synthetic data to improve AI model training and reduce overfitting
+  - Generate relational synthetic data that preserves multi-table relationships for database application testing

--- a/tools/vector-databases/janusgraph.yaml
+++ b/tools/vector-databases/janusgraph.yaml
@@ -1,0 +1,39 @@
+name: JanusGraph
+description: An open-source, distributed graph database optimized for storing and querying large-scale graph data with billions of vertices and edges. Supports integration with multiple storage backends and indexing systems, enabling GraphRAG and AI applications that need scalable graph traversal.
+tagline: Distributed graph database for large-scale graph analytics and AI
+
+github_url: https://github.com/janusgraph/janusgraph
+website_url: https://janusgraph.org
+docs_url: https://docs.janusgraph.org
+
+install_command: |-
+  docker run -p 8182:8182 janusgraph/janusgraph:latest
+
+category: Vector DB
+tags:
+  - graph-database
+  - distributed
+  - big-data
+  - knowledge-graph
+  - gremlin
+  - graph-rag
+  - docker
+pricing: freemium
+is_open_source: true
+license: NOASSERTION
+
+problem_solved: |
+  Building AI applications that need to traverse graph relationships at
+  scale often hits a wall with single-node graph databases that cannot
+  handle billions of edges. JanusGraph solves this with a distributed
+  graph database designed for extreme scale — billions of vertices and
+  edges across multi-datacenter clusters — with pluggable storage
+  backends (Cassandra, HBase, Bigtable) and indexing systems (Elasticsearch,
+  Solr) for hybrid graph-vector search.
+
+use_cases:
+  - Build a large-scale knowledge graph for GraphRAG over billions of entity relationships
+  - Implement a fraud detection system analyzing connection patterns across a global transaction graph
+  - Create a distributed graph architecture that stores and queries AI agent interaction histories at scale
+  - Power a supply chain analytics platform with graph traversal across millions of interconnected suppliers
+  - Develop an entity resolution system linking records across large datasets using graph traversal

--- a/tools/vector-databases/manticore-search.yaml
+++ b/tools/vector-databases/manticore-search.yaml
@@ -1,0 +1,39 @@
+name: Manticore Search
+description: An open-source search database that combines full-text search, vector search, and hybrid search in a single SQL-based system. Built for real-time indexing and low-latency queries, it serves as a drop-in replacement for Elasticsearch with reduced resource usage.
+tagline: Open-source search database with full-text, vector, and hybrid search
+
+github_url: https://github.com/manticoresoftware/manticoresearch
+website_url: https://manticoresearch.com
+docs_url: https://manual.manticoresearch.com
+
+install_command: |-
+  docker run -p 9306:9306 -p 9308:9308 manticoresearch/manticore
+
+category: Vector DB
+tags:
+  - search-database
+  - full-text-search
+  - vector-search
+  - hybrid-search
+  - sql
+  - real-time
+  - elasticsearch-alternative
+  - docker
+pricing: freemium
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Many AI applications need both full-text and vector search, requiring
+  separate systems like Elasticsearch for text and Pinecone for vectors,
+  increasing operational complexity. Manticore Search solves this by
+  combining full-text, vector, and hybrid search in a single SQL-based
+  database with real-time indexing — delivering Elasticsearch-style
+  capabilities with lower resource usage and simpler deployment.
+
+use_cases:
+  - Build a hybrid search engine that blends BM25 full-text ranking with vector similarity scores
+  - Create a real-time product catalog with semantic search that updates as inventory changes
+  - Implement a log analysis platform that searches both text patterns and embedding vectors in one query
+  - Power a recommendation system combining keyword matching with semantic similarity for content discovery
+  - Develop a document search application with full-text precision, vector-based fuzzy matching, and SQL filtering

--- a/tools/vector-databases/mariadb.yaml
+++ b/tools/vector-databases/mariadb.yaml
@@ -1,0 +1,39 @@
+name: MariaDB
+description: A community-developed relational database forked from MySQL with native vector search support. Combines proven relational storage with VECTOR data type and vector index capabilities, enabling hybrid SQL-and-similarity queries on a single database platform.
+tagline: Enterprise relational database with native vector search support
+
+github_url: https://github.com/MariaDB/server
+website_url: https://mariadb.com
+docs_url: https://mariadb.com/docs
+
+install_command: |-
+  docker run -p 3306:3306 mariadb:latest
+
+category: Vector DB
+tags:
+  - sql
+  - relational-database
+  - vector-search
+  - mysql-compatible
+  - hybrid-search
+  - enterprise
+  - docker
+pricing: freemium
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Adding vector search to an existing application usually means
+  introducing a separate vector database alongside the relational
+  database, adding sync complexity and operational overhead. MariaDB
+  solves this by embedding vector search directly into a battle-tested
+  relational database — with VECTOR data type and vector indexes —
+  so developers can run SQL queries with vector similarity in the
+  same database that stores their application data.
+
+use_cases:
+  - Add semantic search to an existing MariaDB-backed application without introducing a separate vector database
+  - Build a hybrid SQL-and-similarity query system for e-commerce that filters by category then ranks by vector similarity
+  - Implement a recommendation engine that uses SQL for user demographics and vector search for product matching
+  - Create a content management system with both structured metadata queries and embedding-based content discovery
+  - Power a customer-facing search that combines relational filtering with vector-based relevance ranking


### PR DESCRIPTION
Adds five tools to the catalog:

- **JanusGraph** — Distributed graph database (5.8k★) for large-scale graph analytics and AI
- **Manticore Search** — Open-source search database (11.9k★) with full-text, vector, and hybrid search
- **MariaDB** — Enterprise relational database (7.8k★) with native vector search support
- **SDV** — Synthetic data generation library (3.5k★) for privacy-preserving AI training data
- **Metaflow** — ML lifecycle framework (10.2k★) by Netflix for building real-world ML systems
