### PR TITLE
Add Numba, Modin, OpenNMT, Vaex, Fluentd to catalog

### DIFF
--- a/tools/data/fluentd.yaml
+++ b/tools/data/fluentd.yaml
@@ -1,0 +1,42 @@
+name: Fluentd
+description: >-
+  Fluentd is an open-source data collector that unifies log and event data ingestion from diverse
+  sources into a consistent, structured format for storage, search, and analysis. It features a
+  pluggable architecture with hundreds of connectors — handling everything from application logs
+  and infrastructure metrics to ML model inference logs and AI pipeline events — routing data to
+  destinations like Elasticsearch, S3, Kafka, and databases.
+tagline: Unified data collection and routing for log and event pipelines
+
+github_url: https://github.com/fluent/fluentd
+website_url: https://www.fluentd.org
+docs_url: https://docs.fluentd.org
+install_command: gem install fluentd
+
+category: Data
+tags:
+  - data-collection
+  - logging
+  - event-processing
+  - data-pipeline
+  - observability
+  - data-ingestion
+  - etl
+  - infrastructure
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Modern AI and data pipelines generate log and event data from dozens of sources — application
+  servers, model inference endpoints, training jobs, database queries, and infrastructure metrics
+  — but each source has its own format, protocol, and destination. Teams waste time building and
+  maintaining brittle ingestion pipelines. Fluentd provides a unified data collection layer with
+  a pluggable connector ecosystem that normalizes, buffers, and routes events to any destination,
+  so pipelines stay decoupled and resilient without custom ingestion code.
+
+use_cases:
+  - Collect and route ML model inference logs from serving endpoints to monitoring and observability backends
+  - Unify application logs, training metrics, and infrastructure events into a single structured data pipeline
+  - Buffer and reliably forward event data from distributed training clusters to centralized storage
+  - Parse and normalize semi-structured log data from diverse sources into consistent JSON for downstream analysis
+  - Enable real-time monitoring dashboards by streaming pipeline and system events to Elasticsearch and Grafana

--- a/tools/data/modin.yaml
+++ b/tools/data/modin.yaml
@@ -1,0 +1,40 @@
+name: Modin
+description: >-
+  Modin is a drop-in replacement for pandas that parallelizes DataFrame operations across all
+  available CPU cores and cluster resources. It scales to multi-terabyte datasets by distributing
+  computation across Ray, Dask, or MPI backends with minimal code changes — often just changing
+  the import statement from import pandas as pd to import modin.pandas as pd.
+tagline: Drop-in parallel pandas — scale DataFrames across cores and clusters
+
+github_url: https://github.com/modin-project/modin
+website_url: https://modin.readthedocs.io
+docs_url: https://modin.readthedocs.io
+install_command: pip install "modin[ray]"
+
+category: Data
+tags:
+  - dataframe
+  - pandas
+  - parallel
+  - distributed
+  - ray
+  - dask
+  - data-processing
+  - python
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Data scientists and ML engineers hit performance and memory walls when processing datasets that
+  exceed a single machine's RAM or CPU capacity with pandas. Modin eliminates this bottleneck by
+  transparently parallelizing DataFrame operations across the available hardware — from multi-core
+  laptops to multi-node Ray clusters — without requiring users to learn distributed computing APIs.
+  The same pandas code automatically scales to larger-than-memory and multi-terabyte datasets.
+
+use_cases:
+  - Process large CSV and Parquet datasets that exceed single-machine memory by distributing across cluster workers
+  - Parallelize data cleaning, feature engineering, and ETL operations across all CPU cores without API changes
+  - Scale pandas-based ML preprocessing pipelines from a laptop to a production Ray cluster seamlessly
+  - Handle multi-terabyte joins, aggregations, and group-by operations that would OOM on standard pandas
+  - Accelerate exploratory data analysis on large datasets by splitting work across distributed workers

--- a/tools/data/vaex.yaml
+++ b/tools/data/vaex.yaml
@@ -1,0 +1,41 @@
+name: Vaex
+description: >-
+  Vaex is an out-of-core DataFrame library for Python that enables visualization and exploration
+  of large tabular datasets on a laptop. It uses lazy evaluation, memory mapping, and efficient
+  columnar operations to handle datasets that don't fit in RAM — processing billions of rows with
+  sub-second interactivity without sampling or aggregating away detail.
+tagline: Explore and visualize billion-row datasets on a laptop
+
+github_url: https://github.com/vaexio/vaex
+website_url: https://vaex.io
+docs_url: https://vaex.io/docs
+install_command: pip install vaex
+
+category: Data
+tags:
+  - dataframe
+  - visualization
+  - out-of-core
+  - big-data
+  - python
+  - exploration
+  - lazy-evaluation
+  - memory-mapping
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: >-
+  Data scientists regularly work with tabular datasets too large to fit in RAM — logs, time-series
+  data, clickstreams, and scientific measurements — but most tools either sample the data (losing
+  detail) or require a cluster. Vaex solves this with an out-of-core, lazy-evaluation DataFrame
+  that memory-maps data from disk and only computes what is needed for the current query, enabling
+  interactive exploration, aggregation, and visualization of billion-row datasets on a single
+  machine without specialized infrastructure.
+
+use_cases:
+  - Interactively explore and visualize billion-row log and event datasets without loading them into RAM
+  - Compute summary statistics, histograms, and heatmaps on large time-series data with sub-second latency
+  - Filter, group, and aggregate streaming or archival datasets using lazy evaluation for instant response
+  - Display interactive scatter plots and density maps of large geospatial or ML feature datasets
+  - Preprocess and clean massive tabular datasets for downstream ML training pipelines efficiently

