### PR TITLE
Add Spark NLP, Rasa, DataHub to catalog

### DIFF
--- a/tools/agent-frameworks/rasa.yaml
+++ b/tools/agent-frameworks/rasa.yaml
@@ -1,0 +1,29 @@
+name: Rasa
+description: An open-source conversational AI framework for building text and voice-based chatbots with NLU, dialogue management, and integrations with messaging platforms like Slack, Facebook Messenger, and Telegram.
+tagline: Open-source framework for contextual AI assistants and chatbots
+
+github_url: https://github.com/RasaHQ/rasa
+website_url: https://rasa.com
+docs_url: https://rasa.com/docs/rasa
+install_command: pip install rasa
+
+category: Agents
+tags: [conversational-ai, nlu, chatbot, dialogue-management, nlp, python]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building a production chatbot requires connecting intent classification, entity extraction,
+  dialogue management, and channel integrations — each typically a separate service with
+  different APIs and deployment models. Rasa provides an all-in-one framework where intent
+  recognition is trained from example conversations, dialogue policies are configurable as
+  stories or rules, and the output integrates with Slack, Facebook, Telegram, and custom
+  channels. The entire system runs on-premise or in a private cloud, giving enterprises full
+  control over conversational data.
+
+use_cases:
+  - Build a customer service chatbot that handles returns, refunds, and order tracking through natural conversation
+  - Create a sales qualification bot that collects lead information and routes qualified prospects to the right team
+  - Deploy a multilingual FAQ assistant trained on product documentation with fallback to human handoff
+  - Develop a workflow automation bot that books appointments, reschedules meetings, and sends reminders via messaging

--- a/tools/data/datahub.yaml
+++ b/tools/data/datahub.yaml
@@ -1,0 +1,29 @@
+name: DataHub
+description: An open-source metadata platform for the modern data stack that enables data discovery, data lineage, data governance, and observability across your organization's data pipelines and AI infrastructure.
+tagline: Open-source data catalog for discovery, lineage, and governance
+
+github_url: https://github.com/datahub-project/datahub
+website_url: https://datahubproject.io
+docs_url: https://datahubproject.io/docs
+install_command: pip install acryl-datahub
+
+category: Data
+tags: [data-catalog, metadata, lineage, governance, data-discovery, data-pipeline]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  As organizations scale their data and AI infrastructure, teams lose track of what datasets
+  exist, where they come from, how they're transformed, and who owns them — leading to
+  duplicated efforts, untrustworthy data, and compliance gaps. DataHub provides a unified
+  metadata platform that automatically ingests schemas, profiles, lineage, and ownership from
+  data warehouses, lakes, BI tools, and ML pipelines. Engineers and analysts can search for
+  datasets, trace column-level lineage upstream to source systems and downstream to dashboards,
+  and enforce data ownership policies.
+
+use_cases:
+  - Discover available datasets across the organization with search filters by source, owner, and data domain
+  - Trace column-level lineage from a dashboard metric back through transformations to the source database
+  - Enforce data governance by documenting ownership, classification, and deprecation status for every dataset
+  - Monitor pipeline health with observability hooks that flag schema changes, data quality issues, and staleness

--- a/tools/rag/spark-nlp.yaml
+++ b/tools/rag/spark-nlp.yaml
@@ -1,0 +1,29 @@
+name: Spark NLP
+description: A state-of-the-art natural language processing library built on Apache Spark that provides production-grade NLP pipelines including named entity recognition, sentiment analysis, text classification, and question answering at scale.
+tagline: Enterprise NLP at scale on Apache Spark with pre-trained pipelines
+
+github_url: https://github.com/JohnSnowLabs/spark-nlp
+website_url: https://sparknlp.org
+docs_url: https://sparknlp.org/docs
+install_command: pip install spark-nlp
+
+category: RAG
+tags: [nlp, spark, big-data, natural-language, entity-recognition, classification]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Processing natural language at enterprise scale typically means stitching together separate
+  libraries for tokenization, NER, sentiment, and embeddings — none of which are designed for
+  distributed execution on large datasets. Spark NLP provides a unified library that runs on
+  Apache Spark clusters, offering 30,000+ pre-trained pipelines and models for tasks like named
+  entity recognition, text classification, question answering, and text generation. It scales
+  from a single node to hundreds of worker nodes without code changes, making it suitable for
+  processing millions of documents in production.
+
+use_cases:
+  - Extract named entities like people, organizations, and locations from millions of documents on a Spark cluster
+  - Build text classification pipelines for sentiment analysis, spam detection, or content moderation at scale
+  - Deploy question-answering models over enterprise document repositories using distributed inference
+  - Create multilingual NLP pipelines that process documents in 200+ languages with pre-trained embeddings


### PR DESCRIPTION
## Tools added

| Tool | Category | Repo | Stars |
|------|----------|------|-------|
| **Spark NLP** | RAG | JohnSnowLabs/spark-nlp | 4.1k★ |
| **Rasa** | Agents | RasaHQ/rasa | 21k★ |
| **DataHub** | Data | datahub-project/datahub | 12k★ |

All three are active open-source tools with verified licensing. Validation passed locally.

Also cleaned up stale tracker entries: OpenDevin (→ OpenHands) and Jina AI (→ Jina) were already in the catalog under different slugs.
