### PR TITLE
Add ImageBind, SpeechBrain, ESPnet, Kaldi, Tortoise TTS to catalog

### DIFF
--- a/tools/other/espnet.yaml
+++ b/tools/other/espnet.yaml
@@ -1,0 +1,30 @@
+name: ESPnet
+description: An end-to-end speech processing toolkit supporting ASR, TTS, speech translation, speaker diarization, and voice conversion with unified recipes.
+tagline: End-to-end speech processing for all tasks
+
+github_url: https://github.com/espnet/espnet
+website_url: https://espnet.github.io/espnet
+docs_url: https://espnet.github.io/espnet
+
+install_command: pip install espnet
+
+category: Other
+tags: [python, speech, asr, tts, speech-recognition, audio, deep-learning, end-to-end]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Speech processing research and development involves a fragmented ecosystem — separate
+  toolkits for ASR, TTS, speaker diarization, and voice conversion, each with its own
+  configuration format, preprocessing pipeline, and evaluation scripts that don't
+  interoperate. ESPnet provides a single framework with consistent recipes, configurations,
+  and experiment management across the full range of speech tasks, making it easy to
+  train, evaluate, and deploy models for any speech application without learning multiple
+  toolkits.
+
+use_cases:
+  - Train a custom ASR model on domain-specific audio data using standardized recipes and configurations
+  - Build a text-to-speech system with multiple voice variants from a single trained model
+  - Create a live speech translation pipeline that transcribes and translates audio in real time
+  - Develop a speaker diarization system that identifies who spoke when in meeting recordings

--- a/tools/other/imagebind.yaml
+++ b/tools/other/imagebind.yaml
@@ -1,0 +1,24 @@
+name: ImageBind
+description: Meta's multimodal embedding model that binds data from six modalities — images, text, audio, depth, thermal, and IMU data — into a shared embedding space.
+tagline: Bind six modalities into one embedding space
+
+github_url: https://github.com/facebookresearch/ImageBind
+
+category: Other
+tags: [python, multimodal, embeddings, vision, audio, deep-learning, meta, zero-shot]
+pricing: free
+is_open_source: true
+
+problem_solved: |
+  Modern AI systems typically handle one or two modalities at a time — image-text models
+  don't understand audio, audio models don't process depth data — requiring separate
+  models for each modality with no shared understanding. ImageBind creates a single
+  embedding space that binds images, text, audio, depth, thermal, and IMU data, enabling
+  emergent zero-shot capabilities across modalities (like searching audio with text or
+  images with sound) without training on every possible pair.
+
+use_cases:
+  - Search video content by matching audio cues (a dog barking) to visual moments across a video library
+  - Build cross-modal retrieval systems that find images using text, audio, or depth data as query input
+  - Enable audio-based image editing by finding visual concepts through their associated sounds
+  - Create emergent multimodal classifiers without training data for every modality combination

--- a/tools/other/kaldi.yaml
+++ b/tools/other/kaldi.yaml
@@ -1,0 +1,27 @@
+name: Kaldi
+description: A speech recognition toolkit for research and production, providing state-of-the-art ASR with Gaussian mixture and deep neural network acoustic models.
+tagline: The gold standard for speech recognition research
+
+github_url: https://github.com/kaldi-asr/kaldi
+website_url: https://kaldi-asr.org
+docs_url: https://kaldi-asr.org/doc
+
+category: Other
+tags: [speech, asr, speech-recognition, cpp, acoustic-modeling, language-modeling, signal-processing]
+pricing: free
+is_open_source: true
+
+problem_solved: |
+  Building high-accuracy automatic speech recognition systems requires sophisticated
+  acoustic modeling, language model integration, and feature extraction pipelines that
+  are tightly coupled and hard to assemble from individual components. Kaldi provides
+  a complete, modular ASR toolkit with implementations of GMM-HMM and DNN-HMM acoustic
+  models, finite-state transducer decoding, and extensive feature extraction libraries,
+  serving as the foundation upon which most modern ASR systems are built and providing
+  reproducible baselines for speech research.
+
+use_cases:
+  - Train custom acoustic models for domain-specific vocabulary (medical, legal, technical terminology)
+  - Build a production-grade speech recognition system with real-time decoding and language model integration
+  - Run reproducible ASR experiments using standardized recipes and evaluation metrics
+  - Extract and experiment with acoustic features (MFCCs, filterbanks, i-vectors) for speech analysis

