### PR TITLE
Add Flax, Griptape, DocTR, OCRmyPDF, Paperless-ngx to catalog

### DIFF
--- a/tools/agent-frameworks/griptape.yaml
+++ b/tools/agent-frameworks/griptape.yaml
@@ -1,0 +1,38 @@
+name: Griptape
+description: >-
+  Griptape is a modular Python framework for building AI agents and workflows
+  with chain-of-thought reasoning, tool integration, structured outputs, and
+  persistent memory. It enables developers to create autonomous agents that can
+  plan, execute multi-step tasks, and interact with external systems reliably.
+tagline: Build modular AI agents with reasoning, tools, and memory
+
+github_url: https://github.com/griptape-ai/griptape
+website_url: https://www.griptape.ai
+docs_url: https://docs.griptape.ai
+install_command: pip install griptape
+
+category: Agents
+tags:
+  - python
+  - agents
+  - multi-agent
+  - orchestration
+  - tools
+  - memory
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >
+  Building reliable AI agents that can reason through complex tasks, use
+  external tools, and remember context across interactions is challenging
+  without a structured framework. Griptape provides a modular architecture with
+  built-in chain-of-thought reasoning, tool-using capabilities, persistent
+  memory stores, and structured output generation — allowing developers to
+  compose production-ready agents from reusable building blocks without building
+  the orchestration layer from scratch.
+
+use_cases:
+  - Create autonomous research agents that search the web, analyze documents, and synthesize findings into reports
+  - Build customer support workflows with agents that query databases, escalate tickets, and generate structured responses
+  - Deploy multi-step automation pipelines where agents plan, execute tools, and validate results before proceeding

--- a/tools/data/doctr.yaml
+++ b/tools/data/doctr.yaml
@@ -1,0 +1,40 @@
+name: DocTR
+description: >-
+  docTR (Document Text Recognition) is a deep-learning-based OCR library that
+  provides accurate text detection, text recognition, layout analysis, and table
+  extraction from documents and images. It features pretrained vision-transformer
+  models for over 20 languages and handles complex layouts, curved text, and
+  mixed-language documents with state-of-the-art accuracy.
+tagline: Deep learning OCR with pretrained vision-transformer models
+
+github_url: https://github.com/mindee/doctr
+website_url: https://mindee.com
+docs_url: https://mindee.github.io/doctr
+install_command: pip install python-doctr
+
+category: Data
+tags:
+  - ocr
+  - document-intelligence
+  - text-recognition
+  - deep-learning
+  - pdf
+  - layout-analysis
+  - python
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >
+  Traditional OCR engines struggle with complex document layouts, curved or
+  skewed text, and mixed-language content — producing errors that cascade into
+  downstream NLP and data extraction pipelines. DocTR uses deep learning models
+  (vision transformers and CNN backbones) trained on diverse document datasets
+  to detect and recognize text in challenging scenarios, outputting structured
+  results with bounding boxes, confidence scores, and reading order for
+  downstream processing.
+
+use_cases:
+  - Extract text from scanned invoices, receipts, and business documents with layout-aware OCR for automated data entry
+  - Process multilingual documents containing mixed Latin, CJK, and Arabic scripts in a single pipeline
+  - Build document digitization workflows that preserve reading order, table structure, and formatting metadata

--- a/tools/data/ocrmypdf.yaml
+++ b/tools/data/ocrmypdf.yaml
@@ -1,0 +1,38 @@
+name: OCRmyPDF
+description: >-
+  OCRmyPDF adds an OCR text layer to scanned PDF files, making them fully
+  searchable, selectable, and copyable while preserving the original page images
+  and visual appearance. It combines Tesseract OCR engine with Ghostscript PDF
+  processing to produce compressed, searchable PDF/A-compliant documents from
+  any scanned or image-based PDF.
+tagline: Add searchable OCR text layers to scanned PDFs
+
+github_url: https://github.com/ocrmypdf/OCRmyPDF
+website_url: https://ocrmypdf.readthedocs.io
+docs_url: https://ocrmypdf.readthedocs.io/en/latest/
+install_command: pip install ocrmypdf
+
+category: Data
+tags:
+  - ocr
+  - pdf
+  - document-processing
+  - searchable-pdf
+  - python
+  - tesseract
+pricing: free
+is_open_source: true
+license: MPL-2.0
+
+problem_solved: >
+  Scanned PDFs and image-based documents are not searchable or text-selectable,
+  making them inaccessible for full-text search, copy-paste, and downstream NLP
+  processing. OCRmyPDF solves this by applying OCR to each page and embedding
+  the recognized text as an invisible layer behind the original image — producing
+  standards-compliant PDF/A files that are both human-readable and machine-searchable
+  without modifying the visual appearance.
+
+use_cases:
+  - Convert scanned document archives into searchable PDFs for enterprise document management systems
+  - Prepare image-based PDFs for downstream NLP pipelines by adding a machine-readable text layer
+  - Automate batch OCR processing of incoming scanned invoices, contracts, and forms for digital workflows

