### PR TITLE
Add Evaluate, TorchMetrics, Grafana Mimir, MiniGPT-4, StableLM to catalog

### DIFF
--- a/tools/llm/minigpt-4.yaml
+++ b/tools/llm/minigpt-4.yaml
@@ -1,0 +1,26 @@
+name: MiniGPT-4
+description: A vision-language model that aligns a frozen visual encoder with a frozen LLM using a single projection layer, enabling multimodal understanding.
+tagline: Vision-language AI with frozen LLM alignment
+
+github_url: https://github.com/Vision-CAIR/MiniGPT-4
+website_url: https://minigpt-4.github.io
+
+category: LLM
+tags: [vision-language, multimodal, llm, image-understanding, gpt-4, transformer, deep-learning]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Building multimodal AI systems that understand both images and text usually requires
+  training massive models from scratch with paired image-text data at enormous compute cost.
+  MiniGPT-4 demonstrates that a single linear projection layer connecting a frozen vision
+  encoder (ViT) to a frozen LLM (Vicuna) can achieve strong visual reasoning capabilities,
+  dramatically reducing the training cost and complexity of building vision-language models
+  while maintaining coherent conversational abilities.
+
+use_cases:
+  - Generate detailed image captions and descriptions using a vision-language model with conversational output
+  - Build multimodal chatbots that can answer questions about uploaded images
+  - Create systems that extract and reason about text visible in screenshots or photographs
+  - Prototype vision-language applications without training a multimodal model from scratch

--- a/tools/llm/stablelm.yaml
+++ b/tools/llm/stablelm.yaml
@@ -1,0 +1,27 @@
+name: StableLM
+description: A family of open-source language models from Stability AI designed for efficiency and accessibility across diverse conversational and coding tasks.
+tagline: Open-source LLMs from Stability AI
+
+github_url: https://github.com/stability-ai/StableLM
+website_url: https://stability.ai/stable-lm
+docs_url: https://github.com/stability-ai/StableLM#readme
+
+category: LLM
+tags: [llm, open-source, text-generation, coding, conversational-ai, stability-ai, transformer]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  High-quality open-source language models often require massive compute budgets and
+  carefully curated training pipelines that most teams cannot replicate. StableLM provides
+  efficiently trained, openly available LLMs in 3B to 12B parameter sizes that achieve
+  competitive performance on reasoning, coding, and conversation benchmarks while running
+  on consumer hardware, making advanced language AI accessible to individual developers
+  and small teams without cloud GPU budgets.
+
+use_cases:
+  - Run a capable LLM locally or on edge devices for privacy-sensitive text generation tasks
+  - Fine-tune StableLM on domain-specific data for specialized chatbots and assistants
+  - Build coding assistants with a model that achieves strong performance on programming benchmarks
+  - Deploy conversational AI on a single consumer GPU using the 3B parameter variant

--- a/tools/monitoring/evaluate.yaml
+++ b/tools/monitoring/evaluate.yaml
@@ -1,0 +1,29 @@
+name: Evaluate
+description: A library from Hugging Face for evaluating machine learning models and datasets with standardized metrics, comparisons, and visualizations.
+tagline: Standardized ML evaluation from Hugging Face
+
+github_url: https://github.com/huggingface/evaluate
+website_url: https://huggingface.co/docs/evaluate
+docs_url: https://huggingface.co/docs/evaluate
+
+install_command: pip install evaluate
+
+category: Monitoring
+tags: [python, evaluation, metrics, huggingface, ml, benchmarking, nlp, computer-vision]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Evaluating ML models consistently across projects is hard — different teams use different
+  metrics, implementations vary, and comparing results from papers to your own experiments
+  requires reimplementing the exact same evaluation code. Evaluate provides a unified API
+  to hundreds of standardized metrics (accuracy, F1, BLEU, ROUGE, perplexity, etc.) with
+  consistent input/output formats, built-in dataset integration, and visualization tools
+  for tracking improvements over time.
+
+use_cases:
+  - Compare a fine-tuned LLM against a baseline using standardized NLP metrics like BLEU, ROUGE, and perplexity
+  - Run regression evaluations on every new model version to catch accuracy regressions before deployment
+  - Generate leaderboard-style comparison reports across multiple models and datasets
+  - Visualize metric trends over training runs to identify overfitting or training instability

