### PR TITLE
Add TypeChat, TextGrad, Fabric, Windmill, TEN Framework to catalog

### DIFF
--- a/tools/agent-frameworks/ten-framework.yaml
+++ b/tools/agent-frameworks/ten-framework.yaml
@@ -1,0 +1,27 @@
+name: TEN Framework
+description: An open-source framework for building conversational AI agents with real-time voice and multi-modal capabilities. It provides infrastructure for voice pipelines, agent orchestration, and multi-modal interactions in real-time applications.
+tagline: Build real-time voice AI agents with multi-modal capabilities
+
+github_url: https://github.com/TEN-framework/ten-framework
+website_url: https://agent.theten.ai
+
+category: Agents
+tags: [agents, voice, real-time, multi-modal, framework, ai]
+pricing: free
+is_open_source: true
+
+problem_solved: |
+  Building real-time voice AI agents is significantly harder than text-based agents — it
+  requires managing audio pipelines, speech-to-text, text-to-speech, voice activity
+  detection, and low-latency streaming, all orchestrated across multiple models. TEN
+  Framework provides a complete infrastructure for these pipelines: connect a wake-word
+  detector, an ASR model, an LLM, and a TTS engine into a working voice agent with
+  minimal glue code. It handles the real-time streaming, buffering, and synchronization
+  that makes conversational voice agents feel natural.
+
+use_cases:
+  - Build a voice-based customer support agent that can hear, understand, and speak back in real time
+  - Create a real-time transcription and analysis pipeline for meetings with multi-modal context
+  - Build a voice assistant for physical spaces that responds to wake words with low latency
+  - Deploy a multi-modal agent that processes both speech input and camera feed simultaneously
+  - Prototype conversational AI experiences with customizable voice pipelines from multiple providers

--- a/tools/dev-tools/fabric.yaml
+++ b/tools/dev-tools/fabric.yaml
@@ -1,0 +1,30 @@
+name: Fabric
+description: An open-source framework for augmenting human capabilities using AI through a curated library of reusable patterns (prompts). Fabric processes any input through community-vetted patterns for summarization, extraction, analysis, and creative tasks.
+tagline: Reusable AI patterns for augmenting human creativity and productivity
+
+github_url: https://github.com/danielmiessler/fabric
+website_url: https://danielmiessler.com/fabric
+
+category: Dev Tools
+tags: [ai, cli, patterns, prompt-engineering, automation, go, productivity]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: brew install fabric-ai
+
+problem_solved: |
+  Most people use AI through ad-hoc prompts they write from scratch each time. Fabric
+  curates a library of proven, community-reviewed patterns — think of them as prompt
+  functions. Each pattern takes an input and produces a structured output: summarize a
+  video, extract wisdom from a book, analyze a debate, write a creative brief. The
+  patterns are version-controlled, shareable, and designed to work with any LLM backend.
+  Instead of prompting from scratch, you pipe content through a pattern and get
+  consistent, high-quality results.
+
+use_cases:
+  - Summarize a YouTube video or podcast transcript into key insights in one command
+  - Extract actionable wisdom and quotable passages from any long-form text
+  - Create a structured creative brief from a rough idea or brainstorming session
+  - Analyze a debate or discussion to surface opposing arguments and logical fallacies
+  - Build custom, reusable patterns for domain-specific tasks your team repeats daily

