### PR TITLE
Add Amundsen, Tracecat, Graphify, TiDB, ParadeDB to catalog

### DIFF
--- a/tools/data/amundsen.yaml
+++ b/tools/data/amundsen.yaml
@@ -1,0 +1,28 @@
+name: Amundsen
+description: A metadata-driven data discovery platform that helps data teams find, understand, and trust their data through search, automated metadata ingestion, column-level lineage, and usage-based resource ranking.
+tagline: Data discovery and metadata platform for modern data teams
+
+github_url: https://github.com/amundsen-io/amundsen
+website_url: https://www.amundsen.io
+docs_url: https://www.amundsen.io/amundsen
+install_command: docker compose up
+
+category: Data
+tags: [data-catalog, metadata, data-discovery, data-governance, lineage, search]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  In large organizations, data lives across hundreds of tables, dashboards, and pipelines with
+  no central catalog — analysts waste hours hunting for the right dataset, trusting stale
+  documentation, or duplicating existing work. Amundsen provides a searchable catalog that
+  automatically ingests table schemas, ownership, usage statistics, and column-level lineage
+  from data warehouses, lakes, and BI tools. Users can search by table name, column content, or
+  popularity, and see upstream and downstream dependencies for any dataset.
+
+use_cases:
+  - Discover relevant datasets across the organization with search ranked by usage, freshness, and ownership
+  - Trace column-level lineage from a report metric back through ETL pipelines to its source tables
+  - Find data owners for troubleshooting broken pipelines or understanding dataset semantics
+  - Reduce duplicated data work by making existing tables and dashboards discoverable through search

--- a/tools/dev-tools/tracecat.yaml
+++ b/tools/dev-tools/tracecat.yaml
@@ -1,0 +1,31 @@
+name: Tracecat
+description: An open-source security automation platform for teams and AI agents that turns natural language prompts into end-to-end security workflows with agents, case management, and event-driven automation.
+tagline: Open-source security automation for teams and AI agents
+
+github_url: https://github.com/TracecatHQ/tracecat
+website_url: https://tracecat.com
+docs_url: https://docs.tracecat.com
+install_command: |
+  pip install tracecat
+  tracecat init
+
+category: Dev Tools
+tags: [security, automation, workflows, soar, ai-agents, siem]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Security teams are overwhelmed by alert volumes from dozens of tools — SIEMs, EDRs, cloud
+  security scanners, and threat feeds — each requiring manual triage and response. Tracecat
+  connects security tools into automated workflows that can be described in natural language:
+  "when a critical alert from CrowdStrike matches a known IoC pattern, create a case, enrich
+  it with VirusTotal, and notify the on-call engineer via Slack." It provides case management,
+  a workflow builder, and agent harness support so teams can automate incident response without
+  writing custom scripts for every playbook.
+
+use_cases:
+  - Automate SOC alert triage by enriching, deduplicating, and routing alerts from SIEM to the right responder
+  - Build end-to-end incident response playbooks with automated evidence collection and case creation
+  - Create agent-driven security workflows that investigate phishing emails, extract IOCs, and block domains
+  - Orchestrate multi-tool response actions across cloud security, endpoint protection, and threat intelligence platforms

--- a/tools/rag/graphify.yaml
+++ b/tools/rag/graphify.yaml
@@ -1,0 +1,29 @@
+name: Graphify
+description: A tool for turning any folder of code, documentation, or data into a queryable knowledge graph that integrates with AI coding assistants like Claude Code, Codex, and Cursor for context-aware development.
+tagline: Turn any codebase into a queryable knowledge graph for AI assistants
+
+github_url: https://github.com/Graphify-Labs/graphify
+website_url: https://graphify.dev
+docs_url: https://graphify.dev/docs
+install_command: pip install graphifyy
+
+category: RAG
+tags: [knowledge-graph, rag, code-analysis, ai-assistant, graph, embedding]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI coding assistants struggle with large codebases — they lack awareness of the full project
+  structure, database schemas, configuration files, and cross-file dependencies. Graphify builds
+  a knowledge graph from your entire project: source code, SQL schemas, infrastructure configs,
+  documentation, images, and more. AI assistants can query this graph to understand project
+  context, find relevant files, trace data flows, and generate code that respects existing
+  conventions — bridging the gap between isolated file-level completion and holistic codebase
+  understanding.
+
+use_cases:
+  - Create a searchable knowledge graph of your entire codebase for context-aware AI code generation
+  - Trace data flow across application code, database schema, and infrastructure definitions in one query
+  - Integrate project documentation, API specs, and architecture diagrams into a unified graph for AI assistants
+  - Query cross-file dependencies and relationships during refactoring or onboarding to a new codebase

