### PR TITLE
Add RamaLama, Apache TVM, DeepChecks, NannyML, Polyaxon to catalog

### DIFF
--- a/tools/dev-tools/apache-tvm.yaml
+++ b/tools/dev-tools/apache-tvm.yaml
@@ -1,0 +1,39 @@
+name: Apache TVM
+description: An open-source machine learning compiler framework for optimizing AI models across diverse hardware backends. Compiles models from TensorFlow, PyTorch, and ONNX into optimized code for CPUs, GPUs, and specialized accelerators.
+tagline: ML compiler framework for optimizing AI models on any hardware
+
+github_url: https://github.com/apache/tvm
+website_url: https://tvm.apache.org
+docs_url: https://tvm.apache.org/docs
+
+install_command: pip install apache-tvm
+
+category: Dev Tools
+tags:
+  - compiler
+  - optimization
+  - inference
+  - hardware-acceleration
+  - tensorflow
+  - pytorch
+  - onnx
+  - gpu
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Deploying AI models across different hardware — from cloud GPUs to
+  edge CPUs — requires manual optimization for each target, creating a
+  maintenance burden as hardware evolves. Apache TVM solves this with an
+  ML compiler framework that automatically optimizes models from any
+  framework (TensorFlow, PyTorch, ONNX) for any target hardware (CPU,
+  GPU, NPU, FPGA), delivering production-ready inference performance
+  without hardware-specific manual tuning.
+
+use_cases:
+  - Optimize a PyTorch model for deployment on edge devices with limited compute resources
+  - Compile a TensorFlow model for maximum inference throughput on a specific GPU architecture
+  - Deploy a single AI model across heterogeneous hardware — cloud GPU servers and edge devices
+  - Reduce model inference latency by automatically applying graph optimizations and operator fusion
+  - Build a hardware-agnostic AI deployment pipeline that targets CPUs, GPUs, and NPUs from the same model

--- a/tools/dev-tools/ramalama.yaml
+++ b/tools/dev-tools/ramalama.yaml
@@ -1,0 +1,37 @@
+name: RamaLama
+description: An open-source developer tool for running AI models locally from any source. Simplifies model serving by downloading, managing, and running models from HuggingFace, Ollama, OCI registries, and other sources with a single command.
+tagline: Run AI models locally from any source with a single command
+
+github_url: https://github.com/containers/ramalama
+website_url: https://ramalama.ai
+docs_url: https://github.com/containers/ramalama#readme
+
+install_command: brew install ramalama
+
+category: Dev Tools
+tags:
+  - local-ai
+  - model-serving
+  - inference
+  - containers
+  - developer-tools
+  - cli
+  - open-source
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Running AI models locally is complex — different models come from
+  different sources (HuggingFace, Ollama, OCI registries) with different
+  download and serving methods, making it hard to standardize local
+  development. RamaLama solves this by providing a single CLI that
+  downloads, manages, and serves models from any source with consistent
+  commands — using container-based isolation to keep the host clean.
+
+use_cases:
+  - Run an LLM locally for development and testing without managing model downloads and dependencies
+  - Serve models from HuggingFace, Ollama, or OCI registries with the same CLI interface
+  - Quickly prototype AI features by spinning up local model endpoints during development
+  - Manage multiple local AI models with version tracking and easy switching between model variants
+  - Set up a consistent local AI development environment across a team with containerized model serving

--- a/tools/monitoring/deepchecks.yaml
+++ b/tools/monitoring/deepchecks.yaml
@@ -1,0 +1,38 @@
+name: DeepChecks
+description: An open-source framework for continuous validation of machine learning models, data, and pipelines. Provides automated testing suites for data quality, model performance, drift detection, and bias evaluation throughout the ML lifecycle.
+tagline: Continuous validation framework for ML models, data, and pipelines
+
+github_url: https://github.com/deepchecks/deepchecks
+website_url: https://deepchecks.com
+docs_url: https://docs.deepchecks.com
+
+install_command: pip install deepchecks
+
+category: Monitoring
+tags:
+  - validation
+  - testing
+  - data-quality
+  - drift-detection
+  - model-monitoring
+  - bias-detection
+  - python
+  - ci-cd
+pricing: freemium
+is_open_source: true
+license: NOASSERTION
+
+problem_solved: |
+  ML models degrade silently in production — data drift, label drift,
+  and feature distribution changes can go undetected until users report
+  problems. DeepChecks solves this by providing automated testing suites
+  that validate data quality, monitor model performance, detect drift,
+  and evaluate bias — integrated into CI/CD pipelines and production
+  monitoring systems from a single Python library.
+
+use_cases:
+  - Automatically validate data quality before training with a comprehensive data integrity test suite
+  - Monitor production models for feature drift and data drift with automated alerting on distribution shifts
+  - Integrate ML model validation into CI/CD pipelines to catch regressions before deployment
+  - Detect bias in model predictions across demographic groups with fairness evaluation metrics
+  - Compare training and serving data distributions to detect training-serving skew before it impacts users

