### PR TITLE
Add Apache Solr, OpenSPG, ScyllaDB, Sphinx to catalog

### DIFF
--- a/tools/other/sphinx.yaml
+++ b/tools/other/sphinx.yaml
@@ -1,0 +1,25 @@
+name: Sphinx
+description: |
+  Sphinx is an open-source full-text search server designed for high performance, relevance, and integration simplicity. It indexes and searches data from SQL databases, NoSQL storage, or flat files, supporting batch indexing, real-time indexes, and three client interfaces: SphinxQL (SQL dialect), SphinxAPI (native protocol), and SphinxSE (MySQL storage engine). Written in C++, Sphinx powers Craigslist's site search across hundreds of millions of monthly queries.
+tagline: High-performance full-text search server
+
+github_url: https://github.com/sphinxsearch/sphinx
+website_url: https://sphinxsearch.com
+docs_url: https://sphinxsearch.com/docs/
+
+category: Other
+tags: [full-text-search, search-engine, sphinxql, information-retrieval, indexing, c-plus-plus]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Traditional SQL databases lack efficient full-text search at scale, and dedicated search engines like Elasticsearch can be operationally heavy. Sphinx fills the gap by providing fast, relevant full-text search with SQL-like syntax, minimal dependencies, and seamless MySQL and PostgreSQL integration — all in a lightweight C++ daemon that can index tens of millions of documents in minutes and serve thousands of queries per second.
+
+use_cases:
+  - Power high-traffic website search serving hundreds of millions of monthly queries across clustered search nodes
+  - Provide faceted full-text product catalog search with relevance ranking, filtering, and real-time indexing from MySQL or PostgreSQL backends
+  - Replace built-in database full-text search in platforms like vBulletin and MediaWiki to dramatically improve speed and relevance on large datasets
+  - Enable SQL-level search integration via the SphinxSE storage engine, letting MySQL queries directly access full-text search results
+
+install_command: sudo apt-get install sphinxsearch

--- a/tools/rag/openspg.yaml
+++ b/tools/rag/openspg.yaml
@@ -1,0 +1,25 @@
+name: OpenSPG
+description: |
+  OpenSPG is a knowledge graph engine for building domain-specific knowledge graphs and GraphRAG applications. It provides semantic modeling, knowledge construction, and logical rule reasoning, and natively supports KAG (Knowledge Augmented Generation) — combining structured knowledge graphs with LLMs for logical reasoning and factual question answering. Developed by Ant Group in collaboration with OpenKG.
+tagline: Knowledge graph engine for GraphRAG and knowledge-augmented generation
+
+github_url: https://github.com/OpenSPG/openspg
+website_url: https://openspg.github.io/v2/
+docs_url: https://openspg.github.io/v2/docs_en
+
+category: RAG
+tags: [knowledge-graph, graphrag, rag, knowledge-augmented-generation, llm, semantic-reasoning, python, java]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Traditional RAG systems rely on vector similarity search, which suffers from semantic ambiguity and cannot effectively handle structured knowledge relationships. Meanwhile, naive GraphRAG approaches using OpenIE introduce noise from incorrect triple extraction. OpenSPG provides a knowledge-augmented generation framework that integrates structured knowledge graphs via SPG semantic modeling with LLMs, enabling logical-form-guided reasoning, factual accuracy, and multi-hop question answering for professional domains where precision is critical.
+
+use_cases:
+  - Build logical reasoning and factual question answering systems for professional domains like finance, legal, and healthcare using structured knowledge graphs connected to LLMs
+  - Overcome traditional RAG vector similarity limitations for complex queries that require traversing multiple entity relationships in a knowledge graph
+  - Power financial risk analysis, compliance checks, and fraud detection using domain-specific knowledge graphs with Ant Group's production-proven approach
+  - Enable knowledge-augmented document retrieval where complete contextual text information is integrated with graph relationships for more accurate results
+
+install_command: pip install openspg-kag

