### PR TITLE
Add BabyAGI, TaskingAI, Playwright MCP, Dust, Screenpipe to catalog

### DIFF
--- a/tools/agent-frameworks/babyagi.yaml
+++ b/tools/agent-frameworks/babyagi.yaml
@@ -1,0 +1,25 @@
+name: BabyAGI
+description: Experimental framework for self-building autonomous agents that can construct, manage, and execute their own functions and workflows at runtime.
+tagline: A self-building autonomous agent framework that writes its own functions
+
+github_url: https://github.com/yoheinakajima/babyagi
+website_url: https://babyagi.org
+docs_url: https://github.com/yoheinakajima/babyagi#readme
+
+install_command: pip install babyagi
+
+category: Agents
+tags: [python, agents, autonomous, experimental, function-framework, task-planning, self-improving]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Traditional agent frameworks require developers to pre-define every function and workflow step, limiting adaptability in dynamic environments. BabyAGI introduces a self-building architecture where the agent can create, register, and manage its own functions at runtime through a graph-based dependency system. Functions are stored in a database with metadata tracking imports, dependencies, and authentication, enabling the agent to dynamically compose new capabilities without manual coding. This shifts agent development from exhaustive pre-planning to emergent behavior where the agent expands its own toolkit based on task requirements.
+
+use_cases:
+  - Build autonomous research agents that discover new data sources and create extraction functions without manual coding
+  - Create self-improving coding agents that can add new analysis capabilities by generating and registering functions at runtime
+  - Prototype experimental agent architectures that need dynamic function composition and dependency tracking
+  - Develop educational platforms where students build agents that learn and extend their own capabilities
+  - Explore emergent agent behaviors through a framework designed for self-modification and growth

--- a/tools/agent-frameworks/dust.yaml
+++ b/tools/agent-frameworks/dust.yaml
@@ -1,0 +1,23 @@
+name: Dust
+description: Custom AI agent platform that lets teams build, deploy, and scale custom AI agents in a collaborative workspace. Supports integration with hundreds of LLMs, custom tools, data sources, and retrieval-augmented generation pipelines for production-grade automation.
+tagline: Build and deploy custom AI agents that do real work for your team
+
+github_url: https://github.com/dust-tt/dust
+website_url: https://dust.tt
+docs_url: https://docs.dust.tt
+
+category: Agents
+tags: [agents, llm, platform, collaboration, automation, workspace, rag, tools, rust]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Teams building AI agents face a fragmented toolchain — stitching together LLM providers, vector stores, tools, and deployment infrastructure while managing access controls, secrets, and sharing across team members. Dust provides a unified platform that combines agent development, management, and deployment in a collaborative workspace. Teams define agents with specific instructions, tool access, and data source connections, then deploy them as API endpoints or share them within the workspace. The platform handles model routing, context management, secret storage, and multi-user access so teams focus on agent behavior rather than infrastructure.
+
+use_cases:
+  - Deploy team-wide AI assistants that have access to shared company documents, wikis, and knowledge bases
+  - Build custom agents that combine web search, database queries, and API calls in multi-step reasoning workflows
+  - Create specialized support agents trained on product documentation that escalate complex issues to human agents
+  - Automate recurring workflows like meeting summarization, email triage, and report generation across team members
+  - Prototype and iterate on agent configurations collaboratively before deploying to production with workspace controls

--- a/tools/agent-frameworks/taskingai.yaml
+++ b/tools/agent-frameworks/taskingai.yaml
@@ -1,0 +1,24 @@
+name: TaskingAI
+description: Open-source Backend as a Service (BaaS) platform for LLM-based agent development and deployment. Unifies hundreds of AI models under a single API with an intuitive console for managing tools, RAG systems, assistants, and conversation history with multi-tenant support.
+tagline: BaaS platform for building and deploying LLM-powered AI agents at scale
+
+github_url: https://github.com/TaskingAI/TaskingAI
+website_url: https://www.tasking.ai
+
+install_command: pip install taskingai
+
+category: Agents
+tags: [python, agents, llm, baas, rag, multi-tenant, api, backend, orchestration, tools]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building production-grade LLM agents requires juggling model integrations, tool management, RAG pipelines, session state, and multi-tenant deployments — each demanding custom infrastructure. TaskingAI solves this with a BaaS architecture that decouples AI logic from client development: developers manage agents, tools, and knowledge bases through a unified console and API, while client SDKs handle only the frontend. The platform supports both stateful (conversation management) and stateless (chat completion) modes, built-in multi-tenancy, and one-click deployment from prototype to production.
+
+use_cases:
+  - Deploy multi-tenant AI agent applications where each customer needs isolated configurations, tools, and memory
+  - Build RAG-powered assistants with integrated document retrieval and customizable chunking strategies
+  - Manage hundreds of LLM model providers through a single unified API with automatic failover between providers
+  - Create tool-augmented agents with built-in plugins for web search, code execution, and custom API integrations
+  - Prototype and productionize agent workflows through an intuitive console with one-click deployment scaling

