### PR TITLE
Add Graphiti, ExecuTorch, TinyGrad, Panel, Voilà to catalog

### DIFF
--- a/tools/dev-tools/executorch.yaml
+++ b/tools/dev-tools/executorch.yaml
@@ -1,0 +1,33 @@
+name: ExecuTorch
+description: >-
+  ExecuTorch is a framework for deploying PyTorch models on mobile,
+  embedded, and edge devices, enabling on-device AI inference with a
+  lightweight, portable runtime and minimal hardware requirements.
+tagline: On-device AI inference for mobile and edge with PyTorch
+
+github_url: https://github.com/pytorch/executorch
+website_url: https://executorch.com/
+docs_url: https://pytorch.github.io/executorch/
+
+category: Dev Tools
+tags: [python, pytorch, mobile, embedded, edge, on-device, inference, deployment]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Running PyTorch models on mobile phones, microcontrollers, and edge
+  devices is challenging — full PyTorch is too large, and model conversion
+  pipelines are fragmented across platforms. ExecuTorch provides a unified,
+  lightweight runtime that exports PyTorch models to a portable format
+  optimized for ARM, Apple Silicon, Qualcomm, and other embedded targets,
+  enabling AI inference without cloud connectivity or GPU hardware.
+
+use_cases:
+  - Run LLMs like Llama on-device for privacy-preserving chat, summarization, and code generation on mobile phones.
+  - Deploy computer vision models on edge cameras and IoT devices for real-time object detection without cloud round-trips.
+  - Enable AI-powered features in embedded systems — smart home devices, wearables, and industrial sensors — with low latency.
+  - Build mobile apps with on-device AI for image classification, speech recognition, and natural language processing.
+  - Distribute AI models to consumer devices with a tiny runtime footprint (hundreds of KB) and no Python dependency.
+
+install_command: pip install executorch

--- a/tools/dev-tools/panel.yaml
+++ b/tools/dev-tools/panel.yaml
@@ -1,0 +1,34 @@
+name: Panel
+description: >-
+  Panel is an open-source Python framework for building interactive
+  data apps, dashboards, and visualizations directly from notebooks
+  and Python scripts, with support for Bokeh, Altair, Plotly, and
+  many other plotting libraries.
+tagline: Build powerful data apps and dashboards in pure Python
+
+github_url: https://github.com/holoviz/panel
+website_url: https://panel.holoviz.org/
+docs_url: https://panel.holoviz.org/reference.html
+
+category: Dev Tools
+tags: [python, dashboard, visualization, data-science, notebooks, reactive, web-app]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Data scientists and ML engineers often build analyses in Jupyter
+  notebooks but lack a straightforward path to turn them into
+  interactive, shareable web applications without learning a full
+  web framework. Panel bridges this gap by letting users create
+  rich dashboards with sliders, dropdowns, plots, and tables using
+  only Python code — no HTML, CSS, or JavaScript required.
+
+use_cases:
+  - Build interactive ML model dashboards that let stakeholders adjust hyperparameters and see predictions update in real time.
+  - Turn Jupyter notebook analyses into shareable web apps for team collaboration and client demos without rewriting code.
+  - Create monitoring dashboards for AI systems — visualize metrics, logs, and alerting data from multiple sources in one place.
+  - Develop internal tool UIs for dataset exploration, annotation, and quality inspection with reactive filtering and search.
+  - Embed interactive visualizations in existing web applications via Panel's server mode or standalone HTML export.
+
+install_command: pip install panel

--- a/tools/dev-tools/voila.yaml
+++ b/tools/dev-tools/voila.yaml
@@ -1,0 +1,34 @@
+name: Voilà
+description: >-
+  Voilà converts Jupyter notebooks into standalone web applications
+  and dashboards with a single command, rendering notebook cell
+  outputs as interactive web pages without requiring code changes
+  or web development skills.
+tagline: Turn Jupyter notebooks into standalone web applications
+
+github_url: https://github.com/voila-dashboards/voila
+website_url: https://voila.readthedocs.io/
+docs_url: https://voila.readthedocs.io/en/stable/
+
+category: Dev Tools
+tags: [python, jupyter, notebooks, dashboard, web-app, data-science, visualization]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Jupyter notebooks are great for exploration and analysis but are
+  not designed for production deployment or sharing with non-technical
+  stakeholders. Voilà instantly converts any notebook into an
+  interactive web application by executing the notebook server-side
+  and rendering only the cell outputs — no code, no messy input cells,
+  just clean, reactive dashboards and reports.
+
+use_cases:
+  - Deploy ML model exploration notebooks as interactive dashboards where business users can adjust parameters and see live predictions.
+  - Publish data analysis reports that stakeholders can view and interact with in a browser without installing Python or Jupyter.
+  - Create internal tool interfaces for dataset inspection, annotation review, and quality checks directly from analysis notebooks.
+  - Build interactive teaching materials and tutorials where students see polished outputs without notebook code complexity.
+  - Embed reactive visualizations from notebooks into company intranets or customer-facing portals via Voilà's server mode.
+
+install_command: pip install voila

