### PR TITLE
Add Presto, Cube, Dolt, Apache CouchDB, Apache HBase to catalog

### DIFF
--- a/tools/data/apache-couchdb.yaml
+++ b/tools/data/apache-couchdb.yaml
@@ -1,0 +1,25 @@
+name: Apache CouchDB
+description: "A document-oriented NoSQL database with an intuitive HTTP/JSON API, multi-primary replication, and offline-first synchronization designed for reliability and resilience across distributed systems."
+tagline: "Seamless multi-primary NoSQL database with HTTP/JSON API"
+github_url: https://github.com/apache/couchdb
+website_url: https://couchdb.apache.org
+docs_url: https://docs.couchdb.org
+install_command: brew install couchdb
+category: Data
+tags:
+  - database
+  - nosql
+  - json
+  - replication
+  - distributed
+  - document-store
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "CouchDB solves the offline-first data synchronization problem by providing a document database designed around multi-primary replication — each node can accept writes independently, and data syncs automatically when connectivity is restored. This makes it ideal for mobile, IoT, and edge applications where network connectivity is intermittent."
+use_cases:
+  - "Build mobile applications with offline-first data that syncs automatically when the device reconnects"
+  - "Deploy a peer-to-peer database across edge devices where each node operates independently"
+  - "Store and query JSON documents with map-reduce views and full-text search capabilities"
+  - "Sync data between cloud and on-premise instances using CouchDB's built-in replication protocol"
+  - "Use CouchDB as a reliable document store for applications requiring HTTP-native database access"

--- a/tools/data/apache-hbase.yaml
+++ b/tools/data/apache-hbase.yaml
@@ -1,0 +1,24 @@
+name: Apache HBase
+description: "A distributed, scalable, big data NoSQL database built on Hadoop for random, real-time read and write access to massive tables with billions of rows and millions of columns."
+tagline: "Distributed big data NoSQL database for real-time random access"
+github_url: https://github.com/apache/hbase
+website_url: https://hbase.apache.org
+docs_url: https://hbase.apache.org/book.html
+category: Data
+tags:
+  - database
+  - nosql
+  - big-data
+  - hadoop
+  - distributed
+  - column-store
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "HBase solves the massive-scale random access problem by providing a column-oriented NoSQL database on top of HDFS that supports billions of rows, millions of columns, and strong consistency — filling the gap where traditional databases can't handle the volume and key-value stores can't handle the data model complexity."
+use_cases:
+  - "Store and query billions of time-series events with low-latency random access for real-time applications"
+  - "Power a recommendation engine with real-time read and write access to a massive user-item interaction matrix"
+  - "Serve as the operational database for real-time data pipelines processing streaming events at petabyte scale"
+  - "Store sparse, wide-column datasets like user profiles with hundreds of optional attributes"
+  - "Integrate with the Hadoop ecosystem for map-reduce processing of large-scale structured data"

--- a/tools/data/cube.yaml
+++ b/tools/data/cube.yaml
@@ -1,0 +1,24 @@
+name: Cube
+description: "An open-source semantic layer for AI, business intelligence, and embedded analytics that provides consistent metrics, caching, and API access across data sources with SQL and REST APIs."
+tagline: "Open-source semantic layer for AI, BI, and embedded analytics"
+github_url: https://github.com/cube-js/cube
+website_url: https://cube.dev
+docs_url: https://cube.dev/docs
+install_command: npm install -g @cubejs-backend/server
+category: Data
+tags:
+  - analytics
+  - semantic-layer
+  - bi
+  - metrics
+  - api
+  - caching
+pricing: freemium
+is_open_source: true
+problem_solved: "Cube solves the data inconsistency problem by providing a semantic layer that defines business metrics once and exposes them through a consistent API to any tool — BI dashboards, AI agents, embedded analytics, or spreadsheets. Instead of each tool redefining 'revenue' or 'active users' with slightly different logic, Cube serves as the single source of truth for business metrics."
+use_cases:
+  - "Define a unified metrics layer for revenue, churn, and retention that serves both BI dashboards and AI agents"
+  - "Pre-aggregate and cache slow queries so dashboards load in milliseconds instead of minutes"
+  - "Embed self-service analytics into a SaaS product with Cube's REST and GraphQL APIs"
+  - "Connect AI and LLM applications to structured data with consistent, documented metric definitions"
+  - "Replace multiple BI tool ETL pipelines with a single semantic layer that exposes SQL and API endpoints"

