### PR TITLE
Add Uptime Kuma, Matomo, Plausible, Umami, Better Stack to catalog

### DIFF
--- a/tools/monitoring/better-stack.yaml
+++ b/tools/monitoring/better-stack.yaml
@@ -1,0 +1,22 @@
+name: Better Stack
+description: "A comprehensive observability platform combining uptime monitoring, structured log management (formerly Logtail), and status pages with ClickHouse-powered log analytics and multi-channel alerting."
+tagline: "Unified uptime monitoring, log management, and status pages"
+website_url: https://betterstack.com
+docs_url: https://betterstack.com/docs
+category: Monitoring
+tags:
+  - uptime
+  - logging
+  - monitoring
+  - alerts
+  - status-page
+  - observability
+pricing: freemium
+is_open_source: false
+problem_solved: "Better Stack solves the fragmented observability problem by combining uptime monitoring, structured log management, and status pages into a single platform — instead of patching together Pingdom, Datadog, and a status page tool, teams get unified alerting, ClickHouse-powered log search, and a public status page from one provider."
+use_cases:
+  - "Monitor website and API uptime from multiple global regions with instant Slack and email alerts"
+  - "Ingest, search, and analyze application logs with ClickHouse-powered structured log management"
+  - "Create a public status page with real-time and historical uptime data for customer-facing services"
+  - "Set up multi-channel alerting with escalation policies for on-call incident response workflows"
+  - "Correlate log errors with uptime incidents to quickly identify root causes of service disruptions"

--- a/tools/monitoring/matomo.yaml
+++ b/tools/monitoring/matomo.yaml
@@ -1,0 +1,25 @@
+name: Matomo
+description: "The leading open-source web analytics platform that provides 100% data ownership and built-in privacy compliance — tracking website visits, user behavior, conversions, and goals without Google dependency."
+tagline: "Open-source web analytics with full data ownership"
+github_url: https://github.com/matomo-org/matomo
+website_url: https://matomo.org
+docs_url: https://matomo.org/guide
+install_command: docker run -d -p 80:80 matomo
+category: Monitoring
+tags:
+  - analytics
+  - privacy
+  - web-analytics
+  - self-hosted
+  - seo
+  - tracking
+pricing: freemium
+is_open_source: true
+license: GPL-3.0
+problem_solved: "Matomo solves the data ownership and privacy compliance problem in web analytics by providing a fully self-hosted alternative to Google Analytics — every visitor data point stays on your servers, is fully GDPR/CCPA compliant by default, and can be analyzed without sending user data to third parties."
+use_cases:
+  - "Track website traffic, page views, user journeys, and conversion funnels with complete data ownership"
+  - "Stay GDPR and CCPA compliant with built-in privacy features like IP anonymization and consent management"
+  - "Analyze e-commerce performance with built-in shopping cart tracking and revenue attribution"
+  - "Set up custom goals, funnels, and event tracking to measure specific user actions and conversions"
+  - "Generate automated SEO and analytics reports emailed to stakeholders on a weekly or monthly schedule"

--- a/tools/monitoring/plausible.yaml
+++ b/tools/monitoring/plausible.yaml
@@ -1,0 +1,24 @@
+name: Plausible
+description: "A lightweight, privacy-first, cookie-free web analytics platform that provides simple, actionable website traffic insights — self-hosted or cloud — as an ethical alternative to Google Analytics."
+tagline: "Simple, privacy-first, open-source web analytics"
+github_url: https://github.com/plausible/analytics
+website_url: https://plausible.io
+docs_url: https://plausible.io/docs
+category: Monitoring
+tags:
+  - analytics
+  - privacy
+  - web-analytics
+  - self-hosted
+  - lightweight
+  - cookie-free
+pricing: freemium
+is_open_source: true
+license: AGPL-3.0
+problem_solved: "Plausible solves the analytics bloat and privacy problem by providing a lightweight, cookie-free analytics script that loads in under 1KB — delivering essential traffic metrics without tracking personal data, needing cookie consent banners, or slowing down page loads. It's a drop-in replacement for Google Analytics that respects visitor privacy."
+use_cases:
+  - "Track website traffic with a lightweight script that does not require cookie consent banners or affect page speed"
+  - "Monitor real-time visitor counts, top pages, referral sources, and countries from a clean dashboard"
+  - "Self-host Plausible on a single server to keep all analytics data on your own infrastructure"
+  - "Share public analytics dashboards with stakeholders or the community without exposing visitor data"
+  - "Set up goal tracking for newsletter signups, purchases, and other conversion events"

