### PR TITLE
Add Pythia, Dolly, OLMo, InternLM to catalog

### DIFF
--- a/tools/llm/dolly.yaml
+++ b/tools/llm/dolly.yaml
@@ -1,0 +1,24 @@
+name: Dolly
+description: Dolly is a family of open-source large language models from Databricks, trained on the Databricks Machine Learning Platform. The models demonstrate that high-quality instruction-following LLMs can be created with relatively modest computational resources using focused fine-tuning on curated instruction datasets.
+tagline: Open-source instruction-following LLMs by Databricks
+
+github_url: https://github.com/databrickslabs/dolly
+website_url: https://www.databricks.com/product/machine-learning
+docs_url: https://github.com/databrickslabs/dolly
+
+install_command: pip install transformers
+
+category: LLM
+tags: [llm, text-generation, open-source, instruction-following, databricks, transformers, chatbot]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building capable instruction-following large language models typically requires massive compute budgets and proprietary training data. Dolly demonstrates that high-quality open-source LLMs can be created by fine-tuning existing base models on carefully curated instruction datasets using standard ML infrastructure. This democratizes LLM development by showing that organizations with modest compute resources can still produce useful, commercially-viable language models.
+
+use_cases:
+  - "Fine-tune and deploy instruction-following LLMs for domain-specific conversational AI applications"
+  - "Build chatbot prototypes that follow user instructions using open-source models on standard ML infrastructure"
+  - "Experiment with instruction-tuning techniques and datasets for research into LLM alignment and behavior"
+  - "Deploy open-weight LLMs for text generation, summarization, and question answering in enterprise environments"

--- a/tools/llm/internlm.yaml
+++ b/tools/llm/internlm.yaml
@@ -1,0 +1,24 @@
+name: InternLM
+description: InternLM is a series of open-source large language models (InternLM2, InternLM2.5, InternLM3) from Shanghai AI Laboratory, optimized for bilingual Chinese-English dialogue with strong performance on reasoning, coding, and long-context tasks. The models offer sizes from 1.8B to 123B parameters with support for 200K+ token contexts.
+tagline: Bilingual LLM series with long-context support by Shanghai AI Lab
+
+github_url: https://github.com/InternLM/InternLM
+website_url: https://internlm.intern-ai.org.cn
+docs_url: https://github.com/InternLM/InternLM
+
+install_command: pip install transformers
+
+category: LLM
+tags: [llm, text-generation, open-source, bilingual, chinese, long-context, transformers, chatbot, fine-tuning]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  High-quality bilingual Chinese-English LLMs with long-context capabilities have been limited, especially those that are fully open-source and commercially usable. InternLM solves this by providing a family of models from 1.8B to 123B parameters with 200K+ token context windows, strong performance on reasoning benchmarks, and a permissive Apache 2.0 license — enabling developers to build bilingual AI applications with state-of-the-art long-document understanding.
+
+use_cases:
+  - "Build bilingual Chinese-English chatbots and conversational AI with long-context dialogue capabilities"
+  - "Perform long-document analysis and question answering with 200K+ token context windows"
+  - "Fine-tune InternLM on domain-specific bilingual data for specialized enterprise applications"
+  - "Deploy open-weight LLMs for inference, coding assistance, and reasoning tasks on production infrastructure"

--- a/tools/llm/olmo.yaml
+++ b/tools/llm/olmo.yaml
@@ -1,0 +1,24 @@
+name: OLMo
+description: OLMo (Open Language Model) is a state-of-the-art open-source LLM framework by the Allen Institute for AI, providing complete training, evaluation, and inference code alongside fully open model weights. The project prioritizes scientific reproducibility with publicly released training data, code, logs, and intermediate checkpoints.
+tagline: Fully open language model framework by AI2
+
+github_url: https://github.com/allenai/OLMo
+website_url: https://allenai.org/olmo
+docs_url: https://github.com/allenai/OLMo-core
+
+install_command: pip install olmo
+
+category: LLM
+tags: [llm, text-generation, open-source, research, training, transformers, ai2, reproducibility]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Most large language models release only final weights, leaving researchers unable to reproduce results, study training dynamics, or verify scientific claims. OLMo solves this by providing a fully open framework that includes training code, curated training data (Dolma), evaluation benchmarks, training logs, and hundreds of intermediate checkpoints — enabling complete reproducibility and scientific study of LLM development from scratch.
+
+use_cases:
+  - "Reproduce and extend LLM research with fully open training data, code, logs, and intermediate model checkpoints"
+  - "Train custom language models from scratch using AI2's curated Dolma dataset and optimized training pipeline"
+  - "Evaluate open LLMs on standardized benchmarks with reproducible evaluation infrastructure"
+  - "Study language model training dynamics and ablation effects using controlled experimental frameworks"

--- a/tools/llm/pythia.yaml
+++ b/tools/llm/pythia.yaml
@@ -1,0 +1,24 @@
+name: Pythia
+description: Pythia is a suite of 16 open-source large language models ranging from 14M to 12B parameters, created by EleutherAI for interpretability and learning dynamics research. Each model has 154 checkpoints saved throughout training on the same data in the same order, enabling causal study of how knowledge evolves during LLM pretraining.
+tagline: Suite of interpretability-focused LLMs for studying training dynamics
+
+github_url: https://github.com/EleutherAI/pythia
+website_url: https://www.eleuther.ai
+docs_url: https://arxiv.org/abs/2304.01373
+
+install_command: pip install transformers
+
+category: LLM
+tags: [llm, text-generation, open-source, interpretability, research, transformers, training-dynamics]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Studying how large language models acquire knowledge during training is difficult without access to intermediate training checkpoints and fully reproducible training setups. Pythia solves this by releasing 16 models at various scales with 154 checkpoints each — all trained on identical data in the same order — providing a standardized research platform for studying learning dynamics, memorization, and emergent behaviors across model sizes and training time.
+
+use_cases:
+  - "Study how knowledge and capabilities emerge during LLM training using 154 intermediate checkpoints per model"
+  - "Benchmark interpretability techniques across 16 model scales from 14M to 12B parameters"
+  - "Investigate memorization, bias, and safety properties of language models throughout the training process"
+  - "Reproduce and extend interpretability research with fully open data, models, and training code"


### PR DESCRIPTION
Add 4 tools to the Agentic AI For Good catalog:

- **Pythia** — Suite of 16 open-source LLMs from EleutherAI for interpretability and learning dynamics research (LLM)
- **Dolly** — Open-source instruction-following LLMs trained on the Databricks ML Platform (LLM)
- **OLMo** — Fully open language model framework by the Allen Institute for AI (LLM)
- **InternLM** — Bilingual Chinese-English LLM series with 200K+ token context by Shanghai AI Lab (LLM)