--- a/tools/dev-tools/numba.yaml
+++ b/tools/dev-tools/numba.yaml
@@ -1,0 +1,40 @@
+name: Numba
+description: >-
+  Numba is a high-performance JIT compiler for Python that translates a subset of Python and NumPy
+  code into optimized machine code using LLVM. With a simple decorator, it accelerates numerical
+  and array-oriented computations to speeds approaching C or Fortran — essential for data science,
+  ML pipelines, simulation, and any Python workload that bottlenecks on tight loops.
+tagline: JIT-compile Python numerical code to near-machine speed
+
+github_url: https://github.com/numba/numba
+website_url: https://numba.pydata.org
+docs_url: https://numba.readthedocs.io
+install_command: pip install numba
+
+category: Dev Tools
+tags:
+  - jit
+  - compiler
+  - python
+  - performance
+  - numpy
+  - llvm
+  - numerical-computing
+  - gpu
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+problem_solved: >-
+  Python's dynamic nature makes numerical and scientific code slow — pure Python loops over arrays
+  can be 10–100x slower than C or Fortran equivalents, forcing developers to rewrite hot paths in
+  a compiled language. Numba solves this by JIT-compiling annotated Python functions at runtime
+  with LLVM, generating optimized CPU or GPU machine code from ordinary Python and NumPy code so
+  developers get C-like performance without leaving Python or rewriting their algorithms.
+
+use_cases:
+  - Accelerate tight numerical loops in data processing and numerical simulation pipelines
+  - Compile machine learning preprocessing and feature engineering steps for faster training throughput
+  - Run vectorized NumPy operations on GPU hardware without rewriting code in CUDA directly
+  - Speed up Monte Carlo simulations, optimization routines, and scientific computing workloads
+  - Optimize custom loss functions, activation computations, and gradient calculations in ML training

--- a/tools/llm/opennmt.yaml
+++ b/tools/llm/opennmt.yaml
@@ -1,0 +1,41 @@
+name: OpenNMT
+description: >-
+  OpenNMT is an open-source neural machine translation toolkit that provides complete workflows
+  for training and deploying sequence-to-sequence models. It supports transformer architectures,
+  multi-GPU training, model quantization, and serves production-ready translation systems with a
+  lightweight inference server for multilingual NLP pipelines.
+tagline: Open-source neural machine translation toolkit
+
+github_url: https://github.com/OpenNMT/OpenNMT-py
+website_url: https://opennmt.net
+docs_url: https://opennmt.net/OpenNMT-py
+install_command: pip install OpenNMT-py
+
+category: LLM
+tags:
+  - machine-translation
+  - neural-networks
+  - seq2seq
+  - transformer
+  - nlp
+  - pytorch
+  - multilingual
+  - inference
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: >-
+  Building production-quality neural machine translation systems requires significant expertise in
+  sequence-to-sequence modeling, data preprocessing, model training, and serving infrastructure.
+  OpenNMT provides a complete, modular toolkit that handles the entire translation pipeline — data
+  tokenization and batching, transformer-based model training on single or multi-GPU setups, model
+  export, and lightweight inference serving — so teams can deploy multilingual translation without
+  building NLP infrastructure from scratch.
+
+use_cases:
+  - Train custom neural machine translation models for domain-specific language pairs and terminology
+  - Deploy a multilingual translation inference server for real-time and batch translation pipelines
+  - Fine-tune pre-trained transformer models on translation tasks with specialized vocabulary and style
+  - Build cross-lingual NLP pipelines that translate input text before downstream analysis and classification
+  - Experiment with sequence-to-sequence architectures for text generation, summarization, and paraphrasing


### PR DESCRIPTION
Add Numba, Modin, OpenNMT, Vaex, and Fluentd to the Agentic AI For Good tool catalog.

## Tools added

| Tool | Category | Stars | Description |
|------|----------|-------|-------------|
| **Numba** | Dev Tools | 11k★ | JIT compiler for Python numerical code using LLVM |
| **Modin** | Data | 10.4k★ | Drop-in parallel pandas — scale DataFrames across cores |
| **OpenNMT** | LLM | 7k★ | Open-source neural machine translation toolkit |
| **Vaex** | Data | 8.5k★ | Out-of-core DataFrame for billion-row dataset exploration |
| **Fluentd** | Data | 13.6k★ | Unified data collector for log and event pipelines |

Fills LLM (+1), Data (+3), and Dev Tools (+1) categories.
