### PR TITLE
Add OpenCode, Devika, DB-GPT, FauxPilot, LLaVA to catalog

### DIFF
--- a/tools/agent-frameworks/db-gpt.yaml
+++ b/tools/agent-frameworks/db-gpt.yaml
@@ -1,0 +1,37 @@
+name: DB-GPT
+description: Open-source agentic AI data assistant that integrates large language models with data sources to enable natural language querying, analysis, and workflow automation across your data stack.
+tagline: Agentic AI data assistant for modern data stacks
+
+github_url: https://github.com/eosphoros-ai/DB-GPT
+website_url: https://docs.dbgpt.cn
+
+category: Agents
+tags:
+  - agents
+  - database
+  - llm
+  - rag
+  - data
+  - ai
+  - open-source
+  - sql
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Accessing and analyzing data typically requires SQL expertise, familiarization with database
+  schemas, and context-switching between analytical tools and chat interfaces. DB-GPT solves
+  this by creating an agentic layer between users and their data. It understands natural language
+  queries, translates them into database operations, retrieves relevant context through RAG,
+  and can execute multi-step data workflows. The platform supports multiple database types,
+  integrates with popular LLMs, and provides a visual interface for building data applications
+  without writing code. For data teams, this reduces the friction between asking a question
+  about data and getting a meaningful answer.
+
+use_cases:
+  - Query databases using natural language without writing SQL or knowing the schema structure
+  - Build conversational AI assistants that answer questions by retrieving and analyzing live data
+  - Automate multi-step data workflows combining database queries, analysis, and report generation
+  - Create data applications with a visual interface that connect LLMs to enterprise data sources
+  - Enable non-technical team members to explore data and generate insights through chat interfaces

--- a/tools/dev-tools/devika.yaml
+++ b/tools/dev-tools/devika.yaml
@@ -1,0 +1,34 @@
+name: Devika
+description: Open-source agentic software engineer that uses AI to understand natural language requirements, plan implementation steps, and autonomously execute software engineering tasks across your codebase.
+tagline: Open-source AI software engineer
+
+github_url: https://github.com/stitionai/devika
+
+category: Dev Tools
+tags:
+  - coding-agent
+  - agent
+  - ai
+  - software-engineering
+  - open-source
+  - developer-tools
+  - autonomous-coding
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Complex software engineering tasks — implementing features across multiple files, debugging
+  production issues, or refactoring large codebases — require understanding context that spans
+  the entire project. Traditional tools help with individual edits but break down on end-to-end
+  tasks that require planning, multi-file changes, and iterative testing. Devika solves this as
+  an agentic software engineer that takes natural language requirements, researches the codebase,
+  plans the implementation, and executes changes autonomously. It brings the same structured
+  approach as a human engineer — understand, plan, build, test — to every software task.
+
+use_cases:
+  - Implement new features from natural language descriptions with automatic multi-file changes
+  - Debug and fix production bugs by tracing through the call stack and verifying the fix
+  - Refactor existing code to improve maintainability while preserving all functionality
+  - Generate tests for existing code to improve coverage across the project
+  - Onboard to new projects by asking Devika to explain code architecture and generate starter implementations

--- a/tools/dev-tools/fauxpilot.yaml
+++ b/tools/dev-tools/fauxpilot.yaml
@@ -1,0 +1,34 @@
+name: FauxPilot
+description: An open-source local code completion server that provides AI-powered code suggestions using private, self-hosted models as an alternative to cloud-based code completion services.
+tagline: Self-hosted AI code completion server
+
+github_url: https://github.com/fauxpilot/fauxpilot
+
+category: Dev Tools
+tags:
+  - code-completion
+  - self-hosted
+  - ai
+  - open-source
+  - developer-tools
+  - privacy
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Cloud-based AI code completion services like GitHub Copilot require sending code to external
+  servers, which raises privacy concerns for organizations with sensitive codebases, compliance
+  requirements, or air-gapped environments. FauxPilot solves this by providing a self-hosted
+  code completion server that runs entirely on your infrastructure. It uses open-source models
+  to generate inline code suggestions in real time, works with multiple editors through the
+  same protocol as Copilot, and puts organizations in full control of their code. For teams
+  in regulated industries, security-conscious companies, or developers working offline, FauxPilot
+  delivers the productivity gains of AI code completion without compromising on data privacy.
+
+use_cases:
+  - Set up private AI code completion for teams with sensitive codebases or compliance requirements
+  - Run code completion servers in air-gapped environments without any external network access
+  - Provide code suggestions in multiple editors using the familiar Copilot-compatible protocol
+  - Fine-tune or swap models to get completions optimized for specific languages and codebases
+  - Reduce per-developer costs by self-hosting code completion instead of paying per-seat SaaS fees

