### PR TITLE
Add SageMaker, Payload CMS, Retool, Sanity, Truss to catalog

### DIFF
--- a/tools/dev-tools/payload-cms.yaml
+++ b/tools/dev-tools/payload-cms.yaml
@@ -1,0 +1,26 @@
+name: Payload CMS
+tagline: Headless CMS and application framework built on Next.js
+description: |-
+  Payload CMS is an open-source headless content management system and application framework built on Next.js and TypeScript. It combines a powerful admin panel, REST and GraphQL APIs, and a flexible field system — making it suitable for both content-focused sites and custom application backends.
+problem_solved: |-
+  Building a custom content management system requires duplicating admin UI, authentication, file upload, and API patterns across projects. Traditional CMS solutions like WordPress are not designed for modern frontend stacks, while headless alternatives sacrifice flexibility. Payload provides a fully extensible CMS with a generated admin panel that adapts to your data model, built on Next.js — so content teams get a rich editor and developers keep full control.
+github_url: https://github.com/payloadcms/payload
+website_url: https://payloadcms.com
+docs_url: https://payloadcms.com/docs
+install_command: npm install payload
+category: Dev Tools
+tags:
+  - cms
+  - headless-cms
+  - nextjs
+  - typescript
+  - api
+pricing: freemium
+is_open_source: true
+license: MIT
+use_cases:
+  - "Building a headless CMS for a marketing website or blog with a custom content model"
+  - "Creating a backend admin panel for managing users, orders, and inventory in a web application"
+  - "Powering a multi-language documentation site with versioned content and media management"
+  - "Building a portfolio or e-commerce site with a flexible field system and rich text editor"
+  - "Using as an application framework for authenticated, database-backed web apps with a generated admin UI"

--- a/tools/dev-tools/retool.yaml
+++ b/tools/dev-tools/retool.yaml
@@ -1,0 +1,24 @@
+name: Retool
+tagline: Low-code platform for building internal tools and dashboards
+description: |-
+  Retool is a low-code platform for building custom internal tools, dashboards, admin panels, and workflow automations. It connects directly to databases and APIs, provides drag-and-drop UI components, and lets developers extend functionality with custom JavaScript and code blocks.
+problem_solved: |-
+  Building internal tools for data management, admin panels, and dashboards usually requires full-stack development effort for every new use case — even simple CRUD apps involve setting up authentication, UI, API endpoints, and database queries. Retool lets teams build production-ready internal tools in minutes by connecting pre-built UI components directly to databases and APIs, with built-in permissions, version control, and audit logging.
+website_url: https://retool.com
+docs_url: https://docs.retool.com
+category: Dev Tools
+tags:
+  - low-code
+  - internal-tools
+  - dashboards
+  - admin-panel
+  - workflow-automation
+  - saas
+pricing: freemium
+is_open_source: false
+use_cases:
+  - "Building admin panels for managing users, orders, and support tickets connected to a database"
+  - "Creating real-time dashboards that visualize data from multiple sources like SQL, REST, and GraphQL"
+  - "Automating internal workflows with approvals, notifications, and scheduled job triggers"
+  - "Replacing spreadsheets with production-ready tools for operations, finance, and customer support teams"
+  - "Developing custom CRM, inventory, or project management tools without a full engineering team"

--- a/tools/dev-tools/sagemaker.yaml
+++ b/tools/dev-tools/sagemaker.yaml
@@ -1,0 +1,26 @@
+name: SageMaker
+tagline: AWS platform for building, training, and deploying ML models at scale
+description: |-
+  Amazon SageMaker is a fully managed machine learning platform that covers the entire ML workflow — data labeling, training, tuning, deployment, and monitoring. It provides built-in algorithms, managed infrastructure, and MLOps tools for teams building production ML systems on AWS.
+problem_solved: |-
+  Building and deploying ML models requires stitching together infrastructure for data processing, training, hosting, and monitoring — each with its own setup, scaling rules, and costs. SageMaker unifies this into a single managed platform with automated scaling, built-in hyperparameter tuning, one-click deployment, and integrated MLOps for governance and monitoring.
+github_url: https://github.com/aws/sagemaker-python-sdk
+website_url: https://aws.amazon.com/sagemaker
+docs_url: https://docs.aws.amazon.com/sagemaker
+install_command: pip install sagemaker
+category: Dev Tools
+tags:
+  - ml-platform
+  - aws
+  - model-training
+  - model-deployment
+  - mlops
+pricing: paid
+is_open_source: false
+license: Apache-2.0
+use_cases:
+  - "Training and fine-tuning ML models using managed infrastructure with automatic scaling"
+  - "Deploying trained models as REST API endpoints for real-time or batch inference"
+  - "Automating ML pipelines with built-in MLOps for model registry, monitoring, and governance"
+  - "Running distributed training jobs across GPU clusters without managing infrastructure"
+  - "Labeling training data, performing feature engineering, and experiment tracking in one platform"

