### PR TITLE
Add Crawlee, Kaggle, QuestDB, RedisVL, gpt-fast to catalog

### DIFF
--- a/tools/data/crawlee.yaml
+++ b/tools/data/crawlee.yaml
@@ -1,0 +1,30 @@
+name: Crawlee
+description: A web scraping and browser automation library for building reliable web crawlers in JavaScript and TypeScript. Supports Puppeteer, Playwright, Cheerio, and raw HTTP — both headful and headless — with automatic proxy rotation, session management, and request queueing.
+tagline: Build reliable web scrapers and crawlers for AI data extraction
+
+github_url: https://github.com/apify/crawlee
+website_url: https://crawlee.dev
+docs_url: https://crawlee.dev/docs/quick-start
+
+install_command: |
+  npm install crawlee
+
+category: Data
+tags: [web-scraping, crawling, browser-automation, data-extraction, nodejs, typescript, puppeteer, playwright]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI teams need clean, structured data from websites for training, RAG pipelines, and evaluation —
+  but building production-grade scrapers requires managing headless browsers, proxy rotation, concurrent
+  request scheduling, and anti-bot evasion. Crawlee abstracts all of that into a single library with
+  automatic retries, session pools, and request queuing, so developers can focus on parsing data rather
+  than browser infrastructure.
+
+use_cases:
+  - Scrape e-commerce product listings and reviews to build training datasets for recommendation models
+  - Extract documentation pages from multiple sources for RAG-based developer assistants
+  - Crawl news sites to collect structured article data for LLM fine-tuning and evaluation
+  - Build automated data pipelines that periodically scrape competitor pricing or job listings
+  - Harvest public web pages to create domain-specific datasets for semantic search and QA systems

--- a/tools/data/kaggle.yaml
+++ b/tools/data/kaggle.yaml
@@ -1,0 +1,28 @@
+name: Kaggle
+description: Kaggle is a data science platform for finding and publishing datasets, exploring and building models, and entering competitions. The Kaggle API provides programmatic access to download datasets, submit competition entries, and manage notebooks from the command line.
+tagline: The data science community platform for datasets, competitions, and models
+
+github_url: https://github.com/Kaggle/kaggle-api
+website_url: https://kaggle.com
+docs_url: https://github.com/Kaggle/kaggle-api
+
+install_command: pip install kaggle
+
+category: Data
+tags: [datasets, data-science, machine-learning, competitions, data-engineering, python, kaggle]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Data practitioners spend a disproportionate amount of time finding quality datasets and reproducing
+  ML workflows. Kaggle centralizes the world's largest repository of public datasets, competition
+  kernels, and trained models — with an API that lets teams download datasets programmatically,
+  submit predictions, and version their work without leaving the command line.
+
+use_cases:
+  - Download competition datasets programmatically for local model development and experimentation
+  - Search and fetch public datasets for training computer vision, NLP, and tabular ML models
+  - Submit model predictions to active competitions for benchmarking against global data science talent
+  - Upload and version team datasets for collaborative machine learning projects
+  - Explore community notebooks to reproduce baselines and learn new techniques before building custom solutions

--- a/tools/data/questdb.yaml
+++ b/tools/data/questdb.yaml
@@ -1,0 +1,30 @@
+name: QuestDB
+description: QuestDB is a high-performance time-series database with SQL analytics, PostgreSQL wire protocol compatibility, and column-oriented storage. It ingests millions of rows per second on commodity hardware with sub-millisecond queries for real-time and historical analytics.
+tagline: High-performance time-series database for real-time analytics
+
+github_url: https://github.com/questdb/questdb
+website_url: https://questdb.io
+docs_url: https://questdb.io/docs
+
+install_command: brew install questdb
+
+category: Data
+tags: [time-series, database, sql, analytics, real-time, streaming, columnar, observability]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI systems that monitor models, log predictions, or track performance metrics need a storage backend
+  that can ingest high-velocity time-series data and query it in real time. Traditional row-oriented
+  databases struggle with the write throughput and query latency required for observability and
+  monitoring at scale. QuestDB's columnar architecture and ingestion pipeline handle millions of rows
+  per second while supporting standard SQL and PostgreSQL wire protocol, so teams can use their existing
+  tools and skills.
+
+use_cases:
+  - Store and query LLM inference latency and token usage metrics for production monitoring dashboards
+  - Log prediction drift and model performance metrics over time for ML observability pipelines
+  - Track feature store access patterns and embedding cache hit rates for AI system optimization
+  - Time-series analytics on sensor data from IoT and edge AI deployments at high ingestion rates
+  - Build real-time anomaly detection pipelines over streaming metrics with sub-millisecond SQL queries

