### PR TITLE
Add MergeKit, Adapters, CockroachDB, EdgeDB, Apache Age to catalog

### DIFF
--- a/tools/fine-tuning/adapters.yaml
+++ b/tools/fine-tuning/adapters.yaml
@@ -1,0 +1,25 @@
+name: Adapters
+description: |
+  Adapters is a unified library for parameter-efficient and modular transfer learning. It integrates over ten adapter methods — including LoRA, Pfeiffer, Houlsby, Prefix Tuning, and IA3 — into twenty-plus state-of-the-art Transformer models with minimal coding overhead. Built as an add-on to HuggingFace Transformers, it enables fine-tuning billion-parameter models on a single GPU.
+tagline: Parameter-efficient transfer learning with adapter methods
+
+github_url: https://github.com/Adapter-Hub/adapters
+website_url: https://adapterhub.ml
+docs_url: https://docs.adapterhub.ml
+
+category: Fine-tuning
+tags: [peft, parameter-efficient-fine-tuning, lora, adapters, transfer-learning, nlp, transformers, huggingface]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Full fine-tuning of large transformer models requires updating billions of parameters, demanding high-end GPUs and extensive memory. Adapters solves this by injecting small, trainable bottleneck modules into frozen pretrained models, reducing storage per task to a few megabytes and enabling fine-tuning on consumer hardware while retaining 95% or more of full fine-tuning performance across a wide range of NLP tasks.
+
+use_cases:
+  - Fine-tune billion-parameter LLMs on consumer GPUs using LoRA and QLoRA adapters, reducing trainable parameters by over 99 percent
+  - Compose multiple task-specific adapters on a shared frozen backbone for efficient multi-task inference without separate models
+  - Apply MAD-X language adapters to adapt multilingual models to new languages with minimal target-language data
+  - Train and share lightweight adapter modules via the AdapterHub repository for easy community reuse
+
+install_command: pip install adapters

--- a/tools/fine-tuning/mergekit.yaml
+++ b/tools/fine-tuning/mergekit.yaml
@@ -1,0 +1,25 @@
+name: MergeKit
+description: |
+  MergeKit is a toolkit for merging pre-trained large language models using an out-of-core approach. It supports linear merging, SLERP, TIES, DARE, DARE-TIES, Model Soups, Task Arithmetic, MoE merging, Arcee Fusion, and evolutionary optimization — all configured via YAML. Merges run on CPU or as little as 8GB of VRAM, and the resulting merged models retain single-model inference cost.
+tagline: Toolkit for merging pre-trained language models
+
+github_url: https://github.com/arcee-ai/mergekit
+website_url: https://github.com/arcee-ai/mergekit
+docs_url: https://docs.arcee.ai/merging/mergekit
+
+category: Fine-tuning
+tags: [llm, model-merging, fine-tuning, pytorch, transformers, slerp, ties, dare]
+pricing: free
+is_open_source: true
+license: LGPL-3.0
+
+problem_solved: |
+  Combining the strengths of multiple pre-trained LLMs — one strong at code, another at reasoning, a third at instruction following — traditionally requires expensive retraining or large GPU clusters. MergeKit solves this with an out-of-core merging approach that lets practitioners compose models on CPU or modest GPUs, democratizing access to advanced model composition techniques like TIES, DARE, and evolutionary optimization.
+
+use_cases:
+  - Combine multiple domain-specialized fine-tunes (code, math, instruction) into a single model without retraining
+  - Merge top-performing open-source checkpoints from leaderboards to create state-of-the-art models
+  - Replace an ensemble of models with a single merged model at equivalent quality but lower inference cost
+  - Automatically discover optimal merge recipes via evolutionary optimization (mergekit-evolve)
+
+install_command: pip install mergekit

--- a/tools/vector-databases/apache-age.yaml
+++ b/tools/vector-databases/apache-age.yaml
@@ -1,0 +1,26 @@
+name: Apache Age
+description: |
+  Apache AGE (A Graph Extension) is a PostgreSQL extension that adds graph database capabilities on top of existing relational data. It enables Cypher (openCypher) graph queries alongside standard SQL, supports ACID transactions, and can be combined with pgvector for hybrid graph and vector AI workloads — all within a single PostgreSQL instance.
+tagline: Graph database extension for PostgreSQL
+
+github_url: https://github.com/apache/age
+website_url: https://age.apache.org
+docs_url: https://age.apache.org/age-manual/master/index.html
+
+category: Vector DB
+tags: [graph-database, postgresql-extension, cypher, opencypher, multi-model, knowledge-graph, pgvector, graphrag]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Traditional relational databases struggle with complex connected data queries such as multi-hop relationships and graph traversals, while standalone graph databases require separate infrastructure and break transactional consistency. Apache AGE bridges this gap by bringing native graph querying with openCypher directly into PostgreSQL, eliminating the need for a separate graph database while preserving ACID transactions, SQL compatibility, triggers, and the full PostgreSQL ecosystem.
+
+use_cases:
+  - Combine knowledge graphs with pgvector for structurally and semantically aware retrieval augmented generation (GraphRAG)
+  - Traverse connected transaction patterns and entity relationships in real-time for fraud detection and analysis
+  - Build, store, and query rich entity-relationship knowledge graphs directly on existing PostgreSQL infrastructure
+  - Power recommendation engines by modeling user-product interactions as a graph with Cypher traversal queries
+
+install_command: |
+  docker pull apache/age

