### PR TITLE
Add Grounding DINO, AnimateDiff, IP-Adapter, DeepLearning4J, IREE to catalog

### DIFF
--- a/tools/other/animatediff.yaml
+++ b/tools/other/animatediff.yaml
@@ -1,0 +1,37 @@
+name: AnimateDiff
+description: A framework for generating animated images from text prompts by inserting a motion module into existing text-to-image diffusion models without task-specific training.
+tagline: Text-to-video animation framework for diffusion models
+
+github_url: https://github.com/guoyww/AnimateDiff
+website_url: https://animatediff.github.io
+
+category: Other
+tags:
+  - video-generation
+  - animation
+  - diffusion
+  - stable-diffusion
+  - text-to-video
+  - motion
+  - deep-learning
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Generating animated content from text typically requires training
+  video diffusion models from scratch or collecting large-scale video
+  datasets. AnimateDiff introduces a plug-and-play motion module that
+  inserts into any personalized text-to-image diffusion model (such as
+  those fine-tuned on specific styles or characters) and converts it
+  into an animation generator — without task-specific video training
+  data. The motion module learns generic motion priors from video
+  data once, then works with any base model, enabling animation of
+  custom subjects, styles, and scenes on consumer GPUs.
+
+use_cases:
+  - Generate animated character sequences from a personalized Stable Diffusion model fine-tuned on your artwork
+  - Create looping background animations for games or websites using text prompts
+  - Produce short animated clips from storyboard descriptions without manual frame-by-frame animation
+  - Add motion to existing image generation workflows for social media content creation
+  - Generate training data for video models by animating static image datasets

--- a/tools/other/deeplearning4j.yaml
+++ b/tools/other/deeplearning4j.yaml
@@ -1,0 +1,39 @@
+name: DeepLearning4J
+description: A comprehensive deep learning library for the Java Virtual Machine with model import from Keras, TensorFlow, and ONNX, plus a PyTorch-like Java API (SameDiff) and a modular C++ math backend.
+tagline: Deep learning for Java, Scala, and the JVM ecosystem
+
+github_url: https://github.com/deeplearning4j/deeplearning4j
+website_url: https://deeplearning4j.konduit.ai
+docs_url: https://deeplearning4j.konduit.ai
+
+category: Other
+tags:
+  - java
+  - deep-learning
+  - jvm
+  - scala
+  - neural-network
+  - tensorflow
+  - onnx
+  - pytorch
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Most deep learning frameworks are Python-first, leaving Java and JVM
+  ecosystems — where most enterprise production systems run — with few
+  options for native model training and inference. DeepLearning4J (DL4J)
+  brings deep learning to the JVM with native Java APIs, model import
+  from Keras, TensorFlow, and ONNX/PyTorch via a modular C++ math
+  library (libnd4j), and SameDiff — a PyTorch-like autodiff library.
+  It integrates with Hadoop, Spark, and Kafka for distributed training
+  on big data pipelines, and runs on CPUs and GPUs without requiring
+  Python or native library conflicts in JVM deployments.
+
+use_cases:
+  - Train an LSTM for time-series forecasting on financial data directly in a Java trading application
+  - Import a Keras image classifier and serve it through a Spring Boot REST API
+  - Run distributed deep learning training across a Spark cluster on Hadoop data
+  - Build a real-time anomaly detection pipeline in Apache Kafka Streams using DL4J
+  - Deploy a TensorFlow model in a JVM microservice without any Python dependencies

--- a/tools/other/grounding-dino.yaml
+++ b/tools/other/grounding-dino.yaml
@@ -1,0 +1,37 @@
+name: Grounding DINO
+description: An open-set object detection model that can detect arbitrary objects from natural language descriptions without requiring predefined categories. Marries DINO with grounded pre-training for zero-shot transfer.
+tagline: Open-set object detection from natural language descriptions
+
+github_url: https://github.com/IDEA-Research/GroundingDINO
+website_url: https://arxiv.org/abs/2303.05499
+
+category: Other
+tags:
+  - object-detection
+  - vision
+  - open-vocabulary
+  - zero-shot
+  - transformer
+  - computer-vision
+  - deep-learning
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Traditional object detection models are limited to a fixed set of
+  predefined categories — they cannot detect objects they were not
+  trained on. Grounding DINO solves open-set detection by marrying
+  the DINO transformer-based detector with grounded language pre-
+  training, enabling detection of arbitrary objects described in
+  natural language. Given a text prompt like "the red car on the left",
+  it finds and localizes matching objects without retraining. This
+  enables zero-shot object detection for any domain without labeled
+  training data for each new category.
+
+use_cases:
+  - Detect arbitrary objects in surveillance footage by describing them in natural language
+  - Build a visual search system that finds products from natural language descriptions
+  - Enable robots to locate objects in unstructured environments using voice commands
+  - Create an automatic image annotation pipeline that labels objects without predefined categories
+  - Combine with GroundingSAM for pixel-perfect segmentation from text prompts

