### PR TITLE
Add Danswer, DocsGPT, MongoDB Atlas Vector Search, Astra DB, Couchbase to catalog

### DIFF
--- a/tools/rag/danswer.yaml
+++ b/tools/rag/danswer.yaml
@@ -1,0 +1,28 @@
+name: Danswer
+description: An open-source enterprise question answering platform that connects LLMs to team documents, wikis, Slack conversations, and knowledge bases with AI-powered search and chat.
+tagline: Ask your company data, get answers instantly
+
+github_url: https://github.com/danswer-ai/danswer
+website_url: https://danswer.ai
+docs_url: https://docs.danswer.ai
+
+category: RAG
+tags: [python, rag, enterprise-search, knowledge-base, slack-integration, llm-ui, self-hosted]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Enterprise knowledge is scattered across wikis, Google Drive, Slack, Confluence, Jira, and
+  shared drives. Finding the right answer means searching every tool individually — and hoping
+  you used the right keywords. Danswer indexes everything into one unified search and chat
+  interface. It connects to 25+ data sources, runs semantic search over all of them, and lets
+  users ask questions in natural language. Every answer shows citations and source documents
+  so you can verify the results.
+
+use_cases:
+  - Deploy a company-wide Q&A chatbot that searches across Slack, Google Drive, Confluence, and Notion simultaneously
+  - Create a self-service employee knowledge base where HR, IT, and legal policies are answerable in one query
+  - Build a developer documentation assistant that indexes internal wikis, API docs, and READMEs
+  - Set up AI-powered Slack bot that answers team questions from indexed company docs
+  - Enable auditors and compliance teams to search across all company documents with citation-backed answers

--- a/tools/rag/docsgpt.yaml
+++ b/tools/rag/docsgpt.yaml
@@ -1,0 +1,29 @@
+name: DocsGPT
+description: An open-source documentation assistant that lets you chat with your project documentation using GPT models. Supports multiple LLM providers and integrates with any documentation source.
+tagline: Chat with any documentation, powered by your favorite LLM
+
+github_url: https://github.com/arc53/DocsGPT
+website_url: https://docsgpt.cloud
+docs_url: https://docs.docsgpt.cloud
+
+install_command: npm install docsgpt
+
+category: RAG
+tags: [python, react, rag, documentation, chatgpt, llm, semantic-search, self-hosted]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Reading documentation is slow and frustrating — you know the answer is somewhere in a 50-page
+  guide but CTRL+F doesn't cut it. DocsGPT lets developers and users paste any documentation URL
+  or upload docs and immediately ask questions about them. It chunks the documentation, embeds it,
+  and retrieves relevant sections at query time. The result is a documentation FAQ chatbot that
+  works with any tech stack, supports 100+ languages, and can be self-hosted or used as a SaaS.
+
+use_cases:
+  - Add a documentation chatbot to your open-source project so users can ask questions without digging through READMEs
+  - Create a customer-facing FAQ assistant that answers product questions from your help center articles
+  - Build an internal knowledge base that indexes Notion pages, Google Docs, and code comments
+  - Deploy a multilingual documentation assistant that answers questions in 100+ languages
+  - Set up self-hosted documentation Q&A for air-gapped environments with proprietary knowledge bases

--- a/tools/vector-databases/astra-db.yaml
+++ b/tools/vector-databases/astra-db.yaml
@@ -1,0 +1,30 @@
+name: Astra DB
+description: A cloud-native database service built on Apache Cassandra with integrated vector search, designed for AI applications that require low-latency semantic search at global scale with zero operational overhead.
+tagline: Cassandra-powered vector database with global scale
+
+github_url: https://github.com/datastax/astrapy
+website_url: https://www.datastax.com/products/datastax-astra
+docs_url: https://docs.datastax.com/en/astra-db/
+
+install_command: pip install astrapy
+
+category: Vector DB
+tags: [vector-search, cassandra, cloud-native, nosql, python, rag, embeddings, semantic-search, serverless]
+pricing: freemium
+is_open_source: false
+license: Apache-2.0
+
+problem_solved: |
+  Running vector search at global scale means managing cluster topology, replication, failover,
+  and latency across regions. Most vector databases are designed for single-region deployments
+  and don't inherit Cassandra's multi-region replication. Astra DB brings Apache Cassandra's
+  proven distributed architecture to vector search — you get automatic multi-region replication,
+  tunable consistency, zero-downtime scaling, and vector search backed by Cassandra's
+  Storage-Attached Indexing. Every write is immediately queryable across all replicas.
+
+use_cases:
+  - Deploy a global semantic search service with automatic multi-region replication for low-latency worldwide access
+  - Power a real-time personalization engine that serves recommendations from Cassandra-backed vector embeddings
+  - Build a chat history retrieval system that stores and searches conversation embeddings at internet scale
+  - Create a document similarity pipeline that indexes millions of documents with Cassandra's proven write throughput
+  - Implement a hybrid search app combining Cassandra CQL filters, full-text search, and ANN vector queries

