### PR TITLE
Add Mage AI, Gotenberg, Logseq, Obsidian, Descript to catalog

### DIFF
--- a/tools/data/gotenberg.yaml
+++ b/tools/data/gotenberg.yaml
@@ -1,0 +1,24 @@
+name: Gotenberg
+tagline: Docker-powered stateless API for document conversion
+description: |-
+  Gotenberg provides a stateless HTTP API for converting HTML, Markdown, and Office documents into PDFs. Powered by Docker and Chromium under the hood, it handles document conversion at scale without needing a browser automation setup or complex dependencies.
+problem_solved: |-
+  Converting HTML, Markdown, or Office documents to PDF at scale typically requires headless browser automation, complex dependency chains, and careful resource management. Gotenberg wraps this into a single Docker container with a clean HTTP API — no Puppeteer scripts, no system dependencies, just a POST request. It handles concurrent conversions, resource isolation, and memory limits out of the box.
+github_url: https://github.com/gotenberg/gotenberg
+website_url: https://gotenberg.dev
+docs_url: https://gotenberg.dev/docs
+category: Data
+tags:
+  - document-conversion
+  - pdf-generation
+  - html-to-pdf
+  - api
+  - docker
+pricing: free
+is_open_source: true
+license: MIT
+use_cases:
+  - "Converting HTML invoices and receipts to PDF for archival and distribution"
+  - "Generating PDF reports from web dashboards using Markdown or HTML templates"
+  - "Processing Office documents (DOCX, XLSX, PPTX) into PDF for unified document pipelines"
+  - "Automating batch PDF conversion for document-heavy workflows in RAG data pipelines"

--- a/tools/data/mage-ai.yaml
+++ b/tools/data/mage-ai.yaml
@@ -1,0 +1,26 @@
+name: Mage AI
+tagline: Data and AI workflows that run on autopilot
+description: |-
+  Mage is an open-source data pipeline platform for building, running, and managing data workflows. It provides an AI-powered workflow builder, monitoring, and automatic recovery for data pipelines that integrate with databases, warehouses, and APIs — replacing fragmented ETL scripts and brittle cron jobs.
+problem_solved: |-
+  Teams managing data pipelines rely on a patchwork of cron jobs, one-off scripts, and fragile handoffs that break silently and have no visibility. Mage replaces this with a unified execution layer featuring AI-generated workflows, automatic retries, monitoring dashboards, and audit logging — so data teams can move from intent to production faster without operational overhead.
+github_url: https://github.com/mage-ai/mage-ai
+website_url: https://www.mage.ai
+docs_url: https://docs.mage.ai
+install_command: pip install mage-ai
+category: Data
+tags:
+  - data-pipeline
+  - etl
+  - orchestration
+  - workflow-automation
+  - open-source
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+use_cases:
+  - "Building automated ETL pipelines that sync data from multiple sources into a data warehouse"
+  - "Creating AI-generated workflows by describing the desired outcome in natural language"
+  - "Orchestrating multi-step data transformations with monitoring, retries, and alerting"
+  - "Migrating legacy SQL models and stored procedures into version-controlled, reusable pipelines"
+  - "Preparing clean, governed datasets for AI training and RAG pipelines"

--- a/tools/other/descript.yaml
+++ b/tools/other/descript.yaml
@@ -1,0 +1,24 @@
+name: Descript
+tagline: AI-powered video and audio editor with text-based editing
+description: |-
+  Descript is an all-in-one video and audio editor that lets you edit media by editing the transcribed text. It features AI-powered transcription, screen recording, voice cloning, filler word removal, and collaborative workflows — making video and audio production as easy as editing a document.
+problem_solved: |-
+  Traditional video and audio editing is time-consuming and requires specialized skills — cutting clips, removing mistakes, and adjusting timing on a timeline is tedious. Descript transcribes media to text so you can edit by deleting or rearranging words, remove filler words and silences automatically, and generate polished content without learning complex editing software.
+website_url: https://www.descript.com
+docs_url: https://docs.descript.com
+category: Other
+tags:
+  - video-editing
+  - audio-editing
+  - transcription
+  - screen-recording
+  - voice-cloning
+  - ai-media
+pricing: paid
+is_open_source: false
+use_cases:
+  - "Editing video podcasts and tutorials by deleting or rearranging transcribed text"
+  - "Removing filler words (um, uh, like) and awkward pauses from recordings automatically"
+  - "Creating screen recordings with AI-generated transcripts and captions for documentation"
+  - "Producing shareable clips from long-form video content with AI-assisted highlights"
+  - "Generating voiceover narration using AI voice cloning and synthetic voices"

