### PR TITLE
Add PocketBase, Directus, Metabase, Redash, DBeaver to catalog

### DIFF
--- a/tools/data/dbeaver.yaml
+++ b/tools/data/dbeaver.yaml
@@ -1,0 +1,25 @@
+name: DBeaver
+description: "A free, universal database tool and SQL client for developers and database administrators that supports all major databases — MySQL, PostgreSQL, SQLite, Oracle, SQL Server, and more — with a rich graphical interface."
+tagline: "Free universal database tool and SQL client for developers"
+github_url: https://github.com/dbeaver/dbeaver
+website_url: https://dbeaver.io
+docs_url: https://dbeaver.com/docs
+install_command: brew install --cask dbeaver-community
+category: Data
+tags:
+  - database
+  - sql-client
+  - ide
+  - postgresql
+  - mysql
+  - query-editor
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "DBeaver solves the database tool fragmentation problem by providing a single cross-platform IDE that connects to any SQL database — PostgreSQL, MySQL, Oracle, SQL Server, SQLite, and 80+ others — with schema browsing, query editing, data export, ER diagrams, and an intuitive interface that works the same way regardless of the underlying database engine."
+use_cases:
+  - "Browse database schemas, tables, views, and indexes across multiple database engines in one window"
+  - "Write and execute SQL queries with autocompletion, syntax highlighting, and query plan visualization"
+  - "Export query results to CSV, Excel, JSON, or Markdown for reporting and data sharing"
+  - "Design database schemas visually with the built-in ER diagram and entity-relationship tools"
+  - "Compare and synchronize database structures between development, staging, and production environments"

--- a/tools/data/metabase.yaml
+++ b/tools/data/metabase.yaml
@@ -1,0 +1,24 @@
+name: Metabase
+description: "An easy-to-use open-source business intelligence tool that lets non-technical users explore data, build dashboards, and ask questions without SQL — connecting to any JDBC-compatible database."
+tagline: "Business intelligence for everyone in your organization"
+github_url: https://github.com/metabase/metabase
+website_url: https://metabase.com
+docs_url: https://metabase.com/docs
+install_command: docker run -d -p 3000:3000 metabase/metabase
+category: Data
+tags:
+  - business-intelligence
+  - analytics
+  - dashboard
+  - visualization
+  - sql
+  - no-code
+pricing: freemium
+is_open_source: true
+problem_solved: "Metabase democratizes data analytics by giving every team member a simple interface to query databases, build visual dashboards, and receive scheduled reports — without writing SQL or needing IT support. Instead of data teams becoming a bottleneck for every ad-hoc question, anyone can explore data through a natural language query builder."
+use_cases:
+  - "Build an executive dashboard showing revenue, user growth, and retention metrics from the production database"
+  - "Set up automated email reports that deliver daily sales summaries to the team every morning"
+  - "Ask ad-hoc questions like 'top 10 products by revenue last month' using a visual query builder"
+  - "Embed Metabase charts directly into customer-facing portals with the embedding API"
+  - "Configure row-level permissions so each team only sees data relevant to their department"

--- a/tools/data/redash.yaml
+++ b/tools/data/redash.yaml
@@ -1,0 +1,25 @@
+name: Redash
+description: "An open-source data visualization and dashboarding tool that connects to any data source — SQL databases, APIs, and cloud services — enabling teams to create, share, and schedule interactive data visualizations."
+tagline: "Connect any data source, visualize and share with your team"
+github_url: https://github.com/getredash/redash
+website_url: https://redash.io
+docs_url: https://redash.io/help
+install_command: docker compose up
+category: Data
+tags:
+  - analytics
+  - dashboard
+  - visualization
+  - sql
+  - collaboration
+  - data-warehouse
+pricing: freemium
+is_open_source: true
+license: BSD-2-Clause
+problem_solved: "Redash solves the cross-source data visibility problem by letting teams query multiple data sources — from PostgreSQL and BigQuery to APIs and CSV files — in a single interface, then build and share dashboards without duplicating data into a separate warehouse. It eliminates the silos where different teams use different tools to access the same data."
+use_cases:
+  - "Query across PostgreSQL, MySQL, BigQuery, and REST APIs from a single SQL editor"
+  - "Build live-updating dashboards that refresh on a schedule for daily stand-ups and weekly reviews"
+  - "Share data-driven insights with stakeholders via shareable dashboard links and scheduled email reports"
+  - "Use the query results API to feed external tools like Slack bots, custom apps, or monitoring systems"
+  - "Let non-technical team members explore pre-built queries through parameterized dashboards"