--- a/tools/dev-tools/gpt-fast.yaml
+++ b/tools/dev-tools/gpt-fast.yaml
@@ -1,0 +1,27 @@
+name: gpt-fast
+description: A simple, efficient PyTorch-native transformer text generation engine under 1000 lines of Python. Features int8/int4 quantization, speculative decoding, tensor parallelism, and support for LLaMA, Mixtral 8x7B, and other transformer architectures on both NVIDIA and AMD GPUs.
+tagline: PyTorch-native LLM inference with <1000 lines of code
+
+github_url: https://github.com/pytorch-labs/gpt-fast
+website_url: https://pytorch.org/blog/accelerating-generative-ai-2/
+docs_url: https://github.com/pytorch-labs/gpt-fast
+
+category: Dev Tools
+tags: [llm-inference, pytorch, quantization, transformer, gpu-optimization, text-generation, speculative-decoding]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  LLM inference frameworks are often heavyweight, opaque, and hard to modify for experimentation.
+  gpt-fast shows that high-performance transformer text generation — with int8/int4 quantization,
+  speculative decoding, and tensor parallelism — can be achieved in under 1000 lines of native PyTorch.
+  It serves as both a performant inference engine for LLaMA-family models and an educational reference
+  for understanding the optimization techniques behind modern LLM serving.
+
+use_cases:
+  - Run LLaMA-family models with efficient int8 or int4 quantization on consumer and datacenter GPUs
+  - Benchmark speculative decoding performance improvements for latency-sensitive text generation
+  - Study and extend a minimal, readable reference implementation of production-quality LLM inference
+  - Deploy multi-GPU tensor parallelism for Mixtral 8x7B MoE models without a heavyweight serving framework
+  - Experiment with PyTorch-native optimizations (torch.compile, CUDA graphs) for transformer inference

--- a/tools/vector-databases/redisvl.yaml
+++ b/tools/vector-databases/redisvl.yaml
@@ -1,0 +1,29 @@
+name: RedisVL
+description: The AI-native Python client for Redis that provides vector search, hybrid (vector + full-text) queries, and integration with popular embedding models. It adds index management, vector similarity search, and metadata filtering on top of Redis' in-memory data store.
+tagline: AI-native vector search for Redis — embeddings, hybrid queries, and RAG
+
+github_url: https://github.com/redis/redis-vl-python
+website_url: https://redis.io/solutions/vector-search
+docs_url: https://redisvl.com/docs
+
+install_command: pip install redisvl
+
+category: Vector DB
+tags: [vector-search, redis, embeddings, semantic-search, rag, hybrid-search, python]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Teams already using Redis for caching or session storage often need vector search for RAG pipelines
+  and semantic search, but implementing vector indexing on top of raw Redis requires low-level
+  knowledge of the Redisearch module and manual embedding management. RedisVL wraps all of that into
+  a clean Python client with automatic index creation, built-in embedding providers (OpenAI, HuggingFace,
+  Cohere), and hybrid vector + full-text queries.
+
+use_cases:
+  - Add semantic search to existing Redis-backed applications without migrating to a separate vector database
+  - Build RAG pipelines that combine vector similarity search with full-text metadata filtering in a single query
+  - Index and search code embeddings for natural language code retrieval across large codebases
+  - Power real-time recommendation systems that combine collaborative filtering with semantic embeddings
+  - Store and query session-based embeddings for conversational AI with automatic index management


### PR DESCRIPTION
This PR adds 5 new tools to the catalog:

- **Crawlee** — Web scraping and browser automation library for building reliable crawlers in JavaScript/TypeScript with Puppeteer, Playwright, Cheerio, and proxy rotation.
- **Kaggle** — Data science platform API for downloading datasets, submitting competition entries, and managing notebooks from the command line.
- **QuestDB** — High-performance time-series database with columnar storage, SQL analytics, and PostgreSQL wire protocol for real-time and historical analytics.
- **RedisVL** — AI-native Python client for Redis vector search with hybrid queries, embedding model integration, and automatic index management.
- **gpt-fast** — PyTorch-native transformer text generation engine under 1000 LOC with int8/int4 quantization, speculative decoding, and tensor parallelism.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Crawlee, Kaggle, QuestDB, gpt-fast, and RedisVL.
  - Included descriptions, tags, categories, pricing, licensing, links, installation instructions, and practical use cases for each tool.
  - Expanded coverage across web automation, data science, time-series databases, developer tools, and vector databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->