### PR TITLE
Add SillyTavern, Stable Diffusion WebUI, Jupyter AI, LangChain4j, ChatDev to catalog

### DIFF
--- a/tools/agent-frameworks/chatdev.yaml
+++ b/tools/agent-frameworks/chatdev.yaml
@@ -1,0 +1,29 @@
+name: ChatDev
+description: A multi-agent collaboration framework where AI agents with specialized roles (CEO, CTO, programmer, reviewer) collaborate through structured chat to autonomously develop software from natural language specifications.
+tagline: Multi-agent AI software development through role-based collaboration
+
+github_url: https://github.com/OpenBMB/ChatDev
+website_url: https://chatdev.ai
+docs_url: https://chatdev.readthedocs.io
+install_command: pip install chatdev
+
+category: Agents
+tags: [agents, multi-agent, software-development, collaboration, autonomous, python]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Automating software development with AI typically involves single-agent code generation that
+  produces isolated snippets — lacking the full software lifecycle of design, implementation,
+  review, testing, and documentation. ChatDev assigns multiple AI agents distinct professional
+  roles (CEO for planning, CTO for architecture, programmer for coding, reviewer for QA) that
+  collaborate through structured multi-turn conversations. The result is end-to-end software
+  creation from a natural language specification, with each phase handled by a specialized agent
+  that reviews and validates the previous phase's output.
+
+use_cases:
+  - Generate a complete web application from a natural language specification through multi-agent collaboration
+  - Create software documentation and test suites automatically alongside generated code
+  - Prototype new features rapidly by describing requirements to a team of specialized AI agents
+  - Automate code review and refactoring with a reviewer agent that validates code quality and best practices

--- a/tools/dev-tools/jupyter-ai.yaml
+++ b/tools/dev-tools/jupyter-ai.yaml
@@ -1,0 +1,27 @@
+name: Jupyter AI
+description: A JupyterLab extension that brings generative AI into computational notebooks, providing a conversational AI assistant, code generation, documentation help, and integration with major LLM providers directly inside the notebook interface.
+tagline: AI-powered code generation and assistance inside Jupyter notebooks
+
+github_url: https://github.com/jupyterlab/jupyter-ai
+website_url: https://jupyter-ai.readthedocs.io
+docs_url: https://jupyter-ai.readthedocs.io/en/latest
+install_command: pip install jupyter-ai
+
+category: Dev Tools
+tags: [jupyter, notebook, ai-assistant, code-generation, python, data-science]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Data scientists and researchers using Jupyter often need to write boilerplate code, debug errors,
+  or explore new libraries — tasks that break their flow by switching between notebook and external
+  AI tools. Jupyter AI embeds LLM-powered chat, code generation, and documentation lookups directly
+  into the JupyterLab interface. Users can ask questions, generate code, or explain errors without
+  leaving their notebook, with the AI aware of the current cell context and notebook environment.
+
+use_cases:
+  - Generate Python code for data analysis, visualization, and machine learning directly inside a notebook cell
+  - Debug notebook errors by asking the AI to explain tracebacks and suggest fixes in context
+  - Ask questions about data science concepts and libraries without switching tabs away from JupyterLab
+  - Generate documentation strings, test cases, and code comments for existing notebook functions and classes

--- a/tools/llm/sillytavern.yaml
+++ b/tools/llm/sillytavern.yaml
@@ -1,0 +1,30 @@
+name: SillyTavern
+description: A powerful LLM frontend for power users that provides an extensive chat interface with character cards, roleplay modes, group chats, lorebooks, and extensible plugin support for local and remote LLM backends.
+tagline: LLM chat frontend with character cards, roleplay, and deep customization
+
+github_url: https://github.com/SillyTavern/SillyTavern
+website_url: https://sillytavern.app
+docs_url: https://docs.sillytavern.app
+install_command: |
+  git clone https://github.com/SillyTavern/SillyTavern
+  cd SillyTavern && npm install
+
+category: LLM
+tags: [llm, web-ui, chat, roleplay, frontend, characters, api]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Most LLM chat interfaces are minimal — they offer a single conversation pane with no
+  customization for character-driven interactions, group conversations, or world-building context.
+  SillyTavern provides a rich front-end with character cards (personality, appearance, backstory),
+  lorebooks (world knowledge), group chat, and format tokens that control response style. It works
+  with any OpenAI-compatible API, local inference servers, or cloud providers, making it the
+  go-to interface for LLM power users who want fine-grained control over their chat experience.
+
+use_cases:
+  - Create detailed AI character profiles with distinct personalities, appearance, and backstory for immersive roleplay
+  - Run multi-character group conversations where different AI personas interact with each other simultaneously
+  - Build persistent world knowledge with lorebooks that inject context into responses without cluttering chat history
+  - Connect to any local or cloud LLM backend with full control over generation parameters and format tokens