--- a/tools/monitoring/nannyml.yaml
+++ b/tools/monitoring/nannyml.yaml
@@ -1,0 +1,38 @@
+name: NannyML
+description: A post-deployment data science library for monitoring ML model performance without ground truth labels. Uses confidence-based performance estimation and drift detection to alert on model degradation the moment it starts, enabling proactive ML operations.
+tagline: Post-deployment ML monitoring without ground truth labels
+
+github_url: https://github.com/NannyML/nannyml
+website_url: https://www.nannyml.com
+docs_url: https://docs.nannyml.com
+
+install_command: pip install nannyml
+
+category: Monitoring
+tags:
+  - model-monitoring
+  - drift-detection
+  - performance-estimation
+  - mlops
+  - python
+  - data-science
+  - post-deployment
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Monitoring ML model performance in production typically requires ground
+  truth labels, which are often delayed by days or weeks — meaning model
+  degradation goes undetected until it is too late. NannyML solves this
+  with confidence-based performance estimation (CBPE) that estimates
+  model performance without needing ground truth, combined with data
+  drift detection that alerts on distribution shifts the moment they
+  occur.
+
+use_cases:
+  - Monitor production ML model accuracy in real time without waiting for ground truth labels to arrive
+  - Alert on data drift and model degradation automatically with confidence-based performance estimates
+  - Implement a proactive ML monitoring system that detects issues before they impact business metrics
+  - Track model performance across segments to identify which customer groups are affected by drift
+  - Build a monitoring dashboard that combines drift detection with estimated performance metrics for ops teams

--- a/tools/other/polyaxon.yaml
+++ b/tools/other/polyaxon.yaml
@@ -1,0 +1,39 @@
+name: Polyaxon
+description: An open-source AI orchestration and infrastructure platform for managing the full ML lifecycle. Provides a control plane for experiment tracking, hyperparameter tuning, distributed training, model registry, and pipeline automation across any infrastructure.
+tagline: AI orchestration platform for the full ML lifecycle
+
+github_url: https://github.com/polyaxon/polyaxon
+website_url: https://polyaxon.com
+docs_url: https://docs.polyaxon.com
+
+install_command: pip install polyaxon
+
+category: Other
+tags:
+  - orchestration
+  - mlops
+  - experiment-tracking
+  - hyperparameter-tuning
+  - distributed-training
+  - kubernetes
+  - python
+  - enterprise
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Managing the full ML lifecycle — from experiment tracking and
+  hyperparameter tuning to distributed training and model deployment —
+  typically requires stitching together multiple tools. Polyaxon solves
+  this with a unified orchestration platform that provides a central
+  control plane for experiment management, automated hyperparameter
+  search, distributed training on Kubernetes, model versioning, and
+  pipeline automation in a single deployable system.
+
+use_cases:
+  - Track and compare thousands of ML experiments with automatic logging of hyperparameters and metrics
+  - Run distributed hyperparameter optimization across multiple GPU nodes with automated scheduling
+  - Orchestrate distributed training of large models across a Kubernetes cluster with fault tolerance
+  - Build a model registry that versions, tags, and deploys model artifacts across staging and production
+  - Create automated ML pipelines that run experiment sweeps, evaluate results, and promote best models


### PR DESCRIPTION
Adds five tools to the catalog:

- **RamaLama** — Run AI models locally from any source (2.9k★) with a simple CLI
- **Apache TVM** — Open ML compiler framework (13.6k★) for optimizing AI models on any hardware
- **DeepChecks** — Continuous ML validation framework (4k★) for data quality and drift detection
- **NannyML** — Post-deployment ML monitoring (2.1k★) without requiring ground truth labels
- **Polyaxon** — AI orchestration platform (3.7k★) for the full ML lifecycle
