### PR TITLE
Add MONAI, Valohai to catalog

### DIFF
--- a/tools/other/monai.yaml
+++ b/tools/other/monai.yaml
@@ -1,0 +1,39 @@
+name: MONAI
+description: An open-source AI toolkit for healthcare imaging from NVIDIA and King's College London. Provides deep learning primitives and workflows for medical image analysis, including segmentation, classification, and detection with pre-trained models.
+tagline: AI toolkit for healthcare imaging research and clinical AI
+
+github_url: https://github.com/Project-MONAI/MONAI
+website_url: https://monai.io
+docs_url: https://docs.monai.io
+
+install_command: pip install monai
+
+category: Other
+tags:
+  - healthcare
+  - medical-imaging
+  - deep-learning
+  - pytorch
+  - computer-vision
+  - segmentation
+  - nvidia
+  - python
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building AI models for medical imaging requires specialized deep
+  learning primitives — for volumetric data, multi-modal images, and
+  clinical data formats — that general-purpose frameworks lack. MONAI
+  solves this with a PyTorch-based framework purpose-built for healthcare
+  AI, providing domain-specific data loaders, transformation pipelines,
+  network architectures, evaluation metrics, and pre-trained models for
+  medical image analysis.
+
+use_cases:
+  - Train a 3D segmentation model for organ or tumor delineation from CT and MRI scans
+  - Build a medical image classification pipeline for pathology detection with pre-trained backbone models
+  - Create a multi-modal AI system that combines radiology images with clinical text data
+  - Develop a federated learning workflow for healthcare AI training across multiple hospital sites
+  - Implement a clinical AI pipeline with DICOM data loading, volumetric transformations, and 3D inference

--- a/tools/other/valohai.yaml
+++ b/tools/other/valohai.yaml
@@ -1,0 +1,35 @@
+name: Valohai
+description: An MLOps platform for managing LLM and specialized model workflows at scale. Provides experiment tracking, pipeline orchestration, model evaluation, and deployment across cloud and on-premise infrastructure with a focus on reproducibility and team collaboration.
+tagline: MLOps platform for LLMs and specialized model pipelines
+
+website_url: https://valohai.com
+docs_url: https://docs.valohai.com
+
+category: Other
+tags:
+  - mlops
+  - experiment-tracking
+  - pipeline-orchestration
+  - model-deployment
+  - collaboration
+  - enterprise
+  - cloud
+pricing: paid
+is_open_source: false
+license: NOASSERTION
+
+problem_solved: |
+  Managing ML workflows across a team — from experiment tracking and
+  pipeline automation to model deployment — requires infrastructure that
+  data scientists can use without DevOps expertise. Valohai solves this
+  with a managed MLOps platform that automates experiment orchestration,
+  tracks model versions and metrics, evaluates LLM outputs, and deploys
+  models across any infrastructure — with built-in reproducibility and
+  team collaboration features.
+
+use_cases:
+  - Orchestrate ML training pipelines across cloud GPUs with automatic experiment tracking and versioning
+  - Compare and evaluate LLM outputs across different model configurations against real data
+  - Build a team ML workflow with shared experiment dashboards, model registries, and deployment pipelines
+  - Automate model retraining pipelines that trigger on new data and deploy updated models automatically
+  - Manage ML infrastructure across cloud and on-premise environments from a single control plane


### PR DESCRIPTION
Adds two tools to the catalog:

- **MONAI** — AI toolkit for healthcare imaging (8.4k★) from NVIDIA for medical image analysis
- **Valohai** — MLOps platform for managing LLM and specialized model pipelines at scale