--- a/tools/other/stable-diffusion-webui.yaml
+++ b/tools/other/stable-diffusion-webui.yaml
@@ -1,0 +1,29 @@
+name: Stable Diffusion WebUI
+description: The most popular open-source web interface for Stable Diffusion image generation, offering txt2img, img2img, inpainting, ControlNet, LoRA, and a rich extension ecosystem for advanced AI image workflows.
+tagline: The definitive web UI for Stable Diffusion with extensible plugin ecosystem
+
+github_url: https://github.com/AUTOMATIC1111/stable-diffusion-webui
+website_url: https://github.com/AUTOMATIC1111/stable-diffusion-webui
+install_command: |
+  git clone https://github.com/AUTOMATIC1111/stable-diffusion-webui
+  cd stable-diffusion-webui && ./webui.sh
+
+category: Other
+tags: [image-generation, stable-diffusion, web-ui, ai-art, gpu, inpainting, controlnet]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Running Stable Diffusion models requires managing model weights, GPU memory, prompt engineering,
+  and complex pipelines like inpainting, upscaling, and ControlNet — all from the command line.
+  AUTOMATIC1111's WebUI wraps the entire Stable Diffusion ecosystem into a browser interface
+  accessible to both beginners and advanced users. It handles model swapping, LoRA loading,
+  prompt scheduling, and extension management, turning a fragmented set of Python scripts into
+  a cohesive image generation platform.
+
+use_cases:
+  - Generate high-quality images from text prompts with fine-grained control over sampling methods and CFG scale
+  - Edit existing images using inpainting, outpainting, and img2img workflows with mask-based region selection
+  - Apply ControlNet for pose-guided generation, depth-aware rendering, and edge-conditioned image synthesis
+  - Use LoRA and Hypernetwork models to apply specific styles, characters, or aesthetic preferences to generations

--- a/tools/rag/langchain4j.yaml
+++ b/tools/rag/langchain4j.yaml
@@ -1,0 +1,33 @@
+name: LangChain4j
+description: An idiomatic, open-source Java library for building LLM-powered applications on the JVM, offering a unified API over popular LLM providers, vector stores, tool calling, agents, and RAG — with seamless integration into Spring Boot and Quarkus.
+tagline: Build LLM-powered Java applications with LangChain's JVM-native port
+
+github_url: https://github.com/langchain4j/langchain4j
+website_url: https://langchain4j.github.io
+docs_url: https://docs.langchain4j.dev
+install_command: |
+  <dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j</artifactId>
+    <version>1.0.0</version>
+  </dependency>
+
+category: RAG
+tags: [java, rag, llm, jvm, agents, spring-boot, quarkus]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Java and JVM developers who want to build LLM-powered applications face a language gap — most
+  AI frameworks are Python-first with minimal Java support. LangChain4j bridges this gap by
+  providing a Java-native library with a unified API across LLM providers (OpenAI, Anthropic,
+  Google, Ollama), embedding stores (Pinecone, Chroma, Weaviate), and RAG pipelines. It
+  integrates natively with Spring Boot and Quarkus so enterprise Java teams can add AI features
+  to existing applications without introducing a separate Python service.
+
+use_cases:
+  - Add RAG-powered chat to Spring Boot applications using enterprise document stores and vector databases
+  - Build AI agents with tool calling and function invocation from Java services without Python dependencies
+  - Implement semantic search over internal documentation with embeddings stored in a JVM-compatible vector store
+  - Create multi-step LLM workflows that chain prompts, data extraction, and decision logic in pure Java


### PR DESCRIPTION
## Tools added

| Tool | Category | Repo | Stars |
|------|----------|------|-------|
| **SillyTavern** | LLM | SillyTavern/SillyTavern | 30k★ |
| **Stable Diffusion WebUI** | Other | AUTOMATIC1111/stable-diffusion-webui | 164k★ |
| **Jupyter AI** | Dev Tools | jupyterlab/jupyter-ai | 4.3k★ |
| **LangChain4j** | RAG | langchain4j/langchain4j | 12.5k★ |
| **ChatDev** | Agents | OpenBMB/ChatDev | 33.7k★ |

All five are well-established open-source tools with active communities and verified licensing. Validation passed locally.
