### PR TITLE
Add Traefik, Automatic1111, Fooocus, Stability AI, Apache Zeppelin to catalog

### DIFF
--- a/tools/data/apache-zeppelin.yaml
+++ b/tools/data/apache-zeppelin.yaml
@@ -1,0 +1,25 @@
+name: Apache Zeppelin
+description: "A web-based notebook for interactive data analytics and collaborative documents — supporting SQL, Python, Scala, R, and 20+ interpreters with built-in visualization and sharing capabilities."
+tagline: "Web-based data analytics notebook with multi-language support"
+github_url: https://github.com/apache/zeppelin
+website_url: https://zeppelin.apache.org
+docs_url: https://zeppelin.apache.org/docs
+install_command: docker run -d -p 8080:8080 apache/zeppelin
+category: Data
+tags:
+  - notebook
+  - sql
+  - python
+  - scala
+  - visualization
+  - collaboration
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Zeppelin solves the multi-language data analysis integration problem by providing a single notebook interface where data engineers and scientists can combine SQL, Python, Scala, R, and Markdown in the same document — with built-in charting and collaborative editing — eliminating the need to switch between different tools for different parts of a data pipeline."
+use_cases:
+  - "Create interactive data analysis notebooks combining SQL queries with Python visualization libraries"
+  - "Collaborate with team members on shared notebooks with real-time editing and commenting"
+  - "Schedule notebook execution for recurring data reports and automated data pipeline monitoring"
+  - "Visualize query results inline with built-in chart types including line, bar, pie, and scatter plots"
+  - "Connect to multiple data sources — JDBC databases, Elasticsearch, Cassandra, and Spark — from one notebook"

--- a/tools/dev-tools/traefik.yaml
+++ b/tools/dev-tools/traefik.yaml
@@ -1,0 +1,25 @@
+name: Traefik
+description: "A cloud-native application proxy and load balancer that automatically discovers services, handles dynamic reverse proxying, load balancing, SSL/TLS termination, and provides observability with zero manual configuration."
+tagline: "The cloud-native application proxy for dynamic microservices"
+github_url: https://github.com/traefik/traefik
+website_url: https://traefik.io
+docs_url: https://doc.traefik.io
+install_command: brew install traefik
+category: Dev Tools
+tags:
+  - reverse-proxy
+  - load-balancer
+  - kubernetes
+  - docker
+  - networking
+  - infrastructure
+pricing: freemium
+is_open_source: true
+license: MIT
+problem_solved: "Traefik solves the dynamic routing problem in containerized and orchestrated environments by automatically discovering services from Docker, Kubernetes, Consul, and other providers — configuring routes, load balancing, SSL certificates, and middleware without manual configuration files or reloads."
+use_cases:
+  - "Automatically configure reverse proxy routes for Docker containers as they start and stop"
+  - "Handle SSL/TLS termination with automatic Let's Encrypt certificate provisioning and renewal"
+  - "Load balance traffic across multiple backend service instances with circuit breakers and retries"
+  - "Expose Kubernetes services with automatic ingress configuration and middleware for rate limiting"
+  - "Monitor request metrics, latency, and error rates with built-in Prometheus and OpenTelemetry metrics"

--- a/tools/other/automatic1111.yaml
+++ b/tools/other/automatic1111.yaml
@@ -1,0 +1,23 @@
+name: Automatic1111
+description: "A feature-rich, browser-based Stable Diffusion web UI for generating AI art and images — supporting txt2img, img2img, inpainting, ControlNet, LoRA, and hundreds of community extensions."
+tagline: "Stable Diffusion web UI for AI image generation"
+github_url: https://github.com/AUTOMATIC1111/stable-diffusion-webui
+docs_url: https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki
+category: Other
+tags:
+  - image-generation
+  - stable-diffusion
+  - ai-art
+  - web-ui
+  - controlnet
+  - lora
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+problem_solved: "Automatic1111 solves the fragmented Stable Diffusion tooling problem by providing a comprehensive, one-click web UI that bundles model loading, prompt engineering, image generation, upscaling, inpainting, and extension management — eliminating the need to use separate command-line tools and scripts for each image generation task."
+use_cases:
+  - "Generate AI art from text prompts with fine-grained control over sampling steps, CFG scale, and seed values"
+  - "Edit existing images with inpainting to replace or modify specific regions based on text descriptions"
+  - "Apply ControlNet guidance to generate images that follow pose skeletons, depth maps, or edge detectors"
+  - "Train and apply custom LoRA models for consistent character, style, or object generation"
+  - "Batch generate hundreds of images with varying prompts and parameters for experimentation"

