### PR TITLE
Add RocksDB, FoundationDB to catalog

### DIFF
--- a/tools/data/foundationdb.yaml
+++ b/tools/data/foundationdb.yaml
@@ -1,0 +1,26 @@
+name: FoundationDB
+description: |
+  FoundationDB is a distributed transactional key-value store providing ACID transactions with strict serializability across clusters of commodity servers. Its unique layered architecture — core KV store with Record Layer, Document Layer, and more — uses deterministic simulation testing for production-grade reliability. It powers Apple iCloud and Snowflake's metadata infrastructure.
+tagline: Distributed database with ACID transactions at scale
+
+github_url: https://github.com/apple/foundationdb
+website_url: https://www.foundationdb.org
+docs_url: https://apple.github.io/foundationdb
+
+category: Data
+tags: [distributed-database, key-value-store, acid-transactions, nosql, transactional, apple, foundationdb]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  There is a fundamental trade-off between ACID transactions and horizontal scalability in database systems: traditional relational databases offer strong consistency but struggle to scale, while NoSQL databases scale well but sacrifice transactional guarantees. FoundationDB resolves this by delivering distributed ACID transactions with strict serializability at scale, enabling applications to maintain data integrity while scaling elastically across commodity hardware.
+
+use_cases:
+  - Serve as the metadata layer for Snowflake's cloud data warehouse, managing petabytes of metadata with ACID guarantees
+  - Power the infrastructure backend for Apple iCloud services, storing user data with strict consistency across global clusters
+  - Provide transactional state storage for AI and ML pipeline metadata, configuration management, and workflow orchestration
+  - Enable multi-model data storage via layered architecture supporting record, document, and graph data models on a single core
+
+install_command: |
+  docker pull foundationdb/foundationdb

--- a/tools/data/rocksdb.yaml
+++ b/tools/data/rocksdb.yaml
@@ -1,0 +1,25 @@
+name: RocksDB
+description: |
+  RocksDB is an embeddable, persistent key-value store developed by Meta (Facebook) for fast flash and RAM storage. It uses an LSM-tree architecture optimized for high read and write throughput, low latency, and efficient compression. Not an SQL database — it is a C++ library for embedding into applications, widely used as the storage engine in ML pipelines, stream processors, and distributed databases.
+tagline: Embeddable persistent key-value store for fast storage
+
+github_url: https://github.com/facebook/rocksdb
+website_url: https://rocksdb.org
+docs_url: https://rocksdb.org/docs/getting-started.html
+
+category: Data
+tags: [key-value-store, embedded-database, lsm-tree, persistent-storage, nosql, storage-engine, cpp]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Traditional SQL databases suffer from high write amplification on flash storage, making them suboptimal for embedded, stateful applications that require high throughput and low latency on SSDs. RocksDB's LSM-tree architecture minimizes write, read, and space amplification, delivering predictable high performance on flash and RAM for applications ranging from stream processors to ML pipeline state stores.
+
+use_cases:
+  - Serve as the embedded state store for Apache Flink and Kafka Streams, enabling fault-tolerant, low-latency stream processing with checkpointing
+  - Power the storage engine for MyRocks, CockroachDB, and YugabyteDB as a persistent, compressed storage layer for distributed SQL databases
+  - Store model checkpoints, feature vectors, and intermediate state for Ray and Flink ML pipelines at scale
+  - Provide the persistent storage backend for LinkedIn's follow feed, processing user activities and timeline data at massive scale
+
+install_command: brew install rocksdb


### PR DESCRIPTION
## Tools added

| Tool | Category | GitHub Stars | Description |
|------|----------|-------------|-------------|
| RocksDB | Data | 31.9k★ | Embeddable persistent key-value store by Meta, LSM-tree optimized, used in Flink, Kafka Streams, Ray |
| FoundationDB | Data | 16.5k★ | Distributed ACID transactional key-value store by Apple, powers Snowflake metadata and iCloud |

All validated locally. Data category (105→107).
