### PR TITLE
Add Alibi Detect, Gensim, Jaeger, Loki, OpenTelemetry to catalog

### DIFF
--- a/tools/llm/gensim.yaml
+++ b/tools/llm/gensim.yaml
@@ -1,0 +1,30 @@
+name: Gensim
+description: A proven Python library for topic modeling, document similarity, and natural language processing with efficient vector-space and semantic modeling implementations.
+tagline: Topic modeling for humans — document similarity, word embeddings, and semantic analysis
+
+github_url: https://github.com/piskvorky/gensim
+website_url: https://radimrehurek.com/gensim
+docs_url: https://radimrehurek.com/gensim/auto_tutorial.html
+
+install_command: pip install gensim
+
+category: LLM
+tags: [python, nlp, topic-modeling, word-embeddings, word2vec, document-similarity, information-retrieval]
+pricing: free
+is_open_source: true
+license: LGPL-2.1
+
+problem_solved: |
+  Understanding the semantic structure of large document collections requires algorithms
+  like topic modeling, document similarity, and word embeddings — but implementing them
+  efficiently from scratch is complex and slow. Gensim provides battle-tested
+  implementations of Word2Vec, FastText, LDA, LSI, and TF-IDF that process datasets
+  larger than RAM using streaming, incremental training, and parallelized routines
+  written in Cython.
+
+use_cases:
+  - Train word embeddings on domain-specific corpora to improve downstream NLP models
+  - Discover latent topics across thousands of documents with LDA topic modeling
+  - Find similar documents in a corpus using TF-IDF or semantic similarity scoring
+  - Build document retrieval pipelines with FastText for out-of-vocabulary word handling
+  - Preprocess and vectorize text for classification, clustering, or search applications

--- a/tools/monitoring/alibi-detect.yaml
+++ b/tools/monitoring/alibi-detect.yaml
@@ -1,0 +1,30 @@
+name: Alibi Detect
+description: An open-source library for outlier detection, adversarial detection, and drift detection on tabular data, text, images, and time series. Built on TensorFlow and PyTorch.
+tagline: Detect outliers, drift, and adversarial examples in ML models
+
+github_url: https://github.com/SeldonIO/alibi-detect
+website_url: https://www.seldon.io/alibi-detect
+docs_url: https://docs.seldon.io/projects/alibi-detect
+
+install_command: pip install alibi-detect
+
+category: Monitoring
+tags: [python, outlier-detection, drift-detection, adversarial, monitoring, mlops]
+pricing: free
+is_open_source: true
+license: NOASSERTION
+
+problem_solved: |
+  Machine learning models in production encounter data that differs from their training
+  distribution — feature drift, label drift, outliers, and adversarial inputs. Without
+  detection, these shifts silently degrade predictions and erode trust. Alibi Detect
+  provides algorithms for online and offline drift detection, outlier detection across
+  tabular, text, image, and time-series data, and adversarial example detection —
+  all from a consistent Python API.
+
+use_cases:
+  - Monitor production ML models for data drift to trigger retraining before accuracy drops
+  - Detect outliers in real-time sensor data streams for anomaly alerting
+  - Identify adversarial inputs designed to manipulate model predictions
+  - Run scheduled drift reports on batch inference pipelines using statistical tests
+  - Detect concept drift in time-series forecasting models to flag regime changes

--- a/tools/monitoring/jaeger.yaml
+++ b/tools/monitoring/jaeger.yaml
@@ -1,0 +1,28 @@
+name: Jaeger
+description: A CNCF-graduated distributed tracing platform for monitoring and troubleshooting microservices-based applications, including LLM inference pipelines and agent workflows.
+tagline: End-to-end distributed tracing for microservices and AI pipelines
+
+github_url: https://github.com/jaegertracing/jaeger
+website_url: https://www.jaegertracing.io
+docs_url: https://www.jaegertracing.io/docs
+
+category: Monitoring
+tags: [distributed-tracing, observability, microservices, monitoring, opentelemetry, cncf]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  In distributed systems — including LLM serving stacks with multiple model replicas,
+  vector databases, and API gateways — a single user request fans out across dozens of
+  services. Debugging latency spikes or errors without request-level context is nearly
+  impossible. Jaeger provides end-to-end distributed tracing: it captures the full path
+  of each request as it traverses services, showing spans, timing, and errors on an
+  interactive timeline.
+
+use_cases:
+  - Trace multi-step LLM inference requests across model servers, caches, and databases
+  - Identify slow services in an agent orchestration pipeline by visualizing span timing
+  - Correlate errors in production AI systems with upstream service failures
+  - Monitor tail latency distributions across distributed model serving infrastructure
+  - Debug performance regressions after deploying a new model version or routing change

