### PR TITLE
Add Monoscope, HertzBeat, TypeDB, MMDetection, SPLADE, Nomic to catalog

### DIFF
--- a/tools/data/typedb.yaml
+++ b/tools/data/typedb.yaml
@@ -1,0 +1,23 @@
+name: TypeDB
+description: TypeDB is a polymorphic database with a strong type system that unifies the strengths of relational, document, and graph databases. Its TypeQL query language is declarative, functional, and strongly typed, making it possible to model complex, interconnected data with elegance and safety.
+tagline: The polymorphic database with a modern type system for complex data
+
+github_url: https://github.com/vaticle/typedb
+website_url: https://typedb.com
+docs_url: https://typedb.com/docs
+
+category: Data
+tags: [database, graph, type-system, knowledge-graph, polymophic, typeql, open-source]
+pricing: freemium
+is_open_source: true
+license: MPL-2.0
+
+problem_solved: |
+  Traditional databases force developers to choose between relational rigor, document flexibility, and graph traversal power — each with its own query language, data model, and limitations. TypeDB unifies all three paradigms under a single polymorphic type system with inheritance and interfaces, letting developers model entities, relations, and attributes in one seamlessly queryable schema.
+
+use_cases:
+  - Build knowledge graphs that require rich type hierarchies, inheritance, and relationship constraints
+  - Model biomedical, financial, or supply chain data with complex interdependencies and strict validation
+  - Replace multi-database architectures (SQL + graph + document) with a single polymorphic store
+  - Develop intelligent applications that need both graph traversal and type-safe querying
+  - Power AI and reasoning systems with a strongly-typed database that enforces logical consistency

--- a/tools/llm/nomic.yaml
+++ b/tools/llm/nomic.yaml
@@ -1,0 +1,24 @@
+name: Nomic
+description: Nomic provides state-of-the-art text embedding models (Nomic Embed) and the Atlas platform for visualizing, exploring, and interacting with large-scale unstructured datasets. The nomic Python SDK gives developers access to Nomic's embedding models, Atlas data maps, and GPT4All local LLM inference in a single package.
+tagline: Embedding models and visualization platform for unstructured data at scale
+
+github_url: https://github.com/nomic-ai/nomic
+website_url: https://atlas.nomic.ai
+docs_url: https://docs.nomic.ai
+install_command: pip install nomic
+
+category: LLM
+tags: [embeddings, llm, nlp, visualization, data-exploration, knowledge-graph, python]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Teams building LLM applications need high-quality text embeddings for semantic search, classification, and clustering, but training custom embedding models is expensive and off-the-shelf options often lack interpretability. Nomic Embed delivers competitive embedding quality with the ability to visualize, explore, and share datasets of millions of points in the Atlas web platform — turning opaque embeddings into interactive maps.
+
+use_cases:
+  - Generate high-quality text embeddings (Nomic Embed) for semantic search, RAG, and classification pipelines
+  - Visualize millions of unstructured data points as interactive maps for exploration, labeling, and pattern discovery
+  - Run GPT4All LLMs locally on consumer hardware for privacy-sensitive inference tasks
+  - Build knowledge graphs and dataset maps that can be shared and collaborated on via the Atlas platform
+  - Embed documents at scale with batch processing and an OpenAI-compatible API interface

--- a/tools/monitoring/hertzbeat.yaml
+++ b/tools/monitoring/hertzbeat.yaml
@@ -1,0 +1,24 @@
+name: HertzBeat
+description: Apache HertzBeat is an AI-powered open-source real-time observability system that unifies metrics and log collection, centralized alerting, and intelligent management and analysis. It requires no agent, supports Prometheus-compatible protocols, and provides powerful custom monitoring and status page building.
+tagline: AI-powered real-time monitoring without the agent overhead
+
+github_url: https://github.com/apache/hertzbeat
+website_url: https://hertzbeat.apache.org
+docs_url: https://hertzbeat.apache.org/docs
+install_command: docker run -d -p 1157:1157 apache/hertzbeat
+
+category: Monitoring
+tags: [monitoring, observability, alerting, metrics, logging, apache, devops, prometheus]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Setting up traditional monitoring stacks requires deploying and maintaining agents on every host, configuring complex collectors, and managing separate systems for metrics, logs, and alerting. HertzBeat eliminates the agent requirement entirely, unifying collection, analysis, alerting, and notification into a single platform with configurable protocol support for HTTP, JMX, SSH, JDBC, and Prometheus.
+
+use_cases:
+  - Monitor applications, databases, operating systems, and cloud-native infrastructure without installing agents on any target
+  - Unify metrics and log collection with centralized alerting, threshold rules, grouping, silencing, and suppression
+  - Build custom status pages that communicate real-time service health to end users
+  - Deploy a high-performance, horizontally scalable observability cluster with multi-network isolation
+  - Integrate alerts with Email, Discord, Slack, Telegram, DingTalk, WeChat, FeiShu, and Webhook