--- a/tools/other/logseq.yaml
+++ b/tools/other/logseq.yaml
@@ -1,0 +1,26 @@
+name: Logseq
+tagline: Open-source knowledge management with outliner and network graph
+description: |-
+  Logseq is an open-source knowledge management and collaboration platform that works on local Markdown and Org-mode files. It combines an outliner-style note-taking interface with bidirectional linking, graph visualization, spaced repetition flashcards, and a powerful query system for building a connected knowledge base.
+problem_solved: |-
+  Traditional note-taking apps trap content in proprietary formats and lack the tools to surface connections between ideas over time. Logseq solves this by storing everything as plain local Markdown or Org files, building a bidirectional link graph that reveals how notes connect, and providing a Datalog query engine for advanced retrieval — all without vendor lock-in.
+github_url: https://github.com/logseq/logseq
+website_url: https://logseq.com
+docs_url: https://docs.logseq.com
+category: Other
+tags:
+  - knowledge-management
+  - note-taking
+  - open-source
+  - org-mode
+  - markdown
+  - graph-database
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+use_cases:
+  - "Building a personal knowledge base with bidirectional links and graph visualization"
+  - "Taking structured meeting notes using outliner-style bullets and hierarchies"
+  - "Creating a networked research library with tags, page properties, and Datalog queries"
+  - "Scheduling spaced repetition flashcards for learning and memorization directly from notes"
+  - "Collaborating on a shared knowledge graph with a team using Git-backed sync"

--- a/tools/other/obsidian.yaml
+++ b/tools/other/obsidian.yaml
@@ -1,0 +1,23 @@
+name: Obsidian
+tagline: Local-first knowledge base with bidirectional linking and plugins
+description: |-
+  Obsidian is a powerful extensible knowledge base that works on local Markdown files. It features bidirectional linking, a graph view, a canvas for visual thinking, and thousands of community plugins — giving users complete control over their notes without vendor lock-in or subscription fees for the core app.
+problem_solved: |-
+  Most note-taking apps lock data in proprietary formats and limit how you can connect and retrieve information. Obsidian keeps everything in plain Markdown files on your device, enabling bidirectional links, a visual knowledge graph, tag-based navigation, and a rich plugin API for custom workflows — so your knowledge base stays portable and grows with you.
+website_url: https://obsidian.md
+docs_url: https://help.obsidian.md
+category: Other
+tags:
+  - knowledge-management
+  - note-taking
+  - markdown
+  - plugins
+  - personal-knowledge-base
+pricing: freemium
+is_open_source: false
+use_cases:
+  - "Building a personal knowledge base with bidirectional links and visual graph exploration"
+  - "Managing research notes with tags, properties, and advanced search across connected notes"
+  - "Writing and publishing a digital garden or wiki using Obsidian Publish"
+  - "Creating interactive visual maps of ideas and processes with the Canvas whiteboard feature"
+  - "Extending workflows with thousands of community plugins for task management, journaling, and AI"


### PR DESCRIPTION
Add 5 tools to the catalog:

- **Mage AI** — Open-source data pipeline platform with AI-powered workflow builder, monitoring, and automatic recovery. (Data)
- **Gotenberg** — Docker-powered stateless API for converting HTML, Markdown, and Office documents to PDF. (Data)
- **Logseq** — Open-source knowledge management platform with outliner note-taking, bidirectional links, and graph visualization. (Other)
- **Obsidian** — Local-first extensible knowledge base with bidirectional linking, graph view, and thousands of plugins. (Other)
- **Descript** — AI-powered video and audio editor that lets you edit media by editing transcribed text. (Other)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Gotenberg and Mage AI, including descriptions, links, categories, pricing, licensing, and use cases.
  * Added catalog entries for Descript, Logseq, and Obsidian with product details, classifications, pricing, and use cases.
  * Expanded the available tool directory with structured information for document conversion, workflow automation, media editing, and knowledge management tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->