--- a/tools/monitoring/loki.yaml
+++ b/tools/monitoring/loki.yaml
@@ -1,0 +1,28 @@
+name: Loki
+description: A horizontally-scalable, highly-available log aggregation system from Grafana Labs that indexes log metadata rather than full-text, making it cost-effective for storing and querying logs from LLM applications and infrastructure.
+tagline: Log aggregation that's cheap, fast, and natively integrated with Grafana
+
+github_url: https://github.com/grafana/loki
+website_url: https://grafana.com/oss/loki
+docs_url: https://grafana.com/docs/loki/latest
+
+category: Monitoring
+tags: [logging, observability, log-aggregation, monitoring, prometheus, grafana, cloud-native]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Traditional log aggregation systems like Elasticsearch index the full text of every log
+  line, which becomes prohibitively expensive at the scale of modern AI infrastructure —
+  model servers generate gigabytes of access and error logs daily. Loki takes a different
+  approach: it only indexes metadata labels (service name, host, level) and stores log
+  content compressed in object storage. This makes it an order of magnitude cheaper to
+  operate while still enabling fast label-based log search.
+
+use_cases:
+  - Aggregate logs from LLM inference servers, API gateways, and vector databases for centralized search
+  - Correlate error logs with Jaeger traces and Prometheus metrics in Grafana dashboards
+  - Monitor log volume and error rates across AI service deployments with alerting rules
+  - Search and filter production logs by service label, severity, and time range in seconds
+  - Store months of AI infrastructure logs at a fraction of the cost of full-text indexing systems

--- a/tools/monitoring/opentelemetry.yaml
+++ b/tools/monitoring/opentelemetry.yaml
@@ -1,0 +1,30 @@
+name: OpenTelemetry
+description: A vendor-neutral observability framework for generating, collecting, and exporting telemetry data — traces, metrics, and logs — from cloud-native and AI applications. CNCF-incubating project with broad industry adoption.
+tagline: The standard for cloud-native observability — traces, metrics, and logs
+
+github_url: https://github.com/open-telemetry/opentelemetry-python
+website_url: https://opentelemetry.io
+docs_url: https://opentelemetry.io/docs
+
+install_command: pip install opentelemetry-api opentelemetry-sdk
+
+category: Monitoring
+tags: [python, observability, distributed-tracing, metrics, logging, telemetry, cncf]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Every observability vendor and open-source project has its own instrumentation API,
+  agent, and data format — making it costly to switch backends or run multiple tools
+  simultaneously. OpenTelemetry provides a single, vendor-neutral set of APIs, SDKs,
+  and protocols for collecting traces, metrics, and logs from applications. Once
+  instrumented with OpenTelemetry, teams can export data to any compatible backend
+  (Jaeger, Prometheus, Grafana, Datadog, etc.) without code changes.
+
+use_cases:
+  - Auto-instrument Python LLM applications to emit traces for every model call and agent step
+  - Export metrics (latency, token counts, error rates) from inference servers to Prometheus
+  - Build a unified observability pipeline for AI services that can route to multiple backends
+  - Correlate LLM inference traces with infrastructure metrics in a single Grafana dashboard
+  - Enable vendor-portable telemetry so teams can switch observability backends without reinstrumenting


### PR DESCRIPTION
Add 5 monitoring/LLM tools to the catalog:

- **Alibi Detect** — Outlier, adversarial, and drift detection for ML models (SeldonIO/alibi-detect, 2.5k★)
- **Gensim** — Topic modeling, document similarity, and word embeddings library (piskvorky/gensim, 16.4k★)
- **Jaeger** — CNCF distributed tracing platform for microservices and AI pipelines (jaegertracing/jaeger, 22.9k★)
- **Loki** — Horizontally-scalable log aggregation by Grafana Labs (grafana/loki, 28.5k★)
- **OpenTelemetry** — Vendor-neutral observability framework for traces, metrics, and logs (open-telemetry/opentelemetry-python, 2.5k★)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Gensim, Alibi Detect, Jaeger, Loki, and OpenTelemetry.
  * Included descriptions, documentation and project links, installation details, licensing, pricing, categories, and tags.
  * Added practical use cases covering embeddings, topic modeling, monitoring, logging, tracing, metrics, and AI infrastructure diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->