--- a/tools/vector-databases/paradedb.yaml
+++ b/tools/vector-databases/paradedb.yaml
@@ -1,0 +1,28 @@
+name: ParadeDB
+description: A PostgreSQL-based database purpose-built for search and vector retrieval that extends Postgres with full-text search, BM25 scoring, and HNSW vector indexing through native extensions.
+tagline: PostgreSQL for search and vector retrieval with native extensions
+
+github_url: https://github.com/paradedb/paradedb
+website_url: https://paradedb.com
+docs_url: https://docs.paradedb.com
+install_command: docker compose up
+
+category: Vector DB
+tags: [postgres, search, vector-search, full-text-search, bm25, hnsw]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Building search and RAG applications typically requires stitching together separate systems:
+  PostgreSQL for application data, Elasticsearch for full-text search, and Pinecone/Weaviate for
+  vector retrieval — each with its own query language, deployment, and operational complexity.
+  ParadeDB extends PostgreSQL with pg_search for BM25 full-text indexing and pgvector-compatible
+  HNSW vector search, enabling developers to run hybrid search (keyword + semantic) alongside
+  their application data in a single Postgres database with standard SQL queries.
+
+use_cases:
+  - Run hybrid search combining full-text BM25 scoring with vector similarity in a single PostgreSQL query
+  - Replace Elasticsearch with native PostgreSQL full-text search using ParadeDB's pg_search extension
+  - Build RAG applications with HNSW vector indexes stored alongside relational application data in Postgres
+  - Add semantic search capabilities to existing PostgreSQL applications without introducing a separate vector database

--- a/tools/vector-databases/tidb.yaml
+++ b/tools/vector-databases/tidb.yaml
@@ -1,0 +1,31 @@
+name: TiDB
+description: A distributed SQL database with built-in vector search that provides ACID transactions, horizontal scalability, and MySQL-compatibility for transactional, analytical, and AI workloads in a single database.
+tagline: Distributed SQL database with vector search for AI workloads
+
+github_url: https://github.com/pingcap/tidb
+website_url: https://tidbcloud.com
+docs_url: https://docs.pingcap.com/tidb/stable
+install_command: |
+  curl --proto '=https' --tlsv1.2 -sSf https://tiup.io/install.sh | sh
+  tiup playground
+
+category: Vector DB
+tags: [database, sql, vector-search, distributed, new-sql, mysql-compatible]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Modern AI applications need a database that handles transactional writes, analytical queries,
+  and vector similarity search — typically requiring separate systems for each workload, with
+  complex data movement between them. TiDB is a distributed SQL database that natively supports
+  vector embeddings with HNSW indexing alongside standard SQL operations and ACID transactions.
+  Teams building RAG pipelines or AI agents can store application data, user profiles, and
+  embeddings in a single MySQL-compatible database that scales horizontally without application
+  changes.
+
+use_cases:
+  - Store application data and vector embeddings in a single SQL database for RAG pipelines and AI agents
+  - Run hybrid search queries that combine vector similarity with SQL filters, joins, and aggregations
+  - Scale a transactional database horizontally for AI workloads without sharding or application rewrites
+  - Replace separate OLTP and vector databases with one system for AI-powered applications


### PR DESCRIPTION
## Tools added

| Tool | Category | Repo | Stars |
|------|----------|------|-------|
| **Amundsen** | Data | amundsen-io/amundsen | 4.7k★ |
| **Tracecat** | Dev Tools | TracecatHQ/tracecat | 3.7k★ |
| **Graphify** | RAG | Graphify-Labs/graphify | 84k★ |
| **TiDB** | Vector DB | pingcap/tidb | 40k★ |
| **ParadeDB** | Vector DB | paradedb/paradedb | 9k★ |

All five are active open-source tools with verified licensing. Validation passed locally.
