### PR TITLE
Add Hasura, NocoDB, Appwrite, Strapi, Postman to catalog

### DIFF
--- a/tools/dev-tools/appwrite.yaml
+++ b/tools/dev-tools/appwrite.yaml
@@ -1,0 +1,25 @@
+name: Appwrite
+description: "A complete open-source backend platform providing authentication, databases, storage, serverless functions, messaging, and realtime capabilities with a unified SDK for web, mobile, and AI applications."
+tagline: "Open-source backend infrastructure for web, mobile, and AI apps"
+github_url: https://github.com/appwrite/appwrite
+website_url: https://appwrite.io
+docs_url: https://appwrite.io/docs
+install_command: docker run -d --name appwrite -p 80:80 appwrite/appwrite
+category: Dev Tools
+tags:
+  - backend
+  - authentication
+  - database
+  - storage
+  - serverless
+  - sdk
+pricing: freemium
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Appwrite eliminates stitching together multiple backend services by providing a single self-hostable platform for auth, databases, file storage, serverless functions, and push notifications — instead of integrating Firebase, Auth0, S3, and a worker queue separately, you deploy one instance and get consistent SDKs across platforms."
+use_cases:
+  - "Deploy a complete authentication system with email, OAuth, and magic link flows in minutes"
+  - "Store and serve user-uploaded files with built-in image transformation and CDN caching"
+  - "Write serverless functions that react to database changes, file uploads, or scheduled cron jobs"
+  - "Build a realtime collaborative app with Appwrite's database subscriptions and WebSocket support"
+  - "Manage user roles and permissions across applications with centralized auth and team management"

--- a/tools/dev-tools/hasura.yaml
+++ b/tools/dev-tools/hasura.yaml
@@ -1,0 +1,25 @@
+name: Hasura
+description: "An instant realtime GraphQL engine that connects to databases and services to auto-generate a production-ready GraphQL API with fine-grained access control, subscriptions, and event-driven webhooks."
+tagline: "Instant realtime GraphQL APIs on all your data"
+github_url: https://github.com/hasura/graphql-engine
+website_url: https://hasura.io
+docs_url: https://hasura.io/docs
+install_command: npm install -g hasura-cli
+category: Dev Tools
+tags:
+  - graphql
+  - api-gateway
+  - postgresql
+  - realtime
+  - webhooks
+  - backend
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Hasura solves the API backend development bottleneck by automatically generating a realtime GraphQL API from any existing PostgreSQL database, with built-in filtering, pagination, subscriptions, and role-based access control — eliminating the need to write boilerplate resolvers and REST endpoints."
+use_cases:
+  - "Stand up a realtime GraphQL API for a new application in minutes by connecting an existing database"
+  - "Subscribe to live database changes over WebSocket for collaborative and realtime features"
+  - "Expose fine-grained GraphQL endpoints to external clients while enforcing row-level permissions"
+  - "Trigger serverless functions via webhooks when database rows are inserted, updated, or deleted"
+  - "Compose multiple databases and REST services into a unified GraphQL schema for frontend consumption"

--- a/tools/dev-tools/nocodb.yaml
+++ b/tools/dev-tools/nocodb.yaml
@@ -1,0 +1,24 @@
+name: NocoDB
+description: "An open-source Airtable alternative that turns any MySQL, PostgreSQL, SQL Server, SQLite, or Snowflake database into a smart spreadsheet interface with auto-generated REST APIs and no-code automations."
+tagline: "The open-source Airtable alternative for any database"
+github_url: https://github.com/nocodb/nocodb
+website_url: https://nocodb.com
+docs_url: https://docs.nocodb.com
+install_command: npm install -g nocodb
+category: Dev Tools
+tags:
+  - spreadsheet
+  - database
+  - no-code
+  - rest-api
+  - low-code
+  - automation
+pricing: freemium
+is_open_source: true
+problem_solved: "NocoDB bridges the gap between databases and business users by providing a spreadsheet-like interface over any SQL database, so non-technical team members can view, filter, and edit records without SQL knowledge while developers get auto-generated REST APIs and programmatic access."
+use_cases:
+  - "Create a project management dashboard that non-technical stakeholders can edit directly against PostgreSQL"
+  - "Build a customer CRM spreadsheet view with relational lookups across multiple connected tables"
+  - "Generate a REST API from an existing database without writing a single line of backend code"
+  - "Set up automated workflows triggered by row changes in a shared spreadsheet interface"
+  - "Let sales and operations teams filter and export data from production databases without SQL queries"

