### PR TITLE
Add Predibase, Yi, TileDB, MyScaleDB, GLM to catalog

### DIFF
--- a/tools/fine-tuning/predibase.yaml
+++ b/tools/fine-tuning/predibase.yaml
@@ -1,0 +1,24 @@
+name: Predibase
+description: Predibase is a fine-tuning platform that provides LoRAX (LoRA eXchange), a high-performance Multi-LoRA inference server capable of serving thousands of fine-tuned LLMs on a single GPU. It dramatically reduces serving costs while maintaining throughput and latency through dynamic adapter loading, heterogeneous continuous batching, and optimized CUDA kernels.
+tagline: Multi-LoRA inference server scaling to thousands of fine-tuned LLMs per GPU
+
+github_url: https://github.com/predibase/lorax
+website_url: https://predibase.com
+docs_url: https://predibase.github.io/lorax
+
+install_command: pip install lorax
+
+category: Fine-tuning
+tags: [fine-tuning, lora, llm-inference, model-serving, pytorch, transformers, llmops]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Serving many fine-tuned versions of large language models is prohibitively expensive when each variant requires its own GPU. Traditional approaches either duplicate model copies across GPUs or require costly model merging. Predibase LoRAX solves this by dynamically loading LoRA adapters just-in-time on a single GPU, packing heterogeneous adapter requests into the same batch, and scheduling adapter exchanges between GPU and CPU memory — enabling thousands of fine-tuned models on one GPU without compromising latency or throughput.
+
+use_cases:
+  - "Serve thousands of fine-tuned LoRA adapters on a single GPU for cost-effective multi-tenant LLM serving"
+  - "Run heterogeneous continuous batching across different adapters to maximize GPU utilization in production"
+  - "Deploy production-ready LLM inference with OpenAI-compatible API, structured outputs, and distributed tracing"
+  - "Merge multiple adapters per request for dynamic model ensembles without pre-merging weights"

--- a/tools/llm/glm.yaml
+++ b/tools/llm/glm.yaml
@@ -1,0 +1,24 @@
+name: GLM
+description: GLM (General Language Model) is a family of open-source language models from Tsinghua University, pretrained with an autoregressive blank-filling objective that unifies understanding and generation tasks. It powers the popular ChatGLM series for bilingual Chinese-English dialogue and achieves strong results on SuperGLUE and other NLP benchmarks.
+tagline: General Language Model family for bilingual understanding and generation
+
+github_url: https://github.com/THUDM/GLM
+website_url: https://glm.ai
+docs_url: https://github.com/THUDM/ChatGLM-6B
+
+install_command: pip install transformers
+
+category: LLM
+tags: [llm, text-generation, transformers, chinese, bilingual, open-source, chat, fine-tuning]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Bilingual Chinese-English language models that handle both natural language understanding and generation tasks have been difficult to find in open-source. GLM solves this by using a novel autoregressive blank-filling objective that trains on both understanding and generation simultaneously, producing models that excel at classification, reasoning, and text production. The ChatGLM derivative specifically optimized for Chinese dialogue makes high-quality bilingual conversational AI accessible to developers and researchers worldwide.
+
+use_cases:
+  - "Build bilingual Chinese-English chatbots and conversational AI with strong dialogue capabilities"
+  - "Fine-tune GLM on specialized NLP tasks including classification, reasoning, and text generation"
+  - "Deploy open-weight language models for research in bilingual NLP and multimodal reasoning"
+  - "Leverage the ChatGLM series for production Chinese-language dialogue applications"

--- a/tools/llm/yi.yaml
+++ b/tools/llm/yi.yaml
@@ -1,0 +1,24 @@
+name: Yi
+description: Yi is a series of open-source bilingual large language models developed by 01.AI, ranging from 6B to 34B parameters with strong performance in both English and Chinese. The models achieve competitive results on benchmarks including coding, math reasoning, and general language understanding while being freely available for research and commercial use under Apache 2.0 licensing.
+tagline: Bilingual open-source LLM series by 01.AI
+
+github_url: https://github.com/01-ai/Yi
+website_url: https://01.ai
+docs_url: https://github.com/01-ai/Yi/wiki
+
+install_command: pip install transformers
+
+category: LLM
+tags: [llm, text-generation, open-source, bilingual, chinese, transformers, fine-tuning]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  High-quality bilingual LLMs have been scarce and expensive, particularly for Chinese-language applications that need both English and Chinese fluency. Yi solves this by providing open-weight models pretrained on a massive bilingual corpus, delivering competitive performance on par with much larger models while being efficient enough to fine-tune and deploy on modest hardware. The Apache 2.0 license enables unrestricted commercial use without costly API dependencies.
+
+use_cases:
+  - "Build bilingual chatbots and conversational AI that seamlessly switch between English and Chinese"
+  - "Fine-tune Yi models on domain-specific datasets for specialized NLP tasks in both languages"
+  - "Deploy open-weight LLMs on consumer hardware for private inference without cloud dependencies"
+  - "Perform complex reasoning tasks including coding, mathematics, and logical problem solving"