--- a/tools/vector-databases/couchbase.yaml
+++ b/tools/vector-databases/couchbase.yaml
@@ -1,0 +1,30 @@
+name: Couchbase
+description: An enterprise distributed NoSQL database with integrated vector search that enables hybrid semantic search across JSON documents, full-text, and AI embeddings from a single platform.
+tagline: Enterprise NoSQL with built-in vector search
+
+github_url: https://github.com/couchbase/couchbase-python-client
+website_url: https://www.couchbase.com
+docs_url: https://docs.couchbase.com/vector-search/vector-search.html
+
+install_command: pip install couchbase
+
+category: Vector DB
+tags: [nosql, vector-search, embeddings, document-database, python, semantic-search, full-text-search, enterprise]
+pricing: paid
+is_open_source: false
+license: Apache-2.0
+
+problem_solved: |
+  Enterprise applications need to store structured data, run full-text search, and power semantic
+  AI queries — but most databases specialize in only one. Couchbase combines a distributed JSON
+  document store, full-text search via Bleve, and Approximate Nearest Neighbor vector search in
+  a single cluster. This means your product catalog, search index, and embedding vectors all live
+  in the same database with the same replication, security, and backup policies. No ETL jobs,
+  no separate vector infrastructure, no data synchronization lag.
+
+use_cases:
+  - Build a hybrid e-commerce search that combines product metadata filters, full-text search, and visual similarity search
+  - Create a document RAG pipeline that queries JSON documents by field, full-text match, and semantic similarity in one query
+  - Deploy an enterprise knowledge base with role-based access control where vectors, documents, and metadata share the same security model
+  - Power a recommendation engine that stores user profiles, behavioral vectors, and product data in a single Couchbase cluster
+  - Implement a fraud detection system that joins transaction vectors with structured account data in real time

--- a/tools/vector-databases/mongodb-atlas-vector-search.yaml
+++ b/tools/vector-databases/mongodb-atlas-vector-search.yaml
@@ -1,0 +1,30 @@
+name: MongoDB Atlas Vector Search
+description: Native vector search integrated directly into MongoDB Atlas, enabling semantic search, RAG, and AI-powered applications on operational data without a separate vector database.
+tagline: Vector search where your data already lives
+
+github_url: https://github.com/mongodb/mongo-python-driver
+website_url: https://www.mongodb.com/products/platform/atlas-vector-search
+docs_url: https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-overview/
+
+install_command: pip install pymongo
+
+category: Vector DB
+tags: [mongodb, vector-search, embeddings, semantic-search, rag, python, nodejs, database]
+pricing: freemium
+is_open_source: false
+license: Apache-2.0
+
+problem_solved: |
+  Adding vector search to an application typically means running a separate vector database
+  alongside your primary database — doubling operational complexity, replication lag, and cloud
+  costs. MongoDB Atlas Vector Search eliminates this by embedding vector search directly into
+  MongoDB's document model. You store vectors alongside your operational data, index them with
+  the Approximate Nearest Neighbor (ANN) algorithm, and query with a single unified API. No
+  sync pipelines, no dual-database management, no extra infrastructure.
+
+use_cases:
+  - Build semantic search over product catalogs using embeddings without syncing data to a separate vector store
+  - Implement RAG pipelines that query operational documents and their vector embeddings in a single query
+  - Create a hybrid search system combining full-text search, geospatial filters, and vector similarity in one database call
+  - Power real-time recommendation engines by querying user behavior vectors alongside metadata filters
+  - Build an anomaly detection system that compares new data points against historical vector embeddings stored in the same collection


### PR DESCRIPTION
## Tools added

This PR adds 5 tools to the Agentic AI For Good catalog:

### RAG
- **Danswer** — Open-source enterprise question answering platform connecting LLMs to team documents, wikis, Slack, and knowledge bases. 30.9k★ on GitHub.
- **DocsGPT** — Open-source documentation assistant for chatting with project documentation using GPT models. 18k★ on GitHub, MIT license.

### Vector DB
- **MongoDB Atlas Vector Search** — Native vector search integrated into MongoDB Atlas, enabling semantic search and RAG without a separate vector database.
- **Astra DB** — DataStax's cloud-native Cassandra-based database with integrated vector search for global-scale AI applications.
- **Couchbase** — Enterprise distributed NoSQL database with built-in vector search for hybrid semantic and full-text search.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable catalog entries for Danswer and DocsGPT, including descriptions, links, licensing, installation details, and use cases.
  * Added catalog entries for Astra DB, Couchbase, and MongoDB Atlas Vector Search with product metadata, setup guidance, categorization, and supported use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->