--- a/tools/dev-tools/textgrad.yaml
+++ b/tools/dev-tools/textgrad.yaml
@@ -1,0 +1,28 @@
+name: TextGrad
+description: Automatic differentiation for AI outputs — TextGrad backpropagates textual feedback through LLM-based systems to optimize prompts, generations, and agent outputs using gradient-like textual signals instead of numerical gradients.
+tagline: Automatic differentiation through text — optimize LLM outputs with backpropagation
+
+github_url: https://github.com/zou-group/textgrad
+
+category: Dev Tools
+tags: [python, pytorch, llm, optimization, gradient, backpropagation, auto-diff]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install textgrad
+
+problem_solved: |
+  Optimizing LLM outputs currently relies on hand-tuning prompts or reinforcement learning.
+  TextGrad brings automatic differentiation to text: it treats each LLM call as a differentiable
+  operation in a computation graph. When you define a loss function on the output (e.g., "is
+  this molecule synthetically feasible?"), TextGrad backpropagates textual gradients through
+  the graph — improving prompts, chain-of-thought reasoning, or LLM-generated code in a
+  principled, automated way rather than through manual iteration.
+
+use_cases:
+  - Automatically optimize few-shot prompts by backpropagating through the prompt encoder
+  - Improve chain-of-thought reasoning quality by tuning intermediate reasoning steps
+  - Optimize LLM-generated code for correctness by defining test-passing as the loss function
+  - Fine-tune agent behavior in multi-step pipelines where each step is an LLM call
+  - Automatically discover better system prompts for classification and extraction tasks

--- a/tools/dev-tools/typechat.yaml
+++ b/tools/dev-tools/typechat.yaml
@@ -1,0 +1,29 @@
+name: TypeChat
+description: A library that makes it easy to build natural language interfaces using types. TypeChat replaces intent parsing with type constraints — you define the desired output structure as TypeScript types and the LLM fills them in, with compile-time validation.
+tagline: Build type-safe natural language interfaces with plain TypeScript types
+
+github_url: https://github.com/microsoft/TypeChat
+website_url: https://microsoft.github.io/TypeChat
+docs_url: https://microsoft.github.io/TypeChat/docs/intro
+
+category: Dev Tools
+tags: [typescript, nlp, llm, type-safety, microsoft, schema, validation]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: npm install typechat
+
+problem_solved: |
+  Every LLM integration needs structured output — but parsing free-text responses is fragile.
+  TypeChat lets you define the schema of what you want back as a regular TypeScript interface.
+  The library constructs a prompt from your types, sends it to the LLM, and validates the
+  response against your schema at runtime. If validation fails, it auto-corrects the LLM.
+  This replaces brittle regex parsing and JSON repair with a type-safe, self-correcting pipeline.
+
+use_cases:
+  - Build a classification system where you define the categories as a TypeScript union type and TypeChat handles the mapping
+  - Extract structured data from unstructured text — orders, invoices, contact info — with compile-time type safety
+  - Create a natural language form filler that validates responses against the expected schema before submission
+  - Build a chatbot that returns typed responses the frontend can use without parsing
+  - Implement an AI-powered search that returns results in a type-safe format matched to your UI components

--- a/tools/dev-tools/windmill.yaml
+++ b/tools/dev-tools/windmill.yaml
@@ -1,0 +1,30 @@
+name: Windmill
+description: An open-source developer platform and workflow engine that turns scripts into auto-generated UIs, scheduled jobs, webhooks, and workflows. Write in TypeScript, Python, Go, or Bash — Windmill handles execution, monitoring, and scaling.
+tagline: Turn scripts into workflows, UIs, and scheduled jobs — instantly
+
+github_url: https://github.com/windmill-labs/windmill
+website_url: https://windmill.dev
+docs_url: https://docs.windmill.dev
+
+category: Dev Tools
+tags: [workflow, automation, scripts, typescript, python, go, low-code, scheduling]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install windmill-api
+
+problem_solved: |
+  Building internal tools and automations usually means either writing full-stack web apps
+  or gluing together fragile no-code tools. Windmill takes scripts you already write — in
+  TypeScript, Python, Go, or Bash — and auto-generates UIs, REST APIs, scheduled tasks,
+  Slack commands, and webhooks around them. It handles execution, state management,
+  retries, and monitoring. Developers write business logic as functions; Windmill provides
+  the infrastructure to run them on triggers, schedules, or user requests.
+
+use_cases:
+  - Turn a Python data cleaning script into an internal dashboard with auto-generated UI
+  - Schedule recurring data syncs between SaaS tools without maintaining a cron server
+  - Build Slack slash commands that invoke TypeScript or Python scripts with user parameters
+  - Create approval workflows where a human reviews and approves automated actions
+  - Hook webhooks from GitHub, Stripe, or Sentry to run custom remediation scripts automatically


### PR DESCRIPTION
Add TypeChat, TextGrad, Fabric, Windmill, and TEN Framework to the Agentic AI For Good catalog.

**TypeChat** (Microsoft) — Build type-safe natural language interfaces using TypeScript types. 8.7k★, MIT.
**TextGrad** — Automatic differentiation through text: backpropagates feedback through LLM-based systems. 3.7k★, MIT.
**Fabric** — Curated library of reusable AI patterns for augmenting human productivity. 43k★, MIT.
**Windmill** — Open-source developer platform that turns scripts into auto-generated UIs and workflows. 17.2k★, Apache-2.0.
**TEN Framework** — Open-source framework for building real-time voice AI agents with multi-modal capabilities. 10.9k★.

All validated locally with `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for TEN Framework, Fabric, TextGrad, TypeChat, and Windmill.
  * Included descriptions, links, categories, licensing and pricing details, installation instructions, and practical use cases for each tool.
  * Added metadata highlighting capabilities such as voice agents, multimodal workflows, AI pattern libraries, structured outputs, and developer automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->