--- a/tools/vector-databases/myscaledb.yaml
+++ b/tools/vector-databases/myscaledb.yaml
@@ -1,0 +1,24 @@
+name: MyScaleDB
+description: MyScaleDB is a SQL-compatible vector database built on ClickHouse, enabling developers to manage structured data, text, vectors, JSON, and time-series data using familiar SQL queries. It combines high-performance vector search with full SQL analytics for filtered search and hybrid text-vector retrieval at billion-scale.
+tagline: SQL vector database for scalable AI applications
+
+github_url: https://github.com/myscale/MyScaleDB
+website_url: https://myscale.com
+docs_url: https://myscale.com/docs/en
+
+install_command: pip install clickhouse-connect
+
+category: Vector DB
+tags: [vector-database, sql, clickhouse, vector-search, rag, embeddings, similarity-search, ann]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Developers building AI applications with vector search often have to learn proprietary APIs and manage separate systems for structured data and vectors. MyScaleDB solves this by providing a fully SQL-compatible vector database built on ClickHouse, allowing teams to use familiar SQL for both vector similarity search and traditional data queries. Its MSTG algorithm enables high-performance billion-scale vector search with metadata filtering, all without requiring specialized vector database expertise.
+
+use_cases:
+  - "Build retrieval-augmented generation pipelines using SQL with native vector search and metadata filtering"
+  - "Perform hybrid search combining full-text search and vector similarity in a single SQL query"
+  - "Manage structured data, vectors, and time-series data on a unified SQL-compatible platform"
+  - "Scale vector search to billions of vectors with high-precision filtered search at any ratio"

--- a/tools/vector-databases/tiledb.yaml
+++ b/tools/vector-databases/tiledb.yaml
@@ -1,0 +1,24 @@
+name: TileDB
+description: TileDB is a universal storage engine for dense and sparse multi-dimensional arrays with built-in vector search capabilities. It provides a powerful platform for managing AI embeddings, dataframes, and geospatial data with cloud-native storage support across S3, GCS, and Azure Blob Storage, enabling efficient similarity search on large-scale vector data alongside structured metadata.
+tagline: Universal storage engine with multi-dimensional array and vector search support
+
+github_url: https://github.com/TileDB-Inc/TileDB
+website_url: https://tiledb.com
+docs_url: https://cloud.tiledb.com/academy
+
+install_command: pip install tiledb-vector-search
+
+category: Vector DB
+tags: [vector-search, embeddings, storage-engine, multi-dimensional, dataframes, sparse-arrays, cloud-storage]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI applications often need to store and search vectors alongside rich structured metadata, requiring separate systems for vector search and data storage. TileDB solves this with a unified array storage engine that handles both dense and sparse multi-dimensional data — including embeddings — with native vector search, time-travel versioning, compression, and multi-cloud storage support. This eliminates the complexity of managing separate vector and metadata stores while providing robust data management features.
+
+use_cases:
+  - "Store and search AI embeddings with their associated metadata in a single unified storage backend"
+  - "Build production retrieval-augmented generation pipelines with time-travel data versioning and cloud-native scalability"
+  - "Manage large-scale scientific and geospatial arrays alongside vector embeddings for multi-modal AI applications"
+  - "Replace separate vector database and data warehouse with a single storage engine for simplified infrastructure"


### PR DESCRIPTION
Add 5 tools to the Agentic AI For Good catalog:

- **Predibase** — Multi-LoRA inference server (LoRAX) for serving thousands of fine-tuned LLMs on a single GPU (Fine-tuning)
- **Yi** — Open-source bilingual LLM series by 01.AI, ranging from 6B to 34B parameters (LLM)
- **TileDB** — Universal storage engine with vector search for multi-dimensional array data (Vector DB)
- **MyScaleDB** — SQL-compatible vector database built on ClickHouse for AI applications (Vector DB)
- **GLM** — General Language Model family by Tsinghua University powering ChatGLM (LLM)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Predibase to the fine-tuning tools catalog.
  * Added GLM and Yi to the language model catalog.
  * Added MyScaleDB and TileDB to the vector database catalog.
  * Included descriptions, documentation links, installation details, licensing, pricing, tags, and relevant use cases for each entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->