### PR TITLE
Add Spring AI, PyMuPDF, FastEmbed, DocArray, Hyperopt to catalog

### DIFF
--- a/tools/data/docarray.yaml
+++ b/tools/data/docarray.yaml
@@ -1,0 +1,37 @@
+name: DocArray
+description: A library from Jina AI for representing, sending, storing, and retrieving multimodal data — text, image, video, audio, 3D mesh — for AI applications. DocArray provides typed data structures optimized for neural search and vector search pipelines.
+tagline: Multimodal AI data structures for vector search and neural search
+
+github_url: https://github.com/docarray/docarray
+website_url: https://docarray.jina.ai
+docs_url: https://docs.docarray.org
+
+install_command: pip install docarray
+
+category: Data
+tags:
+  - multimodal
+  - data-structures
+  - python
+  - embeddings
+  - vector-search
+  - neural-search
+  - jina
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI applications work with diverse data types — text, images, audio, video, 3D meshes — but
+  standard Python data structures (dicts, lists, dataclasses) don't capture the rich relationships
+  between modalities or serialize efficiently to formats compatible with vector databases and search
+  engines. DocArray provides typed, composable document data structures with built-in embedding
+  support, chunking, serialization to JSON/Protobuf, and first-class integration with vector
+  databases like Qdrant, Elasticsearch, and Weaviate.
+
+use_cases:
+  - Represent multimodal documents with text, images, and embeddings in a single typed data structure
+  - Build neural search pipelines that encode, index, and retrieve across text, image, and audio data
+  - Chunk and preprocess long documents for RAG while preserving document structure and metadata
+  - Serialize AI pipeline intermediates to Protobuf for high-performance inter-service communication
+  - Integrate with vector databases directly through DocArray's built-in storage backends

--- a/tools/data/pymupdf.yaml
+++ b/tools/data/pymupdf.yaml
@@ -1,0 +1,36 @@
+name: PyMuPDF
+description: A high-performance Python library for PDF, XPS, EPUB, and other document format rendering and text extraction. PyMuPDF (MuPDF bindings) is widely used for extracting clean text from PDFs for LLM document ingestion pipelines.
+tagline: Fast Python PDF processing and text extraction
+
+github_url: https://github.com/pymupdf/PyMuPDF
+website_url: https://pymupdf.readthedocs.io
+docs_url: https://pymupdf.readthedocs.io
+
+install_command: pip install pymupdf
+
+category: Data
+tags:
+  - pdf
+  - document-processing
+  - text-extraction
+  - python
+  - ocr
+  - data-pipeline
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  LLM document processing pipelines need to extract clean, structured text from PDFs, but most
+  PDF libraries are either slow (PyPDF2, pdfminer) or produce garbled output with merged columns,
+  missing headings, and lost formatting. PyMuPDF is one of the fastest and most accurate PDF text
+  extraction libraries available, handling complex layouts, tables, images, annotations, and forms
+  with sub-millisecond page rendering. It is the de facto standard for production PDF ingestion
+  into RAG pipelines and document AI workflows.
+
+use_cases:
+  - Extract clean text from PDF invoices, contracts, and reports for RAG document ingestion
+  - Parse academic papers and technical documents with complex multi-column layouts
+  - Build document preprocessing pipelines that extract images, tables, and metadata from PDFs
+  - Convert scanned PDF pages to images for downstream OCR processing with Tesseract or EasyOCR
+  - Render PDF pages for visual document analysis and annotation in AI-powered document review

--- a/tools/dev-tools/spring-ai.yaml
+++ b/tools/dev-tools/spring-ai.yaml
@@ -1,0 +1,35 @@
+name: Spring AI
+description: A Java framework from the Spring team for building AI-powered applications with portable API abstractions across LLMs, vector stores, and document processing tools.
+tagline: Build AI applications with Spring Boot and Java
+
+github_url: https://github.com/spring-projects/spring-ai
+website_url: https://spring.io/projects/spring-ai
+docs_url: https://docs.spring.io/spring-ai/reference/
+
+category: Dev Tools
+tags:
+  - java
+  - spring
+  - ai
+  - framework
+  - enterprise
+  - llm
+  - vector-database
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Java developers integrating AI into enterprise applications face a fragmented ecosystem of LLM
+  providers, vector stores, and embedding models — each with different APIs, authentication, and
+  configuration. Spring AI provides a consistent, portable abstraction layer similar to Spring's
+  JDBC and ORM templates. Developers declare a dependency on an AI provider, configure a chat
+  client bean, and use a unified API to call OpenAI, Anthropic, Ollama, or any supported provider
+  without changing application code. This is essential infrastructure for Java-based AI services.
+
+use_cases:
+  - Build a Java REST API that queries different LLMs (OpenAI, Anthropic, Ollama) with a single abstraction
+  - Implement RAG pipelines in Spring Boot applications using vector store templates for Chroma, Pinecone, or Weaviate
+  - Create enterprise document processing workflows that extract, embed, and index documents for semantic search
+  - Develop conversational AI agents with tool calling and memory persistence in a Spring Boot microservice
+  - Integrate AI-powered features into existing Java enterprise applications without replacing the tech stack