--- a/tools/dev-tools/opencode.yaml
+++ b/tools/dev-tools/opencode.yaml
@@ -1,0 +1,37 @@
+name: OpenCode
+description: The open source AI coding agent that runs locally in your terminal — free models included or connect any model from any provider, including Claude, GPT, Gemini and more.
+tagline: Open source AI coding agent
+
+github_url: https://github.com/sst/opencode
+website_url: https://opencode.ai
+docs_url: https://opencode.ai/docs
+install_command: npm install -g opencode-ai
+
+category: Dev Tools
+tags:
+  - coding-agent
+  - ai
+  - cli
+  - terminal
+  - open-source
+  - llm
+  - developer-tools
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Traditional AI coding assistants are tied to a specific IDE or provider, limiting flexibility for
+  developers who want to use the best model for each task or work across different environments.
+  OpenCode solves this as a standalone terminal agent that runs locally, works with any model
+  provider (Claude, GPT, Gemini, local models), and includes free models out of the box. It
+  indexes the full codebase, understands build systems, and can autonomously plan, implement,
+  and verify multi-file changes. For developers who value flexibility and privacy, OpenCode
+  provides a model-agnostic coding agent that doesn't store code or context on external servers.
+
+use_cases:
+  - Implement multi-file features across your codebase with autonomous planning and verification
+  - Debug production issues by tracing through code, running reproduction scripts, and proposing fixes
+  - Refactor legacy modules to modern patterns while keeping existing tests passing
+  - Onboard to unfamiliar codebases by asking for architecture explanations and reference implementations
+  - Automate repetitive code review and refactoring tasks across repository packages

--- a/tools/llm/llava.yaml
+++ b/tools/llm/llava.yaml
@@ -1,0 +1,37 @@
+name: LLaVA
+description: Large Language and Vision Assistant — a multimodal open-source model that combines vision encoders with large language models for visual understanding, reasoning, and conversation about images.
+tagline: Open-source multimodal vision-language model
+
+github_url: https://github.com/haotian-liu/LLaVA
+website_url: https://llava.hliu.cc
+
+category: LLM
+tags:
+  - multimodal
+  - vision-language
+  - llm
+  - open-source
+  - image-understanding
+  - visual-question-answering
+  - deep-learning
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Understanding and reasoning about visual content — images, diagrams, screenshots — is a
+  fundamental capability that most language models lack. Traditional approaches required separate
+  vision and language pipelines, making it difficult to have natural conversations about visual
+  information. LLaVA solves this by combining a vision encoder (CLIP) with a large language
+  model (Vicuna/Llama) through a simple projection layer, enabling the model to understand
+  images and engage in multi-turn conversations about visual content. The model achieves strong
+  performance on visual question answering, image captioning, and multimodal reasoning tasks
+  while being fully open-source and reproducible. For developers building multimodal applications,
+  LLaVA provides a foundation that can be fine-tuned for specific visual understanding tasks.
+
+use_cases:
+  - Build applications that can answer questions about images, diagrams, charts, and screenshots
+  - Generate detailed captions and descriptions for visual content at scale
+  - Create visual assistants that understand product photos, documents, and user interface screens
+  - Fine-tune the model for domain-specific visual understanding tasks like medical imaging or document analysis
+  - Enable multi-turn conversations where users can ask follow-up questions about visual content


### PR DESCRIPTION
Add 5 tools to the catalog:

- **OpenCode** (sst/opencode, 187k★) — Open source AI coding agent
- **Devika** (stitionai/devika, 19.5k★) — Open-source agentic software engineer
- **DB-GPT** (eosphoros-ai/DB-GPT, 19.5k★) — Agentic AI data assistant
- **FauxPilot** (fauxpilot/fauxpilot, 14.7k★) — Self-hosted AI code completion server
- **LLaVA** (haotian-liu/LLaVA, 24.9k★) — Multimodal vision-language model


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DB-GPT, a natural-language data querying and workflow automation framework.
  * Added Devika, an AI development assistant for implementation, debugging, refactoring, testing, and onboarding.
  * Added FauxPilot, a self-hosted, privacy-focused code completion solution.
  * Added OpenCode, a model-agnostic terminal coding agent for implementation, debugging, and code review.
  * Added LLaVA, a multimodal model supporting image understanding, visual questions, captioning, and conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->