--- a/tools/other/fooocus.yaml
+++ b/tools/other/fooocus.yaml
@@ -1,0 +1,23 @@
+name: Fooocus
+description: "An image generation tool focused on simplicity and quality — wrapping Stable Diffusion models with preset styles, automatic prompt optimization, and inpainting — requiring minimal prompt engineering to get great results."
+tagline: "Focus on prompting and generating with Stable Diffusion"
+github_url: https://github.com/lllyasviel/Fooocus
+website_url: https://github.com/lllyasviel/Fooocus
+category: Other
+tags:
+  - image-generation
+  - stable-diffusion
+  - ai-art
+  - prompting
+  - inpainting
+  - upscaling
+pricing: free
+is_open_source: true
+license: GPL-3.0
+problem_solved: "Fooocus solves the prompt engineering complexity in AI image generation by pre-configuring Stable Diffusion models with optimized parameters, style presets, and automatic prompt enhancement — so users get high-quality images without understanding CFG scales, samplers, and scheduler combinations."
+use_cases:
+  - "Generate high-quality images from simple text prompts without tuning complex diffusion parameters"
+  - "Apply curated artistic styles with a single click using built-in style presets and templates"
+  - "Edit and extend images with inpainting, outpainting, and variation generation in a unified interface"
+  - "Upscale and enhance generated images with built-in AI upscaling and face restoration tools"
+  - "Run image generation completely offline on consumer GPUs with automatic model downloading"

--- a/tools/other/stability-ai.yaml
+++ b/tools/other/stability-ai.yaml
@@ -1,0 +1,25 @@
+name: Stability AI
+description: "The company behind Stable Diffusion, providing state-of-the-art generative AI models for image, video, audio, and 3D content creation through open-source model weights and cloud API endpoints."
+tagline: "State-of-the-art generative AI models for image, video, and audio"
+github_url: https://github.com/Stability-AI/generative-models
+website_url: https://stability.ai
+docs_url: https://platform.stability.ai/docs
+install_command: pip install stability-sdk
+category: Other
+tags:
+  - image-generation
+  - video-generation
+  - ai-art
+  - generative-ai
+  - stable-diffusion
+  - models
+pricing: freemium
+is_open_source: true
+license: MIT
+problem_solved: "Stability AI democratizes access to generative AI by releasing powerful open-source models like Stable Diffusion — enabling anyone to run state-of-the-art image, video, and audio generation on their own hardware without paying per-generation API fees or sharing their data with cloud services."
+use_cases:
+  - "Generate photorealistic images from text prompts using Stable Diffusion 3.5 and SDXL models"
+  - "Create short video clips from text descriptions using Stable Video Diffusion models"
+  - "Generate and edit 3D assets from text or image inputs using Stability AI's 3D generation tools"
+  - "Fine-tune Stable Diffusion models on custom datasets for specialized style or subject generation"
+  - "Build applications using the Stability AI API for scalable, cloud-hosted inference"


### PR DESCRIPTION
Add 5 new tools to the Agentic AI For Good catalog:

1. **Traefik** — Cloud-native application proxy and load balancer (63k★, MIT) — `dev-tools`
2. **Automatic1111** — Stable Diffusion web UI for AI image generation (164k★, AGPL-3.0) — `other`
3. **Fooocus** — Image generation focused on simplicity and prompting (51k★, GPL-3.0) — `other`
4. **Stability AI** — Generative AI models for image, video, and audio (27k★, MIT) — `other`
5. **Apache Zeppelin** — Web-based notebook for interactive data analytics (6.6k★, Apache-2.0) — `data`

This batch exhausts all remaining candidates in the tracker.