--- a/tools/vector-databases/scylladb.yaml
+++ b/tools/vector-databases/scylladb.yaml
@@ -1,0 +1,26 @@
+name: ScyllaDB
+description: |
+  ScyllaDB is a high-performance distributed NoSQL wide-column database compatible with Apache Cassandra and Amazon DynamoDB. Built on C++ with a shard-per-core architecture, it delivers predictable low-latency and high-throughput performance. ScyllaDB 6.x and later supports native ANN vector search (HNSW-based) for real-time AI workloads including RAG, semantic caching, feature stores, and billion-scale similarity search.
+tagline: High-performance NoSQL database with native vector search
+
+github_url: https://github.com/scylladb/scylladb
+website_url: https://www.scylladb.com
+docs_url: https://docs.scylladb.com
+
+category: Vector DB
+tags: [nosql, wide-column, cassandra-compatible, dynamodb-compatible, vector-database, ann, hnsw, similarity-search, rag, semantic-caching, distributed]
+pricing: freemium
+is_open_source: false
+license: ScyllaDB Source Available License
+
+problem_solved: |
+  Traditional NoSQL databases lack native vector embedding support for AI workloads, while dedicated vector databases struggle with high-throughput transactional workloads, forcing teams to maintain separate systems. ScyllaDB unifies a high-performance wide-column store with native HNSW-based ANN vector search, enabling real-time AI applications — RAG, semantic caching, feature stores — at billion-scale with sub-2ms P99 latency within a single Cassandra-compatible database.
+
+use_cases:
+  - Store and retrieve document and embedding vectors for retrieval-augmented generation to augment LLM responses with domain-specific context at scale
+  - Cache LLM responses based on embedding similarity to reduce API costs and improve response latency for repeated or similar queries
+  - Serve millions of feature vectors per second for online model inference in recommendation, fraud detection, and personalization systems
+  - Run billion-scale product, image, or video semantic similarity search using ANN (HNSW) with sub-2ms P99 latency
+
+install_command: |
+  docker pull scylladb/scylla

--- a/tools/vector-databases/solr.yaml
+++ b/tools/vector-databases/solr.yaml
@@ -1,0 +1,26 @@
+name: Apache Solr
+description: |
+  Apache Solr is a blazing-fast, open source, multi-modal search platform built on Apache Lucene. It powers full-text, vector, and geospatial search at many of the world's largest organizations. With its DenseVectorField type and k-NN query parsers, Solr enables dense vector indexing and similarity search alongside traditional search, faceting, and analytics — all through a RESTful API.
+tagline: Multi-modal search platform with vector and full-text capabilities
+
+github_url: https://github.com/apache/solr
+website_url: https://solr.apache.org
+docs_url: https://solr.apache.org/guide/solr/latest/
+
+category: Vector DB
+tags: [search, vector-database, full-text-search, semantic-search, lucene, enterprise-search, information-retrieval, geospatial-search]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Organizations need a single scalable platform that combines traditional full-text search with modern vector and semantic search across multi-modal data — text, embeddings, geospatial. Maintaining separate systems for lexical search and vector similarity doubles operational complexity and infrastructure costs. Solver solves this by providing hybrid search capabilities — lexical, vector, and geospatial — all through a unified RESTful API built on Lucene, eliminating the need to manage separate search and vector database systems.
+
+use_cases:
+  - Index documents with dense vector embeddings for semantic similarity retrieval alongside keyword search across large enterprise corpora
+  - Store and query vector embeddings for retrieval-augmented generation pipelines, enabling AI agents to find relevant context via k-NN search
+  - Power faceted e-commerce navigation, "more like this" recommendations, and visual similarity search using combined text and vector queries
+  - Run geospatial-aware search over location-tagged content combined with semantic and keyword filters
+
+install_command: |
+  docker pull solr


### PR DESCRIPTION
## Tools added

| Tool | Category | GitHub Stars | Description |
|------|----------|-------------|-------------|
| Apache Solr | Vector DB | 1.6k★ | Multi-modal search platform on Lucene with DenseVectorField vector search |
| OpenSPG | RAG | 2.2k★ | Knowledge graph engine for GraphRAG and knowledge-augmented generation (by Ant Group) |
| ScyllaDB | Vector DB | 15.7k★ | Distributed NoSQL database with native HNSW-based ANN vector search |
| Sphinx | Other | 1.8k★ | High-performance full-text search server powering Craigslist |

All validated locally. Bringing coverage to RAG (45→46), Vector DB (48→50), Other (88→89).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable catalog entries for Sphinx and OpenSPG.
  * Added Vector Database entries for ScyllaDB and Apache Solr.
  * Included descriptions, use cases, documentation links, licensing details, and installation instructions for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->