--- a/tools/fine-tuning/hyperopt.yaml
+++ b/tools/fine-tuning/hyperopt.yaml
@@ -1,0 +1,36 @@
+name: Hyperopt
+description: A Python library for distributed hyperparameter optimization using Bayesian algorithms. Hyperopt supports tree-of-Parzen-estimators (TPE), random search, and adaptive TPE for tuning ML and LLM fine-tuning configurations efficiently.
+tagline: Distributed Bayesian hyperparameter optimization for ML training
+
+github_url: https://github.com/hyperopt/hyperopt
+website_url: http://hyperopt.github.io/hyperopt
+docs_url: http://hyperopt.github.io/hyperopt
+
+install_command: pip install hyperopt
+
+category: Fine-tuning
+tags:
+  - hyperparameter-optimization
+  - python
+  - bayesian-optimization
+  - machine-learning
+  - training
+  - distributed
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Fine-tuning LLMs and deep learning models requires extensive hyperparameter tuning — learning
+  rates, LoRA rank, batch sizes, optimizer settings — but brute-force grid search or random search
+  wastes expensive GPU hours and rarely finds optimal configurations. Hyperopt provides intelligent
+  Bayesian optimization algorithms (Tree-of-Parzen-Estimators, adaptive TPE) that converge to good
+  hyperparameters in far fewer trials. Its distributed execution engine scales across clusters and
+  supports early stopping to terminate unpromising trials automatically.
+
+use_cases:
+  - Tune LoRA learning rate, rank, and alpha parameters for LLM fine-tuning in fewer GPU hours
+  - Optimize training hyperparameters for distributed fine-tuning runs across multiple GPUs
+  - Automate hyperparameter search for model quantization and compression configurations
+  - Run parallel hyperparameter sweeps across a cluster with MongoDB-based trial coordination
+  - Combine with early stopping algorithms to terminate underperforming trials and save compute

--- a/tools/llm/fastembed.yaml
+++ b/tools/llm/fastembed.yaml
@@ -1,0 +1,37 @@
+name: FastEmbed
+description: A fast, lightweight Python library from Qdrant for generating state-of-the-art text embeddings with minimal dependencies. FastEmbed uses ONNX Runtime under the hood, supporting BGE, Instructor, Jina, and other popular embedding models.
+tagline: Fast, lightweight text embeddings with ONNX Runtime
+
+github_url: https://github.com/qdrant/fastembed
+website_url: https://qdrant.github.io/fastembed/
+docs_url: https://qdrant.github.io/fastembed/
+
+install_command: pip install fastembed
+
+category: LLM
+tags:
+  - embeddings
+  - python
+  - vector-search
+  - text-encoding
+  - nlp
+  - onnx
+  - qdrant
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Generating text embeddings for production RAG pipelines typically requires loading heavy deep
+  learning frameworks like PyTorch or TensorFlow, which are overkill for the simple inference
+  task of producing embeddings. FastEmbed provides a lean alternative using ONNX Runtime — no GPU
+  required, sub-millisecond inference on CPU, minimal memory footprint. It bundles the most popular
+  embedding models (BGE, Instructor, Jina) as quantized ONNX files, so developers get high-quality
+  embeddings with a single pip install and no GPU dependency.
+
+use_cases:
+  - Generate text embeddings for RAG document ingestion without PyTorch or GPU requirements
+  - Build production embedding pipelines for semantic search across millions of documents on CPU
+  - Create lightweight embedding services for edge devices and resource-constrained environments
+  - Batch-embed text corpora for vector database indexing with Qdrant, Pinecone, or Weaviate
+  - Replace slow or heavy embedding libraries with a fast, memory-efficient alternative


### PR DESCRIPTION
## What's new

Five high-quality open-source tools added to the catalog:

- **Spring AI** (Dev Tools) — Java AI framework from the Spring team (9.1k★) providing portable API abstractions across LLMs, vector stores, and document processing tools for enterprise Java applications.
- **PyMuPDF** (Data) — High-performance Python PDF library (10.2k★) for fast text extraction from PDFs, essential for RAG document ingestion pipelines.
- **FastEmbed** (LLM) — Qdrant's lightweight text embedding library (3.1k★) using ONNX Runtime for fast, CPU-only embedding generation.
- **DocArray** (Data) — Jina AI's multimodal data structures library (3.1k★) for representing text, image, and video documents for neural search.
- **Hyperopt** (Fine-tuning) — Distributed Bayesian hyperparameter optimization library (7.6k★) for tuning ML and LLM fine-tuning configurations efficiently.