--- a/tools/dev-tools/playwright-mcp.yaml
+++ b/tools/dev-tools/playwright-mcp.yaml
@@ -1,0 +1,25 @@
+name: Playwright MCP
+description: Model Context Protocol server that provides browser automation capabilities using Playwright's accessibility tree. Enables LLMs and coding agents to navigate, click, type, and extract structured content from web pages without screenshots or vision models.
+tagline: Browser automation for LLMs via the Model Context Protocol
+
+github_url: https://github.com/microsoft/playwright-mcp
+website_url: https://playwright.dev
+docs_url: https://github.com/microsoft/playwright-mcp#readme
+
+install_command: npx @playwright/mcp@latest
+
+category: Dev Tools
+tags: [mcp, browser-automation, playwright, testing, web-scraping, accessibility, llm-tools, nodejs, devtools, automation]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  LLMs and coding agents struggle to interact with web pages through traditional browser automation — pixel-based approaches are ambiguous and vision models are slow and expensive. Playwright MCP solves this by exposing Playwright's accessibility tree through the Model Context Protocol, giving LLMs structured, deterministic access to web page content and interactive elements. Agents can navigate pages, click buttons, fill forms, and extract data using clean accessibility snapshots rather than screenshots, making browser automation faster, cheaper, and more reliable for AI-driven workflows.
+
+use_cases:
+  - Enable coding agents to test web applications by navigating pages, clicking elements, and verifying UI state automatically
+  - Build AI-powered web scrapers that extract structured data from complex multi-page applications
+  - Create self-healing test suites where LLMs can adapt to UI changes by reasoning about accessibility structure
+  - Automate repetitive web tasks like form filling, data entry, and report generation through natural language instructions
+  - Give MCP-compatible AI assistants the ability to browse the web and interact with web applications on behalf of users

--- a/tools/other/screenpipe.yaml
+++ b/tools/other/screenpipe.yaml
@@ -1,0 +1,23 @@
+name: Screenpipe
+description: Local-first AI tool that continuously captures screen and audio activity on your computer, indexing everything you see, say, and do into searchable memory. Enables AI agents to work with your actual work context while keeping all data private and on-device.
+tagline: AI-powered screen and audio memory that remembers everything you do locally
+
+github_url: https://github.com/mediar-ai/screenpipe
+website_url: https://screenpi.pe
+docs_url: https://docs.screenpi.pe
+
+category: Other
+tags: [screen-recording, memory, local-ai, privacy, productivity, mcp, agents, speech-to-text, computer-use, automation]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI agents lack context about what you have actually done, seen, or said during your workday — they operate in a vacuum without access to your real workflow. Screenpipe solves this by continuously recording screen content and audio locally, extracting text, transcripts, and visual context into a searchable database that AI agents can query. Everything runs on-device with no cloud upload, giving agents awareness of your actual work activities while preserving privacy. The platform exposes this memory through APIs and MCP servers so agents can retrieve relevant past context, find information you saw days ago, and automate workflows based on your actual usage patterns.
+
+use_cases:
+  - Recover information you saw on screen days or weeks ago by searching natural language queries against your screen history
+  - Give coding agents access to your terminal output, error messages, and code changes they would not otherwise see
+  - Automate repetitive workflows by having agents detect patterns in your computer usage and suggest optimizations
+  - Build personal AI assistants that know what you are working on, which documents you have open, and what you discussed in meetings
+  - Create meeting summaries and action items automatically by processing audio and on-screen content from video calls


### PR DESCRIPTION
Add 5 tools to the Agentic AI For Good catalog:

1. **BabyAGI** — Experimental framework for self-building autonomous agents (22k★, MIT)
2. **TaskingAI** — Open-source BaaS platform for LLM agent development and deployment (5.4k★, Apache-2.0)
3. **Playwright MCP** — Model Context Protocol server for browser automation by Microsoft (35k★, Apache-2.0)
4. **Dust** — Custom AI agent platform for teams to build and deploy agents in a collaborative workspace (1.4k★, MIT)
5. **Screenpipe** — Local-first AI screen/audio memory tool that indexes everything you do (19.8k★, MIT)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for BabyAGI, Dust, TaskingAI, Playwright MCP, and Screenpipe.
  * Included descriptions, use cases, links, installation details, categories, pricing, and licensing information for each tool.
  * Added coverage for autonomous agents, AI workflow automation, browser automation, and screen-based productivity tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->