### PR TITLE
Add PaddlePaddle, MindSpore, Backstage to catalog

### DIFF
--- a/tools/dev-tools/backstage.yaml
+++ b/tools/dev-tools/backstage.yaml
@@ -1,0 +1,31 @@
+name: Backstage
+description: An open platform for building developer portals that centralize infrastructure, services, documentation, and tooling. Backstage provides a unified developer experience through a plugin architecture and a software catalog.
+tagline: Build your own developer portal with a plugin-based architecture
+
+github_url: https://github.com/backstage/backstage
+website_url: https://backstage.io
+docs_url: https://backstage.io/docs
+
+category: Dev Tools
+tags: [developer-portal, platform-engineering, services, catalog, plugins, typescript, react]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: npx @backstage/create-app
+
+problem_solved: |
+  As engineering organizations grow, developers waste time navigating between dozens of
+  tools — CI/CD dashboards, monitoring alerts, documentation wikis, API catalogs, and
+  service ownership spreadsheets. Backstage brings everything into a single, extensible
+  developer portal. Its software catalog automatically indexes all services, libraries,
+  and deployments. Plugins surface the right information where developers need it: test
+  results next to a service, API docs alongside the code, deployment status beside the
+  runbook. For AI teams, Backstage can catalog models, training runs, and feature stores.
+
+use_cases:
+  - Create a unified service catalog that shows ownership, dependencies, and health for every microservice
+  - Build a documentation hub where tech docs are auto-generated from code annotations and live next to their services
+  - Centralize CI/CD status, monitoring dashboards, and on-call schedules in one place
+  - Create a plugin to catalog ML models, their training runs, and deployment history for AI teams
+  - Surface API documentation, test coverage, and security audit results alongside each service's detail page

--- a/tools/llm/mindspore.yaml
+++ b/tools/llm/mindspore.yaml
@@ -1,0 +1,31 @@
+name: MindSpore
+description: Huawei's open-source deep learning framework designed for efficient AI training and inference across devices, edge, and cloud. Features automatic differentiation, dynamic graphs, and native Ascend processor support.
+tagline: Huawei's AI framework for device-edge-cloud unified training and inference
+
+github_url: https://github.com/mindspore-ai/mindspore
+website_url: https://www.mindspore.cn
+docs_url: https://www.mindspore.cn/docs/en/master/index.html
+
+category: LLM
+tags: [python, deep-learning, framework, training, inference, huawei, ascend, edge]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install mindspore
+
+problem_solved: |
+  Training AI models across different hardware platforms typically requires separate code
+  paths for different accelerators. MindSpore unifies device, edge, and cloud training
+  with a single framework that automatically optimizes computation graphs for the target
+  hardware. Its automatic differential engine generates gradients without manual
+  gradient functions, and the MindIR intermediate representation enables model transfer
+  between training and inference environments. For developers targeting Huawei Ascend
+  processors, MindSpore provides native, optimized support not available in other frameworks.
+
+use_cases:
+  - Train deep learning models on Huawei Ascend processors with native hardware optimization
+  - Deploy models across device, edge, and cloud environments using a single codebase
+  - Build computer vision pipelines for image classification, object detection, and segmentation
+  - Develop NLP models with automatic differentiation and dynamic graph execution
+  - Use MindSpore Lite to deploy optimized models on mobile and IoT devices

--- a/tools/llm/paddlepaddle.yaml
+++ b/tools/llm/paddlepaddle.yaml
@@ -1,0 +1,31 @@
+name: PaddlePaddle
+description: Baidu's open-source deep learning platform with comprehensive support for LLM training, inference, and deployment. Features the PaddleNLP library for large language model development and a dynamic-to-static graph compiler.
+tagline: Baidu's deep learning platform with native LLM and NLP support
+
+github_url: https://github.com/PaddlePaddle/Paddle
+website_url: https://www.paddlepaddle.org
+docs_url: https://www.paddlepaddle.org/documentation/docs/en/guides/index_en.html
+
+category: LLM
+tags: [python, deep-learning, nlp, llm, training, inference, baidu, framework]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install paddlepaddle
+
+problem_solved: |
+  Deep learning frameworks like TensorFlow and PyTorch are general-purpose, but training
+  large language models requires specialized tooling for distributed training, mixed
+  precision, and memory optimization. PaddlePaddle provides a complete LLM development
+  stack: PaddleNLP offers pre-built model architectures, training recipes, and distributed
+  training support out of the box. Its dynamic-to-static compiler converts Python training
+  code into optimized static graphs for production inference, bridging the gap between
+  research flexibility and deployment performance.
+
+use_cases:
+  - Train and fine-tune large language models using PaddleNLP's pre-built architectures and recipes
+  - Deploy LLMs for production inference with the compiled static graph for maximum throughput
+  - Build NLP pipelines for text classification, named entity recognition, and machine translation
+  - Use the distributed training toolkit to scale model training across multiple GPUs or nodes
+  - Leverage PaddleCloud for end-to-end ML workflows from data processing to model serving


### PR DESCRIPTION
Add PaddlePaddle, MindSpore, and Backstage to the Agentic AI For Good catalog.

**PaddlePaddle** (Baidu) — Open-source deep learning platform with native LLM support via PaddleNLP. 24k★, Apache-2.0.
**MindSpore** (Huawei) — AI framework for device-edge-cloud unified training and inference with native Ascend support. 4.7k★, Apache-2.0.
**Backstage** (CNCF) — Open platform for building developer portals with a plugin-based architecture and software catalog. 33.9k★, Apache-2.0.

All validated locally with `npx tsx scripts/validate-tool.ts`.