--- a/tools/monitoring/umami.yaml
+++ b/tools/monitoring/umami.yaml
@@ -1,0 +1,25 @@
+name: Umami
+description: "A modern, privacy-focused web analytics platform that provides simple, fast, and beautiful traffic analytics as an open-source alternative to Google Analytics, Mixpanel, and Amplitude."
+tagline: "Privacy-focused, modern web analytics platform"
+github_url: https://github.com/umami-software/umami
+website_url: https://umami.is
+docs_url: https://umami.is/docs
+install_command: docker run -d -p 3000:3000 ghcr.io/umami-software/umami
+category: Monitoring
+tags:
+  - analytics
+  - privacy
+  - web-analytics
+  - self-hosted
+  - lightweight
+  - realtime
+pricing: freemium
+is_open_source: true
+license: MIT
+problem_solved: "Umami solves the complexity and privacy concerns of traditional analytics by providing a lightweight, self-hosted alternative that tracks page views, events, and sessions without cookies or personal data collection — giving website owners essential traffic insights while staying compliant with privacy regulations out of the box."
+use_cases:
+  - "Track website page views, visitor counts, and session duration without displaying cookie consent banners"
+  - "Monitor real-time visitor activity including current pages, referrers, and geographic locations"
+  - "Set up custom events and goal tracking for button clicks, form submissions, and specific user interactions"
+  - "Compare traffic metrics across date ranges with automatic trend analysis and percentage changes"
+  - "Host analytics on your own infrastructure to maintain full data ownership and control"

--- a/tools/monitoring/uptime-kuma.yaml
+++ b/tools/monitoring/uptime-kuma.yaml
@@ -1,0 +1,25 @@
+name: Uptime Kuma
+description: "A self-hosted, elegant uptime monitoring tool with 100+ status page integrations, real-time notifications, and status pages — supporting HTTP, TCP, ping, DNS, and Docker container monitoring."
+tagline: "Self-hosted uptime monitoring with status pages and alerts"
+github_url: https://github.com/louislam/uptime-kuma
+website_url: https://uptime.kuma.pet
+docs_url: https://github.com/louislam/uptime-kuma/wiki
+install_command: docker run -d -p 3001:3001 louislam/uptime-kuma
+category: Monitoring
+tags:
+  - uptime
+  - monitoring
+  - status-page
+  - alerts
+  - self-hosted
+  - infrastructure
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Uptime Kuma solves the cost and complexity of commercial uptime monitoring by providing a beautiful, self-hosted alternative that monitors HTTP, TCP, ping, DNS, and Docker containers — with 90+ notification channels, customizable status pages, and no per-endpoint pricing. Teams can monitor unlimited endpoints without paying per check or per monitor."
+use_cases:
+  - "Monitor website uptime from multiple regions with real-time alerts via Slack, email, or Telegram"
+  - "Create a public status page showing real-time and historical uptime for all customer-facing services"
+  - "Monitor SSL certificate expiry and get notified weeks before certificates expire"
+  - "Track TCP port and DNS resolution health for internal infrastructure behind a VPN"
+  - "Receive push notifications on your phone when any monitored service goes down or recovers"


### PR DESCRIPTION
Add 5 new tools to the Agentic AI For Good catalog:

1. **Uptime Kuma** — Self-hosted uptime monitoring with status pages and 90+ notification channels (89k★, MIT)
2. **Matomo** — Leading open-source web analytics with full data ownership and privacy compliance (21k★, GPL-3.0)
3. **Plausible** — Lightweight, privacy-first, cookie-free web analytics (27k★, AGPL-3.0)
4. **Umami** — Modern, privacy-focused web analytics platform (37k★, MIT)
5. **Better Stack** — Unified uptime monitoring, log management, and status pages

All tools in `tools/monitoring/` category.
