### PR TITLE
Add Cherry Studio and NextChat to catalog

### DIFF
--- a/tools/dev-tools/cherry-studio.yaml
+++ b/tools/dev-tools/cherry-studio.yaml
@@ -1,0 +1,23 @@
+name: Cherry Studio
+description: Desktop client supporting hundreds of LLM providers with 300+ pre-configured AI assistants, smart chat, autonomous agents, MCP server support, and document processing across Windows, Mac, and Linux.
+tagline: AI productivity studio with multi-model chat, agents, and 300+ assistants
+
+github_url: https://github.com/CherryHQ/cherry-studio
+website_url: https://cherry-ai.com
+docs_url: https://docs.cherry-ai.com
+
+category: Dev Tools
+tags: [desktop, chat, llm, multi-model, agents, assistants, mcp, cross-platform, productivity, document-processing]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Developers and power users juggle multiple LLM providers, AI assistants, and chat interfaces across different browser tabs and desktop apps, with no unified workspace for managing conversations, agents, or documents. Cherry Studio consolidates the entire AI workflow into a single desktop client: support for hundreds of LLM providers (cloud and local), 300+ pre-configured assistants, custom agent creation, MCP server integration, and document processing with WebDAV sync. Users can chat simultaneously with multiple models, manage topics, translate content, and process documents all in one cross-platform application.
+
+use_cases:
+  - Manage conversations across OpenAI, Anthropic, Gemini, and local Ollama models from a single desktop interface
+  - Use 300+ pre-built AI assistants for coding, writing, translation, and analysis without manual configuration
+  - Create custom AI agents with specific instructions, MCP tools, and multiple model backends for specialized workflows
+  - Process and analyze documents across formats (PDF, Office, images) with AI-powered extraction and summarization
+  - Sync chat history, assistants, and settings across devices using WebDAV cloud backup

--- a/tools/other/nextchat.yaml
+++ b/tools/other/nextchat.yaml
@@ -1,0 +1,24 @@
+name: NextChat
+description: Lightweight, cross-platform AI chat assistant supporting OpenAI, Gemini, Claude, and other LLM providers. Available as a web app, Docker container, and native desktop app on iOS, macOS, Android, Linux, and Windows.
+tagline: Light and fast AI assistant across all your devices
+
+github_url: https://github.com/ChatGPTNextWeb/NextChat
+website_url: https://nextchat.dev
+
+install_command: docker pull yidadaa/chatgpt-next-web
+
+category: Other
+tags: [chat, llm, cross-platform, docker, desktop, mobile, openai, gemini, claude, web-app]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Users who work across multiple devices need a consistent, lightweight AI chat interface that works everywhere — on desktop, mobile, and web — without switching between provider-specific apps. NextChat provides a unified chat experience with support for OpenAI, Gemini, Claude, DeepSeek, and dozens of other LLM providers, accessible from any device. It deploys easily via Docker for self-hosted setups, runs as a native desktop app, and is available on iOS and Android app stores. Features include markdown rendering, code highlighting, conversation history, and multi-model support in a clean, minimal interface.
+
+use_cases:
+  - Access a consistent AI chat interface across your phone, laptop, and desktop with synchronized conversation history
+  - Self-host a private AI chat gateway for your team using Docker with support for multiple LLM providers
+  - Switch between OpenAI, Gemini, Claude, and local models in a single conversation for comparative responses
+  - Deploy a lightweight AI chat frontend for non-technical team members without exposing provider API keys directly
+  - Use advanced formatting features like markdown rendering, code highlighting, and LaTeX math in chat responses


### PR DESCRIPTION
Add 2 tools to the Agentic AI For Good catalog:

1. **Cherry Studio** — Desktop client supporting hundreds of LLM providers with 300+ pre-configured AI assistants and MCP server support (48.4k★, AGPL-3.0)
2. **NextChat** — Lightweight cross-platform AI chat assistant supporting OpenAI, Gemini, Claude, and more (88.4k★, MIT)