--- a/tools/dev-tools/sanity.yaml
+++ b/tools/dev-tools/sanity.yaml
@@ -1,0 +1,26 @@
+name: Sanity
+tagline: The composable content cloud for structured content at scale
+description: |-
+  Sanity is a composable content platform that provides a real-time, hosted backend for structured content with a customizable studio editor. It offers GROQ and GraphQL APIs, image transformations, asset pipelines, and real-time collaboration — making it suitable for content-driven applications at any scale.
+problem_solved: |-
+  Traditional CMS platforms couple content editing with presentation, making it hard to reuse content across websites, mobile apps, and digital signage. Sanity decouples content management from delivery with a real-time API, customizable editing studio, and structured content schemas — so content teams get a tailored editing experience while developers consume content through GROQ, GraphQL, or REST without presentation constraints.
+github_url: https://github.com/sanity-io/sanity
+website_url: https://www.sanity.io
+docs_url: https://www.sanity.io/docs
+install_command: npm install @sanity/cli
+category: Dev Tools
+tags:
+  - cms
+  - headless-cms
+  - content-platform
+  - real-time
+  - structured-content
+pricing: freemium
+is_open_source: true
+license: MIT
+use_cases:
+  - "Managing structured content for a multi-platform website serving web, mobile, and digital signage"
+  - "Building an editorial workflow with real-time collaboration, version history, and scheduled publishing"
+  - "Creating a custom content studio tailored to specific content types and editorial workflows"
+  - "Powering a multilingual content hub with image transformations and asset pipeline management"
+  - "Integrating with frontend frameworks via GROQ, GraphQL, or REST APIs for dynamic content delivery"

--- a/tools/dev-tools/truss.yaml
+++ b/tools/dev-tools/truss.yaml
@@ -1,0 +1,26 @@
+name: Truss
+tagline: Python framework for serving AI models in production
+description: |-
+  Truss is an open-source Python framework for packaging, deploying, and serving machine learning models. It wraps models with a production-ready HTTP server, handles dependency management, and provides a standardized interface for model serving — enabling teams to deploy models from any framework to any cloud.
+problem_solved: |-
+  Deploying ML models to production involves more than just exporting weights — you need an HTTP server, dependency management, request validation, batching, and resource configuration. Teams end up writing and maintaining custom serving boilerplate for every model. Truss standardizes this by wrapping any model in a consistent interface with automatic server generation, dependency resolution, and one-command deployment to any cloud provider.
+github_url: https://github.com/basetenlabs/truss
+website_url: https://truss.baseten.co
+docs_url: https://truss.baseten.co/docs
+install_command: pip install truss
+category: Dev Tools
+tags:
+  - model-serving
+  - deployment
+  - mlops
+  - python
+  - infrastructure
+pricing: free
+is_open_source: true
+license: MIT
+use_cases:
+  - "Deploying a fine-tuned LLM as a REST API endpoint with automatic batching and scaling"
+  - "Packaging a computer vision model with its dependencies for serverless or container deployment"
+  - "Running a multi-model inference pipeline with shared infrastructure and centralized monitoring"
+  - "Migrating Jupyter notebook models to production serving without rewriting the prediction logic"
+  - "Standardizing model deployment across teams with a consistent interface and CI/CD integration"


### PR DESCRIPTION
Add 5 tools to the catalog:

- **SageMaker** — AWS fully managed ML platform for building, training, and deploying models at scale. (Dev Tools)
- **Payload CMS** — Open-source headless CMS and application framework built on Next.js and TypeScript. (Dev Tools)
- **Retool** — Low-code platform for building custom internal tools, dashboards, and admin panels. (Dev Tools)
- **Sanity** — Composable content cloud with real-time structured content backend and customizable studio. (Dev Tools)
- **Truss** — Open-source Python framework for packaging, deploying, and serving ML models in production. (Dev Tools)
