### PR TITLE
Add NCNN, MNN, TNN, Flower, FATE to catalog

### DIFF
--- a/tools/dev-tools/mnn.yaml
+++ b/tools/dev-tools/mnn.yaml
@@ -1,0 +1,39 @@
+name: MNN
+description: A blazing-fast, lightweight neural network inference engine developed by Alibaba. Supports on-device LLM inference and stable diffusion, with optimized backends for ARM, x86, CUDA, OpenCL, Metal, and Vulkan.
+tagline: Alibaba's lightweight inference engine for on-device LLMs and edge AI
+
+github_url: https://github.com/alibaba/MNN
+docs_url: https://mnn-docs.readthedocs.io/en/latest
+
+install_command: pip install MNN
+
+category: Dev Tools
+tags:
+  - inference
+  - mobile
+  - on-device
+  - deep-learning
+  - cross-platform
+  - arm
+  - llm
+  - optimization
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Running large models on edge devices — smartphones, IoT, embedded
+  systems — requires an inference engine that balances speed against the
+  strict memory and power budgets of mobile hardware. MNN is battle-tested
+  across hundreds of millions of Alibaba devices, supporting on-device LLM
+  inference, stable diffusion, and vision models. It converts models from
+  TensorFlow, PyTorch, and ONNX, and dispatches to the optimal backend
+  (ARM NEON, x86 AVX, Vulkan, CUDA, Metal, OpenCL) without manual
+  configuration.
+
+use_cases:
+  - Run a 7B LLM on-device using MNN's transformer runtime for private AI inference
+  - Deploy stable diffusion image generation on a mobile phone with Metal GPU acceleration
+  - Convert a TensorFlow detection model and run it at 60 FPS on an edge device
+  - Power a cross-platform mobile app with real-time ML inference on Android and iOS
+  - Benchmark and optimize an ONNX model across ARM, x86, and GPU backends in one pipeline

--- a/tools/dev-tools/ncnn.yaml
+++ b/tools/dev-tools/ncnn.yaml
@@ -1,0 +1,39 @@
+name: NCNN
+description: A high-performance neural network inference framework optimized for mobile and embedded platforms. Supports Android, iOS, Linux, Windows, macOS, WebAssembly, and various hardware backends including ARM, x86, and Vulkan GPU.
+tagline: High-performance neural network inference for mobile and embedded devices
+
+github_url: https://github.com/Tencent/ncnn
+docs_url: https://github.com/Tencent/ncnn/wiki
+
+install_command: pip install ncnn
+
+category: Dev Tools
+tags:
+  - mobile
+  - inference
+  - neural-network
+  - on-device
+  - cross-platform
+  - arm
+  - vulkan
+  - deep-learning
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Deploying neural network inference on mobile and embedded devices is
+  constrained by limited compute, memory, and battery. Standard frameworks
+  designed for desktop GPUs don't fit. NCNN is a pure C++ inference
+  framework built from the ground up for mobile — it does not depend on
+  third-party libraries, supports multi-core optimization and ARM NEON,
+  and gains GPU acceleration through Vulkan. Models from PyTorch, ONNX,
+  and TensorFlow can be converted with a single CLI tool (PNNX) and run
+  efficiently on phones, tablets, and IoT hardware.
+
+use_cases:
+  - Deploy a real-time object detection model on a smartphone camera feed with minimal latency
+  - Run an LLM on-device using the ncnn Vulkan backend for GPU acceleration
+  - Port a PyTorch segmentation model to a Raspberry Pi for edge AI inference
+  - Integrate face recognition into an iOS or Android app with 0 third-party dependencies
+  - Batch-convert ONNX models to ncnn format and deploy across hundreds of device variants

--- a/tools/dev-tools/tnn.yaml
+++ b/tools/dev-tools/tnn.yaml
@@ -1,0 +1,39 @@
+name: TNN
+description: A cross-platform deep learning inference framework developed by Tencent Youtu Lab and Guangying Lab. Optimized for mobile, desktop, and server deployment with model compression, operator fusion, and code pruning capabilities.
+tagline: Tencent's cross-platform deep learning inference framework
+
+github_url: https://github.com/Tencent/TNN
+docs_url: https://github.com/Tencent/TNN
+
+install_command: pip install tnn
+
+category: Dev Tools
+tags:
+  - inference
+  - mobile
+  - deep-learning
+  - cross-platform
+  - optimization
+  - model-compression
+  - tencent
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Deploying deep learning models across mobile, desktop, and server
+  platforms usually forces a choice between raw speed and portability.
+  TNN, built on the lineage of ncnn and Rapidnet, delivers both: it
+  provides a unified inference runtime across Android, iOS, Windows,
+  Linux, and macOS with architecture-specific optimizations (ARM NEON,
+  x86 AVX, GPU). Model compression and operator pruning reduce the
+  binary size, making TNN suitable for production apps including Tencent's
+  own Mobile QQ and Weishi. Models from PyTorch, ONNX, and TensorFlow
+  can be converted via the TNN converter toolchain.
+
+use_cases:
+  - Deploy a YOLO object detection model in a mobile app with real-time video processing
+  - Run a BERT-based question answering model on-device for privacy-preserving AI
+  - Convert and optimize a PyTorch classification model for deployment on Android and iOS
+  - Prune and compress a neural network to reduce app binary size while maintaining accuracy
+  - Benchmark inference throughput across ARM, x86, and GPU backends from a single model