--- a/tools/dev-tools/directus.yaml
+++ b/tools/dev-tools/directus.yaml
@@ -1,0 +1,25 @@
+name: Directus
+description: "A flexible open-source backend platform that turns any SQL database into a headless CMS with auto-generated REST and GraphQL APIs, a customizable admin app, and real-time data sync."
+tagline: "Turn your database into a headless CMS with instant APIs"
+github_url: https://github.com/directus/directus
+website_url: https://directus.io
+docs_url: https://docs.directus.io
+install_command: npm install -g directus
+category: Dev Tools
+tags:
+  - cms
+  - headless-cms
+  - api
+  - database
+  - rest-api
+  - graphql
+  - no-code
+pricing: freemium
+is_open_source: true
+problem_solved: "Directus solves the content management bottleneck by wrapping any SQL database with an auto-generated REST and GraphQL API, a dynamic admin panel, and real-time data synchronization — without imposing a rigid schema or proprietary data format, so developers keep full control of the database while non-technical users get a powerful interface."
+use_cases:
+  - "Generate a REST and GraphQL API from an existing PostgreSQL database with no configuration needed"
+  - "Give content editors a customizable admin dashboard to manage relational data across tables"
+  - "Build custom data workflows with Directus flows, hooks, and webhook triggers"
+  - "Create role-based access controls and permission policies at the field and item level"
+  - "Serve real-time data to frontend applications using Directus' WebSocket and SSE subscriptions"

--- a/tools/dev-tools/pocketbase.yaml
+++ b/tools/dev-tools/pocketbase.yaml
@@ -1,0 +1,25 @@
+name: PocketBase
+description: "An open-source realtime backend in a single Go binary, providing database, authentication, file storage, admin UI, and REST API — deployable with zero dependencies."
+tagline: "Open-source realtime backend in a single file"
+github_url: https://github.com/pocketbase/pocketbase
+website_url: https://pocketbase.io
+docs_url: https://pocketbase.io/docs
+install_command: brew install pocketbase/tap/pocketbase
+category: Dev Tools
+tags:
+  - backend
+  - realtime
+  - authentication
+  - database
+  - api
+  - go
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "PocketBase eliminates the complexity of setting up a backend by shipping a complete realtime backend — database, auth, file storage, admin dashboard, and REST API — as a single Go binary. Instead of wiring up a web framework, database driver, auth library, and admin panel separately, you download one file and start building."
+use_cases:
+  - "Deploy a full backend with authentication and database for a side project in under one minute"
+  - "Build web and mobile apps with realtime data sync using PocketBase's subscription API"
+  - "Use the built-in admin panel to manage users, collections, and file uploads without coding"
+  - "Create role-based access rules with PocketBase's declarative permission system"
+  - "Embed PocketBase as an embedded database in desktop applications using its Go package"


### PR DESCRIPTION
Add 5 new tools to the Agentic AI For Good catalog:

1. **PocketBase** — Open-source realtime backend in a single Go binary (59k★, MIT)
2. **Directus** — Flexible headless CMS and backend platform from any SQL database (36k★)
3. **Metabase** — Easy-to-use open-source BI and analytics tool for everyone (48k★)
4. **Redash** — Open-source data visualization and dashboarding for any data source (28k★, BSD-2-Clause)
5. **DBeaver** — Free universal database tool and SQL client (50k★, Apache-2.0)

PocketBase and Directus in `tools/dev-tools/`. Metabase, Redash, and DBeaver in `tools/data/`.