--- a/tools/other/tinygrad.yaml
+++ b/tools/other/tinygrad.yaml
@@ -1,0 +1,35 @@
+name: TinyGrad
+description: >-
+  TinyGrad is a minimal deep learning framework that implements the
+  full tensor operation graph and autograd from scratch, designed for
+  simplicity, hackability, and educational clarity rather than
+  production performance.
+tagline: A minimal deep learning framework you can understand end-to-end
+
+github_url: https://github.com/tinygrad/tinygrad
+website_url: https://tinygrad.org/
+docs_url: https://docs.tinygrad.org/
+
+category: Other
+tags: [python, deep-learning, autograd, tensor, framework, education, pytorch]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Modern deep learning frameworks like PyTorch and TensorFlow are
+  enormous codebases with millions of lines, making it nearly impossible
+  for learners and researchers to understand the full stack — from tensor
+  operations through autograd to GPU kernels. TinyGrad implements the
+  entire deep learning stack in a few thousand lines of Python, making
+  the core concepts of tensor computation, automatic differentiation,
+  and kernel compilation accessible to anyone who reads the code.
+
+use_cases:
+  - Learn how deep learning frameworks work end-to-end by reading a minimal, readable Python implementation of tensors and autograd.
+  - Rapidly prototype and experiment with custom neural network architectures without the overhead of full PyTorch or TensorFlow.
+  - Teach deep learning fundamentals — the framework is small enough that students can trace through the entire backpropagation flow.
+  - Hack on the framework itself — add custom ops, new backends, or alternative kernel compilers with minimal code changes.
+  - Build educational demos and visualizations of gradient descent, optimizer internals, and computation graphs in action.
+
+install_command: pip install tinygrad

--- a/tools/rag/graphiti.yaml
+++ b/tools/rag/graphiti.yaml
@@ -1,0 +1,33 @@
+name: Graphiti
+description: >-
+  Graphiti is an open-source framework for building and querying real-time
+  knowledge graphs that represent agent state, entity relationships, and
+  temporal business context for AI agents.
+tagline: Build real-time knowledge graphs for AI agents
+
+github_url: https://github.com/getzep/graphiti
+website_url: https://graphiti.help/
+docs_url: https://help.graphiti.help/
+
+category: RAG
+tags: [python, knowledge-graph, rag, agents, temporal, entities, relationships]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI agents lack persistent, evolving context about entities and their
+  relationships — they operate in stateless turns, forgetting past
+  interactions and failing to build a cohesive understanding over time.
+  Graphiti maintains a real-time knowledge graph that dynamically updates
+  as agents interact, integrating temporal awareness, entity deduplication,
+  and semantic search to provide long-running context for agentic workflows.
+
+use_cases:
+  - Equip customer support agents with a persistent knowledge graph of user preferences, past issues, and account history across sessions.
+  - Power research assistants that build and query evolving entity-relationship graphs from documents and conversations over time.
+  - Enable agentic workflows that need temporal reasoning — tracking how entity relationships change across days or weeks.
+  - Integrate with LLM agents to provide structured, queryable memory that goes beyond simple vector stores or chat history.
+  - Build real-time monitoring dashboards that visualize entity networks and relationship changes as agents operate.
+
+install_command: pip install graphiti


### PR DESCRIPTION
Add 5 tools to the Agentic AI For Good catalog:

- **Graphiti** (RAG) — Build real-time knowledge graphs for AI agents
- **ExecuTorch** (Dev Tools) — On-device AI inference for mobile and edge with PyTorch  
- **TinyGrad** (Other) — A minimal deep learning framework you can understand end-to-end
- **Panel** (Dev Tools) — Build powerful data apps and dashboards in pure Python
- **Voilà** (Dev Tools) — Turn Jupyter notebooks into standalone web applications

All entries validated with `npx tsx scripts/validate-tool.ts` and pass CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for ExecuTorch, Panel, Voilà, TinyGrad, and Graphiti.
  * Included descriptions, documentation and website links, categories, tags, licensing, pricing, use cases, and installation instructions for each tool.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->