### PR TITLE
Add Kedro, CVAT, Apache Pulsar, NATS, Pachyderm to catalog

### DIFF
--- a/tools/data/apache-pulsar.yaml
+++ b/tools/data/apache-pulsar.yaml
@@ -1,0 +1,40 @@
+name: Apache Pulsar
+description: A distributed pub-sub messaging system for real-time data streaming and event-driven AI workflows. Designed for high-throughput, low-latency message delivery with multi-tenancy, geo-replication, and tiered storage for large-scale data pipelines.
+tagline: Distributed pub-sub messaging for real-time AI data streaming
+
+github_url: https://github.com/apache/pulsar
+website_url: https://pulsar.apache.org
+docs_url: https://pulsar.apache.org/docs
+
+install_command: |-
+  docker run -p 6650:6650 -p 8080:8080 apachepulsar/pulsar:latest bin/pulsar standalone
+
+category: Data
+tags:
+  - messaging
+  - streaming
+  - pub-sub
+  - real-time
+  - event-driven
+  - data-pipeline
+  - distributed
+  - docker
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI applications that need to process data in real time often struggle
+  with unreliable message delivery, limited throughput, and complex
+  cluster management. Apache Pulsar solves this with a cloud-native
+  pub-sub messaging system designed for high-throughput, low-latency
+  streaming — featuring multi-tenancy, geo-replication, tiered storage,
+  and exactly-once semantics for building reliable event-driven AI
+  data pipelines at scale.
+
+use_cases:
+  - Build a real-time data ingestion pipeline that streams raw data to AI inference services
+  - Create an event-driven ML architecture where model retraining triggers on data arrival events
+  - Implement a multi-tenant streaming platform that serves separate data pipelines for different AI teams
+  - Power a geo-distributed AI application with cross-region message replication and failover
+  - Stream feature data from production to training infrastructure with exactly-once delivery guarantees

--- a/tools/data/cvat.yaml
+++ b/tools/data/cvat.yaml
@@ -1,0 +1,40 @@
+name: CVAT
+description: A leading open-source platform for building high-quality visual datasets through computer vision annotation. Supports image and video annotation with AI-assisted labeling, automated annotation with model integration, and team collaboration workflows.
+tagline: Open-source computer vision annotation tool for AI training data
+
+github_url: https://github.com/openvinotoolkit/cvat
+website_url: https://www.cvat.ai
+docs_url: https://docs.cvat.ai
+
+install_command: |-
+  docker compose -f docker-compose.yml up -d
+
+category: Data
+tags:
+  - annotation
+  - computer-vision
+  - data-labeling
+  - training-data
+  - image-annotation
+  - video-annotation
+  - docker
+  - team-collaboration
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Building computer vision AI models requires large, accurately labeled
+  datasets, but manual annotation is slow and inconsistent across team
+  members. CVAT solves this with a web-based annotation platform that
+  supports images, video, and 3D data — with AI-assisted labeling,
+  automated annotation via model integration, quality control workflows,
+  and team collaboration features that dramatically speed up dataset
+  creation.
+
+use_cases:
+  - Label a large image dataset for training a custom object detection model with AI-assisted annotation
+  - Annotate video frames for action recognition with automated interpolation between keyframes
+  - Build a team data labeling pipeline with role-based access, review workflows, and quality tracking
+  - Create a semantic segmentation dataset using automated segmentation model suggestions
+  - Develop a training data pipeline that integrates CVAT with model training for active learning loops

--- a/tools/data/kedro.yaml
+++ b/tools/data/kedro.yaml
@@ -1,0 +1,39 @@
+name: Kedro
+description: A toolbox for production-ready data science that applies software engineering best practices to machine learning pipelines. Provides a modular, versioned, and reproducible framework for building data pipelines that scale from prototype to production.
+tagline: Production-ready data science with modular, versioned ML pipelines
+
+github_url: https://github.com/kedro-org/kedro
+website_url: https://kedro.org
+docs_url: https://docs.kedro.org
+
+install_command: pip install kedro
+
+category: Data
+tags:
+  - pipeline
+  - data-science
+  - mlops
+  - workflow
+  - versioning
+  - python
+  - reproducibility
+  - production
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Data science projects often start as exploratory notebooks that are
+  difficult to productionize — tangled code, no versioning, and manual
+  data handoffs between steps. Kedro solves this by providing a
+  framework that enforces modular pipeline architecture, automatic
+  data cataloging, parameter configuration, and pipeline versioning —
+  letting data scientists write production-ready code from day one
+  without becoming software engineers.
+
+use_cases:
+  - Build a modular, versioned data pipeline for training AI models with automatic data cataloging
+  - Create reproducible ML experiments with parameterized pipelines that track data lineage across runs
+  - Deploy a production data science workflow that runs in CI/CD with automated testing and validation
+  - Implement a data transformation pipeline that loads from multiple sources, processes, and serves to ML models
+  - Structure a team data science project with consistent conventions for code, data, and configuration management