--- a/tools/vector-databases/cockroachdb.yaml
+++ b/tools/vector-databases/cockroachdb.yaml
@@ -1,0 +1,26 @@
+name: CockroachDB
+description: |
+  CockroachDB is a cloud-native distributed SQL database with built-in pgvector-compatible vector search (added in v24.2). It enables AI applications to store, index, and query high-dimensional vector embeddings alongside relational operational data in a single strongly-consistent, resilient database. Its distributed architecture provides automatic failover, horizontal scaling, and geo-replication.
+tagline: Distributed SQL database with native vector search
+
+github_url: https://github.com/cockroachdb/cockroach
+website_url: https://www.cockroachlabs.com
+docs_url: https://www.cockroachlabs.com/docs/stable/vector
+
+category: Vector DB
+tags: [distributed-sql, vector-database, pgvector, vector-search, ai-embeddings, cloud-native, geo-replication]
+pricing: freemium
+is_open_source: false
+license: Business Source License
+
+problem_solved: |
+  Traditional databases lack native vector search for AI embeddings, forcing teams to maintain separate vector databases that add operational complexity and break transactional consistency. CockroachDB unifies vector and relational data in a single distributed SQL database, eliminating data silos between AI and operational workloads while providing geo-distributed fault tolerance, horizontal scale, and PostgreSQL compatibility.
+
+use_cases:
+  - Store document embeddings and perform pgvector-compatible cosine similarity search alongside structured metadata queries for RAG pipelines
+  - Combine user preference vectors with real-time operational data for globally distributed AI-powered recommendation systems
+  - Unify text embeddings, image vectors, and structured business data in one database for multi-modal AI applications
+  - Serve as persistent, geo-replicated storage for AI agent conversational memory, knowledge graphs, and tool-use state across regions
+
+install_command: |
+  docker run -d --name=roach -p 26257:26257 cockroachdb/cockroach:latest start-single-node --insecure

--- a/tools/vector-databases/edgedb.yaml
+++ b/tools/vector-databases/edgedb.yaml
@@ -1,0 +1,25 @@
+name: EdgeDB
+description: |
+  EdgeDB (now Gel) is an open-source graph-relational database built on PostgreSQL. It combines relational databases, graph databases, and ORM capabilities with EdgeQL — a modern query language. Since v3.0, it natively supports pgvector for vector similarity search, making it a unified platform for structured data, graph relationships, and AI embeddings.
+tagline: Graph-relational database with pgvector for AI workloads
+
+github_url: https://github.com/geldata/gel
+website_url: https://www.geldata.com
+docs_url: https://docs.geldata.com
+
+category: Vector DB
+tags: [graph-relational, vector-database, postgresql, pgvector, embeddings, semantic-search, edgeql, gel]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Traditional databases lack native vector search, forcing developers to run a separate vector database alongside their primary store. EdgeDB solves this by integrating pgvector directly into a graph-relational database on PostgreSQL, letting teams store structured data, relationships, and AI embeddings together with a single query language — eliminating data silos and reducing operational complexity for AI applications.
+
+use_cases:
+  - Store document chunk embeddings and perform semantic similarity search to retrieve relevant context for RAG pipelines within the same database as application data
+  - Build search engines that understand meaning using cosine similarity and pgvector indexes on product descriptions or knowledge bases
+  - Persist AI agent conversation history, tool outputs, and contextual state as vector embeddings for long-term memory and retrieval-augmented reasoning
+  - Find similar items via vector distance queries while combining graph relationships with embedding similarity for hybrid recommendations
+
+install_command: pip install gel


### PR DESCRIPTION
## Tools added

| Tool | Category | GitHub Stars | Description |
|------|----------|-------------|-------------|
| MergeKit | Fine-tuning | 7.2k★ | Toolkit for merging pre-trained LLMs via TIES, DARE, SLERP, evolutionary optimization |
| Adapters | Fine-tuning | 2.8k★ | Parameter-efficient transfer learning library with LoRA, Pfeiffer, Prefix Tuning, and more |
| CockroachDB | Vector DB | 32.3k★ | Cloud-native distributed SQL with pgvector-compatible vector search (v24.2+) |
| EdgeDB (Gel) | Vector DB | 14.1k★ | Open-source graph-relational database with native pgvector for AI workloads |
| Apache Age | Vector DB | 4.7k★ | PostgreSQL graph extension with openCypher, combinable with pgvector for GraphRAG |

All validated locally. Bringing Fine-tuning (46→48), Vector DB (50→53).