--- a/tools/data/dolt.yaml
+++ b/tools/data/dolt.yaml
@@ -1,0 +1,25 @@
+name: Dolt
+description: "A version-controlled SQL database that brings Git-like branching, merging, diffing, and forking to your data — enabling collaboration on datasets the way developers collaborate on code."
+tagline: "Git for Data — version-controlled SQL database"
+github_url: https://github.com/dolthub/dolt
+website_url: https://dolthub.com
+docs_url: https://docs.dolthub.com
+install_command: brew install dolt
+category: Data
+tags:
+  - version-control
+  - database
+  - sql
+  - data-versioning
+  - collaboration
+  - git
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Dolt solves the data versioning problem by combining a MySQL-compatible SQL database with Git-like version control — commit, branch, merge, diff, and push datasets just like code. Instead of managing data changes through manual exports, timestamped snapshots, or complex migration scripts, teams track every change, collaborate on datasets, and roll back to any point in history."
+use_cases:
+  - "Track every change to a dataset with full Git-style commit history and rollback to any revision"
+  - "Branch a production database to experiment with schema changes or data transformations safely"
+  - "Collaborate on curated datasets by pushing and pulling database changes across team members"
+  - "Diff two database snapshots to see exactly what data changed between deployments or time periods"
+  - "Use Dolt as a version-controlled data store for AI agent memory and state management"

--- a/tools/data/presto.yaml
+++ b/tools/data/presto.yaml
@@ -1,0 +1,25 @@
+name: Presto
+description: "An open-source distributed SQL query engine for big data analytics that runs queries against data lakes, relational databases, and NoSQL systems — from gigabytes to petabytes — with ANSI SQL support."
+tagline: "Distributed SQL query engine for big data analytics"
+github_url: https://github.com/prestodb/presto
+website_url: https://prestodb.io
+docs_url: https://prestodb.io/docs/current
+install_command: docker run -d -p 8080:8080 prestodb/presto
+category: Data
+tags:
+  - sql
+  - big-data
+  - query-engine
+  - analytics
+  - data-lake
+  - distributed
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Presto solves the cross-source data query problem by letting analysts and engineers run ANSI SQL against data stored in HDFS, S3, relational databases, Kafka, and NoSQL systems — without moving data into a separate warehouse. Instead of ETL-ing everything into one system, teams query data in place with a single engine that scales to petabytes."
+use_cases:
+  - "Run interactive SQL queries across petabytes of data in S3 and HDFS without pre-loading into a warehouse"
+  - "Federate queries across MySQL, PostgreSQL, MongoDB, and Kafka topics from a single SQL interface"
+  - "Power BI tools like Tableau and Superset with a fast ANSI SQL endpoint for live dashboards"
+  - "Join data from a data lake with operational databases for real-time analytics use cases"
+  - "Replace slow Hive queries with Presto's in-memory pipelined execution for 10x faster analytics"


### PR DESCRIPTION
Add 5 new tools to the Agentic AI For Good catalog:

1. **Presto** — Distributed SQL query engine for big data analytics across any data source (16k★, Apache-2.0)
2. **Cube** — Open-source semantic layer for AI, BI, and embedded analytics (20k★)
3. **Dolt** — Git for Data — version-controlled SQL database (23k★, Apache-2.0)
4. **Apache CouchDB** — Document NoSQL database with multi-primary replication (6.9k★, Apache-2.0)
5. **Apache HBase** — Distributed big data NoSQL database on Hadoop (5.5k★, Apache-2.0)

All tools in `tools/data/` category.
