### PR TITLE
Add Flash Linear Attention, GPTQ, AQLM, StreamingLLM to catalog

### DIFF
--- a/tools/fine-tuning/flash-linear-attention.yaml
+++ b/tools/fine-tuning/flash-linear-attention.yaml
@@ -1,0 +1,40 @@
+name: Flash Linear Attention
+description: A collection of efficient Triton-based kernels for linear attention mechanisms including Mamba-2, GLA, DeltaNet, and other state-space model layers with hardware-aware optimizations.
+tagline: Hardware-efficient linear attention kernels for state-space models
+
+github_url: https://github.com/fla-org/flash-linear-attention
+docs_url: https://github.com/fla-org/flash-linear-attention
+
+install_command: pip install flash-linear-attention
+
+category: Fine-tuning
+tags:
+  - attention
+  - transformer
+  - kernel
+  - triton
+  - mamba
+  - state-space-model
+  - cuda
+  - optimization
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Linear attention and state-space models (Mamba, GLA, DeltaNet) offer
+  theoretical efficiency over standard quadratic attention, but their
+  custom CUDA kernels are difficult to implement and optimize. Flash
+  Linear Attention provides a unified collection of Triton-based kernels
+  for these emerging architectures — Mamba-2, GLA (Gated Linear
+  Attention), DeltaNet, and more — with hardware-aware optimizations for
+  modern GPUs. Each kernel is benchmarked and tuned for throughput and
+  memory efficiency, reducing development time for researchers and
+  engineers working on sub-quadratic attention mechanisms.
+
+use_cases:
+  - Train a linear attention language model with the Mamba-2 kernel for faster sequence processing
+  - Replace the standard attention in a transformer with GLA kernels for improved long-context efficiency
+  - Benchmark linear attention variants against softmax attention for a specific GPU architecture
+  - Integrate DeltaNet recurrent kernels into an existing transformer training pipeline
+  - Experiment with hybrid attention architectures combining linear and quadratic attention layers

--- a/tools/llm/aqlm.yaml
+++ b/tools/llm/aqlm.yaml
@@ -1,0 +1,39 @@
+name: AQLM
+description: Additive Quantization of Language Models — a post-training compression method that represents each weight as a sum of multiple learned codebooks for extreme compression to 2 bits per parameter.
+tagline: Extreme 2-bit LLM compression via additive quantization
+
+github_url: https://github.com/Vahe1994/AQLM
+docs_url: https://github.com/Vahe1994/AQLM
+
+install_command: pip install aqlm
+
+category: LLM
+tags:
+  - quantization
+  - compression
+  - llm
+  - inference
+  - optimization
+  - model-compression
+  - codebook
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Standard quantization methods hit a quality wall below 3 bits per
+  parameter, limiting compression on memory-constrained hardware. AQLM
+  (Additive Quantization of Language Models) breaks through this barrier
+  by representing each weight as a sum of vectors from multiple learned
+  codebooks, rather than a single scalar value. This achieves 2 bits per
+  parameter with significantly less accuracy loss than GPTQ or AWQ at
+  comparable compression ratios. AQLM is particularly effective for
+  deploying LLMs on edge devices, mobile hardware, or any environment
+  where GPU memory is tightly constrained.
+
+use_cases:
+  - Compress a 13B Llama model to 2-bit and fit it on a single consumer GPU with 8GB VRAM
+  - Deploy quantized LLMs on mobile devices or edge hardware with extreme memory constraints
+  - Compare AQLM 2-bit compression against GPTQ 3-bit for a production model serving pipeline
+  - Run a 7B model entirely in GPU memory on an RTX 3060 or similar 6-8 GB card
+  - Quantize model ensembles for deployment on resource-constrained cloud instances

--- a/tools/llm/gptq.yaml
+++ b/tools/llm/gptq.yaml
@@ -1,0 +1,38 @@
+name: GPTQ
+description: A post-training quantization toolkit for LLMs that compresses models to 3-4 bits while preserving accuracy. Supports GPU acceleration via NVIDIA, AMD, and Intel hardware.
+tagline: Post-training LLM quantization with GPU acceleration
+
+github_url: https://github.com/ModelCloud/GPTQModel
+docs_url: https://github.com/ModelCloud/GPTQModel
+
+install_command: pip install gptqmodel
+
+category: LLM
+tags:
+  - quantization
+  - compression
+  - llm
+  - gpu
+  - optimization
+  - inference
+  - model-optimization
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Large language models require enormous GPU memory — a 70B parameter
+  model in fp16 needs 140GB, far beyond a single consumer GPU. GPTQ
+  (Post-Training Quantization for GPTs) compresses LLMs to 3-4 bits per
+  parameter with minimal accuracy loss, reducing memory requirements by
+  4-5x. GPTQModel is the maintained, hardware-accelerated implementation
+  supporting NVIDIA CUDA, AMD ROCm, and Intel GPU backends. It
+  integrates with HuggingFace, vLLM, and SGLang for seamless deployment
+  of quantized models on consumer and enterprise hardware.
+
+use_cases:
+  - Quantize a 70B Llama model to 4-bit and run it on a single A100 GPU
+  - Deploy quantized LLMs on consumer GPUs (RTX 3090/4090) without losing significant accuracy
+  - Apply INT3 quantization to reduce model serving cost in production by 4x
+  - Integrate GPTQ quantized models with vLLM for high-throughput inference
+  - Batch-quantize multiple model variants with per-layer sensitivity analysis for optimal compression

--- a/tools/llm/streamingllm.yaml
+++ b/tools/llm/streamingllm.yaml
@@ -1,0 +1,38 @@
+name: StreamingLLM
+description: An efficient framework for running LLMs on streaming text of up to 4 million tokens by leveraging the attention sink phenomenon — initial tokens naturally attract attention and can serve as a stabilizer.
+tagline: Run LLMs on streaming text with millions of tokens
+
+github_url: https://github.com/mit-han-lab/streaming-llm
+docs_url: https://github.com/mit-han-lab/streaming-llm
+
+category: LLM
+tags:
+  - inference
+  - long-context
+  - streaming
+  - attention
+  - llm
+  - optimization
+  - mit
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Standard LLMs have a fixed context window — tokens beyond the window
+  cause OOM errors or force expensive re-computation. StreamingLLM
+  enables LLMs to process streaming, infinitely-long text by keeping
+  only a sliding window of recent tokens plus the initial "attention
+  sink" tokens. It leverages the discovery that the first few tokens
+  naturally attract disproportionate attention (the attention sink
+  phenomenon), allowing the model to maintain stable generation quality
+  over millions of tokens without recomputing the full history. This
+  works with Llama 2, MPT, Falcon, Pythia, and other open models
+  without retraining.
+
+use_cases:
+  - Process a 100K-token codebase diff in a single LLM pass without hitting context limits
+  - Run a live transcription system where the LLM maintains state across hours of streaming audio
+  - Analyze large log files by streaming through millions of tokens with consistent performance
+  - Build a chat application with infinite conversation history that stays responsive
+  - Enable long-document question answering on entire books without chunking or retrieval


### PR DESCRIPTION
Add four new tools to the catalog:

**Flash Linear Attention** - Hardware-efficient Triton kernels for linear attention and state-space models (5.4k★, MIT)
**GPTQ** - Post-training LLM quantization toolkit with GPU acceleration for NVIDIA, AMD, and Intel (1.2k★, MIT)
**AQLM** - Extreme 2-bit LLM compression via additive quantization (1.3k★, Apache-2.0)
**StreamingLLM** - Run LLMs on streaming text with up to 4 million tokens using attention sinks (7.2k★, MIT)