--- a/tools/monitoring/grafana-mimir.yaml
+++ b/tools/monitoring/grafana-mimir.yaml
@@ -1,0 +1,27 @@
+name: Grafana Mimir
+description: A horizontally scalable, highly available, multi-tenant long-term storage backend for Prometheus metrics with Grafana-native querying.
+tagline: Scalable long-term storage for Prometheus metrics
+
+github_url: https://github.com/grafana/mimir
+website_url: https://grafana.com/products/mimir
+docs_url: https://grafana.com/docs/mimir
+
+category: Monitoring
+tags: [prometheus, metrics, monitoring, observability, scalable-storage, grafana, time-series]
+pricing: freemium
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Prometheus is the standard for metrics collection but its single-node architecture limits
+  retention and scale — TSDB storage grows unbounded, query performance degrades, and
+  high-availability requires complex federation setups. Grafana Mimir replaces the
+  Prometheus storage layer with a horizontally scalable, multi-tenant backend that
+  supports unlimited retention, global query views across multiple Prometheus instances,
+  and seamless integration with the Grafana ecosystem for visualization and alerting.
+
+use_cases:
+  - Store Prometheus metrics for months or years without worrying about disk space or query slowdowns
+  - Query metrics across multiple Kubernetes clusters from a single Grafana dashboard using global views
+  - Operate a multi-tenant metrics platform serving dozens of teams with per-tenant data isolation
+  - Replace Thanos or Cortex with a simpler, Grafana-native scalable metrics backend

--- a/tools/monitoring/torchmetrics.yaml
+++ b/tools/monitoring/torchmetrics.yaml
@@ -1,0 +1,29 @@
+name: TorchMetrics
+description: A collection of machine learning metrics for distributed, scalable PyTorch models with a standardized API across domains.
+tagline: PyTorch metrics made distributed and scalable
+
+github_url: https://github.com/Lightning-AI/torchmetrics
+website_url: https://torchmetrics.readthedocs.io
+docs_url: https://torchmetrics.readthedocs.io
+
+install_command: pip install torchmetrics
+
+category: Monitoring
+tags: [python, pytorch, metrics, evaluation, distributed, deep-learning, classification, regression]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Computing metrics like accuracy, F1 score, or mean average precision during distributed
+  training requires aggregating results across GPUs and devices — naive implementations
+  produce incorrect averages and don't handle the synchronization logic. TorchMetrics
+  provides 100+ built-in metrics that automatically handle distributed synchronization,
+  device placement, and multi-batch accumulation, so you get correct results whether
+  training on one GPU or a thousand.
+
+use_cases:
+  - Track accuracy, precision, and recall during multi-GPU training without writing custom distributed aggregation code
+  - Compute regression metrics (MAE, RMSE, R²) across distributed validation loops
+  - Log per-class metrics for imbalanced classification problems to detect minority-class degradation
+  - Build custom domain-specific metrics with automatic distributed handling using the library's base classes


### PR DESCRIPTION
This PR adds 5 new tools to the catalog:

- **Evaluate** — Hugging Face's library for evaluating ML models and datasets with standardized metrics and comparisons (Apache-2.0, 2.5k★)
- **TorchMetrics** — Collection of 100+ ML metrics for distributed PyTorch training from Lightning AI (Apache-2.0, 2.4k★)
- **Grafana Mimir** — Horizontally scalable, multi-tenant long-term storage backend for Prometheus metrics (AGPL-3.0, 5.2k★)
- **MiniGPT-4** — Vision-language model that aligns a frozen visual encoder with a frozen LLM via a single projection layer (BSD-3-Clause, 25.7k★)
- **StableLM** — Family of open-source LLMs from Stability AI for conversational and coding tasks (Apache-2.0, 15.7k★)