--- a/tools/dev-tools/postman.yaml
+++ b/tools/dev-tools/postman.yaml
@@ -1,0 +1,24 @@
+name: Postman
+description: "An API platform for designing, testing, documenting, monitoring, and sharing APIs across the entire development lifecycle, with collaborative workspaces, automated testing via Newman, and CI/CD integration."
+tagline: "The complete API platform for building and using APIs"
+github_url: https://github.com/postmanlabs/newman
+website_url: https://postman.com
+docs_url: https://learning.postman.com
+install_command: npm install -g newman
+category: Dev Tools
+tags:
+  - api-testing
+  - rest-client
+  - collaboration
+  - monitoring
+  - documentation
+  - ci-cd
+pricing: freemium
+is_open_source: false
+problem_solved: "Postman solves API development fragmentation by providing a single platform to design, test, document, and monitor APIs — instead of switching between curl, documentation generators, and test scripts, teams collaborate in shared workspaces with collections, environments, automated tests, and CI integration from prototype to production."
+use_cases:
+  - "Design and prototype REST and GraphQL APIs with a visual editor before writing any backend code"
+  - "Automate API regression tests with Newman running in CI/CD pipelines on every push to the repository"
+  - "Generate and publish interactive API documentation from Postman collections with example requests"
+  - "Monitor production API endpoints and alert on failures, response time regressions, or schema changes"
+  - "Share curated API collections with team members including pre-configured auth tokens and environment variables"

--- a/tools/dev-tools/strapi.yaml
+++ b/tools/dev-tools/strapi.yaml
@@ -1,0 +1,24 @@
+name: Strapi
+description: "The leading open-source headless CMS that lets developers build customizable content APIs with a visual admin panel, supporting REST, GraphQL, and any SQL database with a plugin ecosystem."
+tagline: "Open-source headless CMS for building powerful content APIs"
+github_url: https://github.com/strapi/strapi
+website_url: https://strapi.io
+docs_url: https://docs.strapi.io
+install_command: npx create-strapi-app@latest my-project
+category: Dev Tools
+tags:
+  - cms
+  - headless
+  - content-management
+  - api
+  - rest-api
+  - graphql
+pricing: freemium
+is_open_source: true
+problem_solved: "Strapi solves content management fragmentation by letting developers define content types through a visual admin UI that automatically generates REST and GraphQL APIs, while content editors get a powerful dashboard — all self-hosted and fully customizable without the constraints of closed SaaS CMS platforms."
+use_cases:
+  - "Build a content API for a blog or documentation site with automatic REST and GraphQL endpoints"
+  - "Give marketing teams a dashboard to manage website content without developer involvement"
+  - "Create a multilingual content repository with custom fields, media library, and role-based access control"
+  - "Extend any content type with webhooks, custom routes, lifecycle hooks, and plugin integrations"
+  - "Self-host a privacy-compliant CMS that keeps all data on your own infrastructure behind your firewall"


### PR DESCRIPTION
Add 5 new tools to the Agentic AI For Good catalog:

1. **Hasura** — Instant realtime GraphQL engine for PostgreSQL (32k★, Apache-2.0)
2. **NocoDB** — Open-source Airtable alternative for any SQL database (63k★)
3. **Appwrite** — Complete open-source backend platform with auth, DB, storage, functions (56k★, BSD-3-Clause)
4. **Strapi** — Leading open-source headless CMS with REST & GraphQL APIs (72k★)
5. **Postman** — API platform for designing, testing, documenting, and monitoring APIs

All tools are in `tools/dev-tools/` category.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added five developer tool entries: Appwrite, Hasura, NocoDB, Postman, and Strapi.
  - Added descriptions, documentation and website links, installation details, licensing and pricing information.
  - Included tags, supported use cases, and explanations of the problems each tool addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->