--- a/tools/data/nats.yaml
+++ b/tools/data/nats.yaml
@@ -1,0 +1,40 @@
+name: NATS
+description: A high-performance cloud and edge native messaging system for distributed data streaming and microservice communication. Designed for lightweight, secure, and resilient data exchange across AI and ML infrastructure with support for pub-sub, request-reply, and stream processing.
+tagline: Cloud-native messaging system for distributed AI data streaming
+
+github_url: https://github.com/nats-io/nats-server
+website_url: https://nats.io
+docs_url: https://docs.nats.io
+
+install_command: |-
+  docker run -p 4222:4222 nats:latest
+
+category: Data
+tags:
+  - messaging
+  - streaming
+  - pub-sub
+  - microservices
+  - edge
+  - cloud-native
+  - lightweight
+  - docker
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Distributing data across AI infrastructure — from edge devices to
+  cloud GPUs — requires a messaging system that is lightweight enough
+  for resource-constrained devices yet powerful enough for data-center
+  clusters. NATS solves this with a high-performance messaging layer
+  designed for cloud and edge environments, supporting pub-sub,
+  request-reply, and JetStream for persistent streaming — all with
+  sub-millisecond latency and minimal resource overhead.
+
+use_cases:
+  - Distribute inference requests across a fleet of GPU workers with NATS request-reply load balancing
+  - Stream sensor data from edge devices to a central AI training cluster with lightweight pub-sub
+  - Build an event-driven AI pipeline where model serving and data processing communicate via NATS
+  - Create a resilient microservice mesh for ML infrastructure with automatic reconnection and clustering
+  - Implement a real-time model monitoring system that streams metrics from production to observability dashboards

--- a/tools/data/pachyderm.yaml
+++ b/tools/data/pachyderm.yaml
@@ -1,0 +1,40 @@
+name: Pachyderm
+description: A data versioning and pipeline platform that provides data-centric reproducible ML workflows. Combines data lineage tracking with automated pipeline execution, enabling teams to build, test, and deploy data-driven AI applications with Git-like version control for datasets.
+tagline: Data versioning and pipelines for reproducible ML workflows
+
+github_url: https://github.com/pachyderm/pachyderm
+website_url: https://pachyderm.com
+docs_url: https://docs.pachyderm.com
+
+install_command: |-
+  brew install pachyderm/tap/pachctl
+
+category: Data
+tags:
+  - data-versioning
+  - pipeline
+  - mlops
+  - reproducibility
+  - data-lineage
+  - kubernetes
+  - docker
+  - enterprise
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Machine learning pipelines lack the data versioning and lineage
+  guarantees that source code has with Git — making it impossible to
+  reproduce historical training runs or trace model performance changes
+  to specific data changes. Pachyderm solves this with data-centric
+  version control and automated pipelines that track every data commit,
+  trigger pipeline stages on data changes, and provide complete lineage
+  from raw data to model output.
+
+use_cases:
+  - Version control large datasets with Git-like commits for reproducible ML model training
+  - Build an automated data pipeline that retrains models automatically when source data changes
+  - Create a data lineage audit trail that tracks every transformation from raw data to model prediction
+  - Implement a CI/CD pipeline for ML that tests model accuracy against versioned data snapshots
+  - Power a team data science platform where multiple teams work on versioned datasets without conflicts


### PR DESCRIPTION
Adds five data tools to the catalog:

- **Kedro** — Production-ready data science framework (10.9k★) with modular, versioned ML pipelines
- **CVAT** — Leading CV annotation platform (16.3k★) for building high-quality visual AI training datasets
- **Apache Pulsar** — Distributed pub-sub messaging (15.3k★) for real-time AI data streaming
- **NATS** — Cloud-native messaging system (20.2k★) for edge-to-cloud AI infrastructure
- **Pachyderm** — Data versioning and pipeline platform (6.3k★) for reproducible ML workflows