--- a/tools/monitoring/monoscope.yaml
+++ b/tools/monitoring/monoscope.yaml
@@ -1,0 +1,23 @@
+name: Monoscope
+description: Monoscope is an AI-powered observability platform that lets you ingest and explore logs, traces, and metrics using natural language queries. It stores data in S3-compatible buckets and provides LLM-driven analysis for rapid incident response, custom dashboards, and intelligent alerting.
+tagline: AI-native observability with natural language querying
+
+github_url: https://github.com/monoscope-tech/monoscope
+website_url: https://monoscope.tech
+docs_url: https://docs.monoscope.tech
+
+category: Monitoring
+tags: [observability, monitoring, logging, tracing, metrics, opentelemetry, llm, devtools]
+pricing: freemium
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Traditional observability platforms require complex query languages (PromQL, LogQL) to extract insights from telemetry data, creating a high barrier for developers who just need answers fast. Monoscope eliminates this friction by letting teams query logs, traces, and metrics in natural language via LLMs, while storing all data cost-effectively in S3-compatible object storage.
+
+use_cases:
+  - Query production logs and traces using natural language to diagnose incidents without learning a query language
+  - Unify observability data from OpenTelemetry, Prometheus, and other sources into a single S3-backed platform
+  - Set up intelligent alerts that adapt to traffic patterns and reduce noise with rich context in every notification
+  - Monitor API performance, database queries, and infrastructure health from pre-built dashboards
+  - Capture full-stack context for every issue — from user action to database query — via session replay and trace correlation

--- a/tools/other/mmdetection.yaml
+++ b/tools/other/mmdetection.yaml
@@ -1,0 +1,24 @@
+name: MMDetection
+description: OpenMMLab Detection Toolbox and Benchmark provides a comprehensive framework for object detection, instance segmentation, and panseg. It offers hundreds of pre-trained models with configurable pipelines, standardized evaluation, and modular components for rapid experimentation.
+tagline: Open-source object detection toolbox with hundreds of pre-trained models
+
+github_url: https://github.com/open-mmlab/mmdetection
+website_url: https://mmdetection.readthedocs.io
+docs_url: https://mmdetection.readthedocs.io/en/latest
+install_command: pip install mmdetection
+
+category: Other
+tags: [computer-vision, object-detection, deep-learning, pytorch, segmentation, openmmlab]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building high-quality object detection systems from scratch requires extensive expertise in model architecture design, data augmentation, training strategies, and evaluation protocols. MMDetection standardizes the entire pipeline with modular, configurable components and hundreds of pre-trained models that researchers and engineers can immediately benchmark, fine-tune, and deploy.
+
+use_cases:
+  - Detect objects in images and video streams using state-of-the-art models like DETR, YOLO, Mask R-CNN, and Swin Transformer
+  - Benchmark detection models on standard datasets (COCO, Pascal VOC, Cityscapes) with a unified evaluation framework
+  - Prototype new detection architectures by mixing and matching modular components
+  - Fine-tune pre-trained detection models on custom datasets with minimal code changes
+  - Deploy instance segmentation and panseg pipelines for autonomous driving, medical imaging, and industrial inspection

--- a/tools/rag/splade.yaml
+++ b/tools/rag/splade.yaml
@@ -1,0 +1,24 @@
+name: SPLADE
+description: SPLADE is a sparse neural retrieval model that learns query and document sparse representations via BERT-based expansion and regularization. It combines the effectiveness of dense retrieval with the efficiency of inverted indexes, providing interpretable and fast first-stage ranking for information retrieval systems.
+tagline: Sparse neural search that bridges dense retrieval with inverted index efficiency
+
+github_url: https://github.com/naver/splade
+website_url: https://naver.github.io/splade
+docs_url: https://github.com/naver/splade#readme
+install_command: pip install splade
+
+category: RAG
+tags: [information-retrieval, neural-search, sparse-representation, nlp, beir, bert]
+pricing: free
+is_open_source: true
+license: NOASSERTION
+
+problem_solved: |
+  Traditional dense retrieval models produce high-dimensional embeddings that require approximate nearest neighbor search and specialized vector databases, while BM25 keyword search lacks semantic understanding. SPLADE bridges this gap by learning sparse representations via BERT that work with standard inverted indexes, delivering retrieval quality competitive with dense models while being interpretable and searchable without specialized infrastructure.
+
+use_cases:
+  - Build a retrieval pipeline that combines semantic understanding with inverted index efficiency on standard hardware
+  - Replace or augment BM25-based search with neural sparse retrieval for better out-of-domain generalization
+  - Index and retrieve documents at scale without a vector database — standard Lucene or Elasticsearch indexes work
+  - Implement hybrid retrieval systems that fuse sparse (SPLADE) and dense (DPR/ColBERT) signals for maximum recall
+  - Deploy interpretable retrieval where every match can be traced to explicit term overlap


### PR DESCRIPTION
Add 6 new tools to the catalog:

- **Monoscope** — AI-powered observability platform for logs, traces, and metrics with natural-language querying (monitoring)
- **HertzBeat** — Apache open-source real-time observability system with agentless monitoring (monitoring)
- **TypeDB** — Polymorphic database with strong type system unifying relational/document/graph models (data)
- **MMDetection** — OpenMMLab detection toolbox with hundreds of pre-trained models (other)
- **SPLADE** — Sparse neural retrieval model bridging dense retrieval with inverted index efficiency (RAG)
- **Nomic** — Text embedding models, Atlas visualization platform, and GPT4All local LLM inference (LLM)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for TypeDB, Nomic, HertzBeat, Monoscope, MMDetection, and SPLADE.
  * Included descriptions, links, categories, tags, licensing and pricing details, installation guidance, and supported use cases for each tool.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->