--- a/tools/other/speechbrain.yaml
+++ b/tools/other/speechbrain.yaml
@@ -1,0 +1,30 @@
+name: SpeechBrain
+description: A PyTorch-based speech toolkit for building speech recognition, speaker recognition, enhancement, and synthesis systems with pre-trained models.
+tagline: All-in-one PyTorch speech toolkit
+
+github_url: https://github.com/speechbrain/speechbrain
+website_url: https://speechbrain.github.io
+docs_url: https://speechbrain.readthedocs.io
+
+install_command: pip install speechbrain
+
+category: Other
+tags: [python, speech, audio, asr, speaker-recognition, pytorch, tts, deep-learning]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building speech AI systems — ASR, speaker identification, speech enhancement, TTS —
+  requires integrating multiple specialized libraries with different APIs, preprocessing
+  pipelines, and training paradigms that are difficult to combine into a single workflow.
+  SpeechBrain provides a unified PyTorch framework for all speech tasks with consistent
+  APIs, pre-trained model hubs, and recipes for replicating state-of-the-art results,
+  enabling researchers and engineers to build production speech systems without juggling
+  half a dozen incompatible libraries.
+
+use_cases:
+  - Build a speech-to-text pipeline using pre-trained ASR models fine-tuned on domain-specific vocabulary
+  - Create a speaker verification system for authentication applications
+  - Enhance noisy audio recordings with deep learning-based speech enhancement models
+  - Develop custom text-to-speech systems with voice cloning from a few seconds of reference audio

--- a/tools/other/tortoise-tts.yaml
+++ b/tools/other/tortoise-tts.yaml
@@ -1,0 +1,27 @@
+name: Tortoise TTS
+description: A multi-voice text-to-speech system trained for high-quality speech synthesis with voice cloning from a few seconds of reference audio.
+tagline: High-quality TTS with voice cloning
+
+github_url: https://github.com/neonbjb/tortoise-tts
+
+install_command: pip install tortoise-tts
+
+category: Other
+tags: [python, tts, speech-synthesis, voice-cloning, audio, deep-learning, text-to-speech]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Generating natural-sounding speech in a specific voice typically requires hours of
+  studio-quality recordings and custom model training that is inaccessible to most
+  developers and content creators. Tortoise TTS achieves high-quality voice cloning
+  from just a few seconds of reference audio using a multi-stage autoregressive and
+  diffusion-based architecture, producing expressive, natural speech that preserves
+  the vocal characteristics, prosody, and speaking style of the original speaker.
+
+use_cases:
+  - Generate audio narration for videos and podcasts using a cloned voice from a short sample
+  - Create personalized voice assistants that speak in a consistent, branded voice
+  - Produce multilingual speech output with consistent voice characteristics across languages
+  - Build accessibility tools that synthesize natural speech for users with speech impairments


### PR DESCRIPTION
This PR adds 5 new tools to the catalog:

- **ImageBind** — Meta's multimodal embedding model binding six modalities (image, text, audio, depth, thermal, IMU) into a shared space for emergent zero-shot capabilities (9.1k★)
- **SpeechBrain** — Unified PyTorch framework for speech tasks including ASR, speaker recognition, enhancement, and TTS with pre-trained model hubs (Apache-2.0, 11.7k★)
- **ESPnet** — End-to-end speech processing toolkit covering ASR, TTS, speech translation, speaker diarization, and voice conversion (Apache-2.0, 9.9k★)
- **Kaldi** — The foundational speech recognition toolkit with GMM and DNN acoustic models used by most modern ASR systems (15.4k★)
- **Tortoise TTS** — High-quality multi-voice TTS system with voice cloning from just seconds of reference audio (Apache-2.0, 14.9k★)
