### PR TITLE
Add Phidata, OpenAI Swarm to catalog

### DIFF
--- a/tools/agent-frameworks/openai-swarm.yaml
+++ b/tools/agent-frameworks/openai-swarm.yaml
@@ -1,0 +1,36 @@
+name: OpenAI Swarm
+description: An experimental, lightweight multi-agent orchestration framework from OpenAI that explores ergonomic patterns for agent coordination, handoffs, and routine-based task execution.
+tagline: Lightweight multi-agent orchestration from OpenAI
+
+github_url: https://github.com/openai/swarm
+website_url: https://github.com/openai/swarm
+
+install_command: pip install openai-swarm
+
+category: Agents
+tags:
+  - agents
+  - multi-agent
+  - openai
+  - orchestration
+  - python
+  - handoffs
+  - routines
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Multi-agent systems are powerful but complex: coordinating agent handoffs, managing shared
+  context, and defining clear task boundaries requires significant framework overhead. OpenAI
+  Swarm is a minimal, educational framework that explores two core primitives — routines and
+  handoffs — for building multi-agent coordination. Rather than a production SDK, Swarm serves
+  as a reference implementation of OpenAI's agent design patterns, making it easy to understand
+  and customize agent orchestration for specific use cases.
+
+use_cases:
+  - Learn and experiment with OpenAI's agent routing and handoff design patterns
+  - Build a triage agent that routes customer requests to specialized sub-agents
+  - Implement a multi-step research pipeline with handoffs between search, analysis, and writing agents
+  - Prototype agent orchestration logic with a minimal, readable codebase before scaling
+  - Study reference implementations of function calling, context management, and agent delegation

--- a/tools/agent-frameworks/phidata.yaml
+++ b/tools/agent-frameworks/phidata.yaml
@@ -1,0 +1,37 @@
+name: Phidata
+description: A full-stack Python framework for building AI assistants and multi-agent systems with memory, knowledge, tools, and model-agnostic LLM support. Phidata provides managed infrastructure for deploying production-grade assistants.
+tagline: Build and deploy AI assistants with memory, knowledge, and tools
+
+github_url: https://github.com/phidatahq/phidata
+website_url: https://www.phidata.com
+docs_url: https://docs.phidata.com
+
+install_command: pip install phidata
+
+category: Agents
+tags:
+  - agents
+  - ai-assistant
+  - python
+  - llm
+  - multi-agent
+  - framework
+  - memory
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building a production-ready AI assistant involves much more than calling an LLM: you need
+  persistent memory across sessions, a knowledge base for RAG, tool/function calling, multi-agent
+  orchestration, and deployment infrastructure. Most frameworks handle one or two of these but
+  leave the rest as an exercise to the developer. Phidata is a full-stack assistant framework
+  that bundles memory, knowledge retrieval, tool execution, and one-command deployment — all
+  with model-agnostic LLM support so you're not locked into a single provider.
+
+use_cases:
+  - Build a customer support assistant with session memory, knowledge base, and handoff to human agents
+  - Create a research assistant that searches the web, reads documents, and synthesizes findings
+  - Deploy a multi-agent system where specialized agents collaborate on complex tasks
+  - Develop an internal knowledge assistant connected to company databases and documentation
+  - Launch a production AI assistant on managed infrastructure with monitoring and logging


### PR DESCRIPTION
## What's new

Two agent frameworks added to the catalog:

- **Phidata** (Agents) — Full-stack Python framework for building AI assistants with memory, knowledge, tools, and multi-agent orchestration (41.1k★, Apache-2.0).
- **OpenAI Swarm** (Agents) — OpenAI's experimental lightweight multi-agent orchestration framework exploring routines and handoffs (21.8k★, MIT).