--- a/tools/fine-tuning/fate.yaml
+++ b/tools/fine-tuning/fate.yaml
@@ -1,0 +1,40 @@
+name: FATE
+description: An industrial-grade federated learning framework designed for privacy-preserving machine learning across distributed data silos. Supports secure multi-party computation, differential privacy, and heterogeneous data sources.
+tagline: Industrial federated learning framework for privacy-preserving AI
+
+github_url: https://github.com/FederatedAI/FATE
+docs_url: https://fate.readthedocs.io/en/latest
+
+install_command: pip install fate
+
+category: Fine-tuning
+tags:
+  - federated-learning
+  - privacy
+  - distributed-training
+  - python
+  - machine-learning
+  - security
+  - multi-party-computation
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Organizations across finance, healthcare, and government hold valuable
+  data they cannot share due to privacy regulations (GDPR, HIPAA, CCPA).
+  FATE (Federated AI Technology Enabler) provides a production-grade
+  federated learning platform with secure multi-party computation (MPC),
+  differential privacy, and homomorphic encryption. It supports
+  horizontal and vertical federated learning, enabling multiple parties
+  to collaboratively train models where each party contributes different
+  features or samples of the same dataset — without exposing raw data.
+  FATE includes a complete cluster management dashboard and monitoring
+  system for enterprise deployment.
+
+use_cases:
+  - Train a credit risk model across multiple banks without exposing individual customer data
+  - Build a collaborative fraud detection system between financial institutions using vertical federated learning
+  - Develop a healthcare outcome predictor across hospitals while complying with HIPAA data-sharing restrictions
+  - Run secure multi-party computation for feature engineering across organizations without raw data leakage
+  - Deploy a production federated learning cluster with the FATE management dashboard and operator monitoring

--- a/tools/fine-tuning/flower.yaml
+++ b/tools/fine-tuning/flower.yaml
@@ -1,0 +1,40 @@
+name: Flower
+description: A friendly federated AI framework for training machine learning models across distributed data sources without centralizing sensitive data. Supports simulation, real-world deployment, and heterogeneous edge devices.
+tagline: Federated learning framework for privacy-preserving distributed AI
+
+github_url: https://github.com/flwrlabs/flower
+website_url: https://flower.ai
+docs_url: https://flower.ai/docs
+
+install_command: pip install flwr
+
+category: Fine-tuning
+tags:
+  - federated-learning
+  - distributed-training
+  - privacy
+  - python
+  - machine-learning
+  - collaborative
+  - edge
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Training ML models on sensitive data (health records, financial
+  transactions, personal messages) requires keeping data on-device or
+  on-premises, but traditional training centralizes everything. Flower
+  enables federated learning: models are trained across distributed
+  clients — phones, hospitals, factories — and only weight updates,
+  never raw data, leave each client. Flower supports simulation for
+  rapid prototyping and production deployment with heterogeneous
+  hardware, straggler handling, and secure aggregation. It integrates
+  with PyTorch, TensorFlow, Hugging Face, and JAX out of the box.
+
+use_cases:
+  - Train a medical image classifier across multiple hospitals without sharing patient data
+  - Fine-tune an LLM on users' mobile typing data while keeping keystrokes private
+  - Simulate a 1000-client federated learning experiment on a single machine before production rollout
+  - Build a keyboard prediction model that improves on-device without uploading user text
+  - Aggregate model updates from factory sensors across manufacturing sites to train a predictive maintenance model


### PR DESCRIPTION
Add five new tools to the catalog:

**NCNN** - High-performance neural network inference framework for mobile and embedded devices (23.5k★, BSD-3-Clause)
**MNN** - Blazing-fast inference engine by Alibaba for on-device LLMs and edge AI (15.7k★, Apache-2.0)
**TNN** - Tencent's cross-platform deep learning inference framework (4.6k★, BSD-3-Clause)
**Flower** - Federated AI framework for privacy-preserving distributed ML training (7k★, Apache-2.0)
**FATE** - Industrial-grade federated learning framework for enterprise privacy-preserving AI (6.1k★, Apache-2.0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for MNN, NCNN, and TNN inference frameworks.
  * Added catalog entries for FATE and Flower federated learning frameworks.
  * Included descriptions, documentation links, installation instructions, licensing details, tags, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->