### PR TITLE
Add ToolJet, whylogs to catalog

### DIFF
--- a/tools/dev-tools/tooljet.yaml
+++ b/tools/dev-tools/tooljet.yaml
@@ -1,0 +1,31 @@
+name: ToolJet
+description: An open-source low-code platform for building internal tools, dashboards, business applications, workflows, and AI agents with drag-and-drop UI, pre-built integrations, and a visual app builder.
+tagline: Open-source low-code platform for internal tools and AI agents
+
+github_url: https://github.com/ToolJet/ToolJet
+website_url: https://tooljet.ai
+docs_url: https://docs.tooljet.ai
+
+category: Dev Tools
+tags: [low-code, internal-tools, dashboard, workflow-automation, ai-agents, app-builder]
+pricing: freemium
+is_open_source: true
+license: AGPL-3.0
+
+install_command: |
+  npm install -g @tooljet/cli
+  tooljet setup
+
+problem_solved: |
+  Building internal tools — admin panels, dashboards, approval workflows — traditionally
+  requires full-stack development effort even for simple CRUD interfaces. ToolJet provides
+  a visual app builder with drag-and-drop widgets, 50+ pre-built integrations (databases,
+  APIs, SaaS), and an AI agent builder that lets teams create production-ready applications
+  and AI-powered workflows in minutes instead of weeks, without leaving the browser.
+
+use_cases:
+  - Build admin dashboards and data management panels connected to PostgreSQL, MySQL, or REST APIs
+  - Create approval workflows and business process automation with visual builders
+  - Deploy AI agents that interact with internal databases and APIs through natural language
+  - Design custom CRM and inventory management interfaces for internal teams
+  - Monitor application metrics and logs in real-time with customizable dashboard widgets

--- a/tools/monitoring/whylogs.yaml
+++ b/tools/monitoring/whylogs.yaml
@@ -1,0 +1,30 @@
+name: whylogs
+description: An open-source data logging library for ML models and data pipelines that provides visibility into data quality, model performance, and drift over time with privacy-preserving profiling.
+tagline: ML data logging and monitoring made simple
+
+github_url: https://github.com/whylabs/whylogs
+website_url: https://whylabs.ai
+docs_url: https://docs.whylabs.ai/docs/whylogs-overview
+
+category: Monitoring
+tags: [ml-monitoring, data-quality, model-monitoring, data-drift, observability, python, logging]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install whylogs
+
+problem_solved: |
+  Machine learning models in production degrade over time due to data drift, concept drift,
+  and data quality issues — but most teams lack visibility into what their models are seeing
+  and predicting. Traditional monitoring solutions require sending raw data to external services,
+  creating privacy and compliance risks. Whylogs generates statistical profiles of datasets
+  (distributions, missing values, types) in a privacy-preserving manner, enabling teams to
+  detect drift, track data quality, and debug model performance issues without exposing raw data.
+
+use_cases:
+  - Detect data drift between training and production datasets to catch model degradation early
+  - Monitor data quality metrics (missing values, type ratios, distribution shifts) in ML pipelines
+  - Track model performance over time and correlate changes with input distribution shifts
+  - Generate privacy-preserving data profiles that can be shared without exposing raw customer data
+  - Integrate ML monitoring into existing observability stacks with logging and alerting integrations


### PR DESCRIPTION
## What's added

Adds 2 more tools to the Agentic AI For Good catalog:

- **ToolJet** (Dev Tools) — Open-source low-code platform for building internal tools, dashboards, and AI agents
- **whylogs** (Monitoring) — Open-source data logging library for ML model and data pipeline observability

Both tools verified: active repos, valid metadata, local validation passed.