--- a/tools/data/paperless-ngx.yaml
+++ b/tools/data/paperless-ngx.yaml
@@ -1,0 +1,41 @@
+name: Paperless-ngx
+description: >-
+  Paperless-ngx is an open-source document management system that automatically
+  scans, indexes, classifies, and archives physical documents. It uses machine
+  learning to tag, sort, and make documents fully searchable — with support for
+  multi-user access, email import, automated classification, barcode recognition,
+  and comprehensive full-text search across your entire document archive.
+tagline: Self-hosted document management with AI-powered classification
+
+github_url: https://github.com/paperless-ngx/paperless-ngx
+website_url: https://docs.paperless-ngx.com
+docs_url: https://docs.paperless-ngx.com
+install_command: |-
+  bash -c "$(curl --location --silent --show-error https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/main/install-paperless-ngx.sh)"
+
+category: Data
+tags:
+  - document-management
+  - ocr
+  - dms
+  - self-hosted
+  - classification
+  - search
+  - pdf
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: >
+  Managing physical documents — receipts, invoices, contracts, statements — is
+  tedious and error-prone without a digital system. Traditional approaches
+  (filing cabinets, manual scanning, folder hierarchies) lack searchability,
+  automatic classification, and version control. Paperless-ngx solves this by
+  automatically OCR-ing every document, applying machine-learning-based
+  classification to tag and sort them, and providing a full-text search engine
+  that instantly finds any document by content, date, correspondent, or tag.
+
+use_cases:
+  - Digitize and automatically classify incoming invoices, receipts, and bank statements for paperless personal finance
+  - Set up a shared document archive for teams with email import, automated tagging, and granular user permissions
+  - "Build an automated document pipeline: scan documents, have them OCR'd and classified, then archive with full-text search"

--- a/tools/llm/flax.yaml
+++ b/tools/llm/flax.yaml
@@ -1,0 +1,38 @@
+name: Flax
+description: >-
+  Flax is a high-performance neural network library for JAX designed for
+  flexibility and research. It provides a modular API for building transformers,
+  large language models, CNNs, and other deep learning architectures with easy
+  checkpointing, distributed training, and seamless integration with the JAX
+  ecosystem.
+tagline: Flexible neural network library for JAX
+
+github_url: https://github.com/google/flax
+website_url: https://flax.readthedocs.io
+docs_url: https://flax.readthedocs.io/en/latest/
+install_command: pip install flax
+
+category: LLM
+tags:
+  - jax
+  - neural-network
+  - deep-learning
+  - transformer
+  - research
+  - python
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >
+  Training large neural networks in JAX requires writing complex training loops,
+  managing model parameters and state, and handling distributed computation
+  manually. Flax provides a high-level, modular API that abstracts away these
+  complexities — offering pre-built layers, optimizers, checkpointing, and
+  multi-device training support — so researchers can focus on model architecture
+  and experimentation rather than infrastructure.
+
+use_cases:
+  - Train large language models and transformers with distributed data parallelism across multiple GPUs/TPUs
+  - Build and experiment with custom neural network architectures using a modular, functional API
+  - Leverage JAX's JIT compilation and auto-differentiation for high-performance research prototyping


### PR DESCRIPTION
## Added tools

| Tool | Category | Description |
|------|----------|-------------|
| **Flax** | LLM | Neural network library for JAX by Google (7.2k★) |
| **Griptape** | Agents | Modular Python framework for AI agents and workflows (2.5k★) |
| **DocTR** | Data | Deep-learning OCR with pretrained vision-transformer models (6.1k★) |
| **OCRmyPDF** | Data | Add searchable OCR text layer to scanned PDFs (34k★) |
| **Paperless-ngx** | Data | AI-powered self-hosted document management system (43k★) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Griptape, DocTR, OCRmyPDF, Paperless-ngx, and Flax.
  * Included descriptions, use cases, categories, tags, installation guidance, documentation links, licensing, and pricing information.
  * Added searchable metadata highlighting applications in AI agents, OCR, document management, and machine learning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->