### PR TITLE
Add cuDF, cuML, cuGraph to catalog

### DIFF
--- a/tools/data/cudf.yaml
+++ b/tools/data/cudf.yaml
@@ -1,0 +1,41 @@
+name: cuDF
+description: >-
+  cuDF is a GPU DataFrame library for loading, joining, aggregating, filtering, and manipulating
+  tabular data at GPU speeds. It provides a pandas-like API powered by the RAPIDS ecosystem,
+  delivering 10–50x speedups on ETL, data preparation, and feature engineering pipelines by
+  executing operations on NVIDIA GPUs instead of CPU cores.
+tagline: GPU-accelerated DataFrame library with a pandas-like API
+
+github_url: https://github.com/rapidsai/cudf
+website_url: https://rapids.ai
+docs_url: https://docs.rapids.ai/api/cudf/stable
+install_command: pip install cudf-cu12
+
+category: Data
+tags:
+  - gpu
+  - dataframe
+  - pandas
+  - rapids
+  - data-processing
+  - etl
+  - nvidia
+  - parallel
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Data processing and feature engineering on large datasets is bottlenecked by CPU parallelism
+  limits — pandas operations on multi-gigabyte DataFrames take minutes or hours, and scaling to
+  clusters adds operational complexity. cuDF solves this by reimplementing the pandas API on GPU
+  hardware, executing operations in parallel across thousands of CUDA cores so that common data
+  transformations — joins, group-bys, filters, and aggregations — run 10–50x faster without
+  requiring changes to existing pandas code or cluster infrastructure.
+
+use_cases:
+  - Accelerate ETL and data preparation pipelines by 10–50x with GPU-parallel DataFrame operations
+  - Run pandas-compatible joins, group-bys, and aggregations on large datasets using a single GPU
+  - Preprocess and feature-engineer training data for ML pipelines with GPU-accelerated transformations
+  - Process real-time streaming features and batch data at GPU speed for downstream model training
+  - Replace CPU-bound data wrangling in ML pipelines with drop-in GPU-accelerated DataFrame operations

--- a/tools/dev-tools/cuml.yaml
+++ b/tools/dev-tools/cuml.yaml
@@ -1,0 +1,40 @@
+name: cuML
+description: >-
+  cuML is a suite of GPU-accelerated machine learning algorithms that implements scikit-learn-like
+  APIs for training and inference on NVIDIA GPUs. It covers classification, regression, clustering,
+  dimensionality reduction, and feature engineering — delivering 10–50x speedups over CPU-based
+  implementations by leveraging the RAPIDS ecosystem and CUDA-optimized primitives.
+tagline: GPU-accelerated ML algorithms with scikit-learn-compatible APIs
+
+github_url: https://github.com/rapidsai/cuml
+website_url: https://rapids.ai
+docs_url: https://docs.rapids.ai/api/cuml/stable
+install_command: pip install cuml-cu12
+
+category: Dev Tools
+tags:
+  - gpu
+  - machine-learning
+  - scikit-learn
+  - rapids
+  - training
+  - inference
+  - nvidia
+  - parallel
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Traditional ML libraries like scikit-learn are CPU-bound, limiting training and inference speed
+  on large datasets even with multi-core processors. cuML eliminates this bottleneck by porting
+  the most common ML algorithms — random forests, gradient boosting, PCA, UMAP, KNN, and linear
+  models — to run on NVIDIA GPUs with a familiar, scikit-learn-compatible API so data scientists
+  get GPU-speed training and inference without learning new frameworks or rewriting their pipelines.
+
+use_cases:
+  - Train random forest and gradient boosting models on large datasets at GPU speed instead of CPU-bound scikit-learn
+  - Accelerate dimensionality reduction (PCA, UMAP, t-SNE) and clustering (DBSCAN, K-Means) on GPU hardware
+  - Run GPU-powered nearest neighbor search and similarity matching in real-time ML inference pipelines
+  - Replace CPU-based feature engineering with GPU-parallel transformations for faster experimentation
+  - Build end-to-end GPU-accelerated ML training pipelines that keep data on-GPU across preprocessing and modeling

--- a/tools/other/cugraph.yaml
+++ b/tools/other/cugraph.yaml
@@ -1,0 +1,41 @@
+name: cuGraph
+description: >-
+  cuGraph is a GPU-accelerated graph analytics library that provides a NetworkX-compatible API for
+  analyzing large-scale graphs — centrality, community detection, pathfinding, and clustering — at
+  GPU speeds. Built on RAPIDS, it scales to graphs with billions of edges on a single GPU by
+  parallelizing graph algorithms across thousands of CUDA cores.
+tagline: GPU-accelerated graph analytics with a NetworkX-compatible API
+
+github_url: https://github.com/rapidsai/cugraph
+website_url: https://rapids.ai
+docs_url: https://docs.rapids.ai/api/cugraph/stable
+install_command: pip install cugraph-cu12
+
+category: Other
+tags:
+  - gpu
+  - graph-analytics
+  - networkx
+  - rapids
+  - graph
+  - nvidia
+  - parallel
+  - graph-algorithms
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Graph analytics workloads on real-world graphs — social networks, knowledge graphs, fraud
+  networks, and infrastructure topologies — are computationally intensive and quickly exceed the
+  capacity of CPU-based libraries like NetworkX. cuGraph solves this by reimplementing graph
+  algorithms (PageRank, Louvain community detection, betweenness centrality, BFS, and SSSP) on
+  GPU hardware, enabling analysts and data scientists to run graph computations on billion-edge
+  graphs in seconds instead of hours without changing their high-level API patterns.
+
+use_cases:
+  - Run PageRank, centrality, and community detection on billion-edge knowledge graphs at GPU speeds
+  - Detect fraud rings and anomalous connection patterns in large-scale transaction networks in real time
+  - Analyze social network graphs and recommendation system graphs with GPU-accelerated pathfinding
+  - Perform large-scale graph clustering and partitioning for distributed ML training and data pipelines
+  - Compute shortest paths and connectivity in infrastructure and logistics networks at interactive speeds


### PR DESCRIPTION
Add cuDF, cuML, and cuGraph to the Agentic AI For Good tool catalog.

## Tools added

| Tool | Category | Stars | Description |
|------|----------|-------|-------------|
| **cuDF** | Data | 9.7k★ | GPU-accelerated DataFrame library with pandas-like API (RAPIDS) |
| **cuML** | Dev Tools | 5.2k★ | GPU-accelerated ML algorithms with scikit-learn-compatible APIs (RAPIDS) |
| **cuGraph** | Other | 2.2k★ | GPU-accelerated graph analytics with NetworkX-compatible API (RAPIDS) |

Fills Data (+1), Dev Tools (+1), and Other (+1) categories.