--- a/tools/other/ip-adapter.yaml
+++ b/tools/other/ip-adapter.yaml
@@ -1,0 +1,39 @@
+name: IP-Adapter
+description: An image prompt adapter that enables pretrained text-to-image diffusion models to generate images guided by reference images, supporting both image and text conditioning without fine-tuning.
+tagline: Image prompt adapter for text-to-image diffusion models
+
+github_url: https://github.com/tencent-ailab/IP-Adapter
+docs_url: https://github.com/tencent-ailab/IP-Adapter
+
+install_command: pip install ip-adapter
+
+category: Other
+tags:
+  - image-generation
+  - diffusion
+  - stable-diffusion
+  - image-prompt
+  - adapter
+  - transfer-learning
+  - computer-vision
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Text-to-image models are excellent at following text descriptions but
+  struggle to capture the visual essence of a reference image — style,
+  composition, color palette, or subject identity — through text alone.
+  IP-Adapter adds a lightweight, decoupled cross-attention mechanism
+  that accepts an image prompt alongside the text prompt, enabling
+  pretrained diffusion models to generate images that respect both
+  textual and visual guidance. Unlike full fine-tuning or DreamBooth,
+  IP-Adapter is a single add-on module trained once that works with any
+  base model and preserves the original text conditioning capabilities.
+
+use_cases:
+  - Generate product images in a specific brand style by providing a reference image
+  - Create consistent character illustrations across multiple generations using a character reference
+  - Transfer the artistic style of one image to new subjects described in text
+  - Build a design tool where users drag a reference image to guide the AI's visual output
+  - Enable image-conditional generation without retraining or storing multiple model checkpoints

--- a/tools/other/iree.yaml
+++ b/tools/other/iree.yaml
@@ -1,0 +1,42 @@
+name: IREE
+description: A retargetable MLIR-based machine learning compiler and runtime toolkit that optimizes and executes models from TensorFlow, PyTorch, and JAX on CPUs, GPUs, and specialized accelerators.
+tagline: MLIR-based ML compiler for cross-platform model deployment
+
+github_url: https://github.com/iree-org/iree
+website_url: https://iree.dev
+docs_url: https://iree.dev/reference/bindings/python
+
+install_command: pip install iree-base-compiler iree-base-runtime
+
+category: Other
+tags:
+  - compiler
+  - mlir
+  - optimization
+  - inference
+  - cross-platform
+  - gpu
+  - tensorflow
+  - pytorch
+  - jax
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Deploying ML models across diverse hardware — from mobile CPUs to
+  desktop GPUs to AI accelerators — requires platform-specific tuning
+  and separate runtime backends. IREE solves this with an MLIR-based
+  compiler that takes models from TensorFlow, PyTorch, and JAX and
+  generates optimized code for any target. Its HAL (Hardware
+  Abstraction Layer) runtime dispatches to Vulkan, CUDA, Metal, ROCm,
+  and CPU backends with near-native performance. Models are compiled
+  once and deployed across platforms without hardware-specific retuning,
+  and the runtime is lightweight enough for embedded use cases.
+
+use_cases:
+  - Compile a PyTorch model once and deploy it on NVIDIA GPU, AMD GPU, and CPU from the same binary
+  - Run a TensorFlow model on a Vulkan-capable mobile device without platform-specific code
+  - Build a cross-platform AI application that uses Metal on macOS, Vulkan on Android, and CUDA on Linux
+  - Optimize a JAX model for low-latency inference on edge hardware using MLIR-based fusion passes
+  - Deploy compiled model binaries to embedded devices with the minimal IREE runtime footprint


### PR DESCRIPTION
Add five new tools to the catalog:

**Grounding DINO** - Open-set object detection from natural language descriptions (10.4k★, Apache-2.0)
**AnimateDiff** - Text-to-video animation framework for diffusion models (12.2k★, Apache-2.0)
**IP-Adapter** - Image prompt adapter for text-to-image diffusion models (6.6k★, Apache-2.0)
**DeepLearning4J** - Deep learning for Java, Scala, and the JVM ecosystem (14.2k★, Apache-2.0)
**IREE** - MLIR-based ML compiler for cross-platform model deployment (3.8k★, Apache-2.0)
