### PR TITLE
Add Medusa, T5, RedPajama, Deequ, Distil-Whisper to catalog

### DIFF
--- a/tools/data/deequ.yaml
+++ b/tools/data/deequ.yaml
@@ -1,0 +1,29 @@
+name: Deequ
+description: A library built on Apache Spark for defining and automating data quality constraints, measuring data quality metrics, and preventing data issues in large-scale datasets.
+tagline: Unit tests for data quality at scale
+
+github_url: https://github.com/awslabs/deequ
+website_url: https://aws.amazon.com/blogs/big-data/test-data-quality-at-scale-with-deequ/
+
+category: Data
+tags: [data-quality, spark, testing, validation, data-engineering, big-data]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Large-scale data pipelines accumulate quality issues — missing values, schema
+  violations, duplicate records, and distribution drift — that silently degrade
+  downstream ML models and analytics. Manually inspecting petabyte-scale datasets
+  is impractical. Deequ provides declarative data quality constraints that run as
+  Spark jobs, computing comprehensive metrics (completeness, uniqueness, consistency,
+  distribution) and surfacing violations as actionable reports. Its constraint
+  verification model enables automated data quality testing analogous to unit tests
+  for software, catching issues before they propagate to production.
+
+use_cases:
+  - Define constraint-based data quality tests that run on every ETL pipeline execution
+  - Monitor data distribution drift over time with automated metric computation and alerting
+  - Validate schema conformance and detect missing or malformed fields in large datasets
+  - Compute data quality reports for regulatory compliance and data governance requirements
+  - Integrate data quality checks into Spark-based ML pipelines to prevent garbage-in-garbage-out

--- a/tools/data/redpajama.yaml
+++ b/tools/data/redpajama.yaml
@@ -1,0 +1,29 @@
+name: RedPajama
+description: An open dataset with 30 trillion tokens for training large language models, providing high-quality, deduplicated training data with comprehensive quality signals and metadata.
+tagline: Open dataset with 30T tokens for LLM training
+
+github_url: https://github.com/togethercomputer/RedPajama-Data
+website_url: https://together.ai
+docs_url: https://huggingface.co/datasets/togethercomputer/RedPajama-Data-V2
+
+category: Data
+tags: [dataset, training-data, llm, open-data, pretraining, deduplication]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Training state-of-the-art large language models requires massive, diverse, and
+  high-quality text data, but creating such datasets from scratch is prohibitively
+  expensive and time-consuming. RedPajama provides a fully open dataset with 30
+  trillion tokens from diverse web sources, processed with deduplication, quality
+  filtering, and comprehensive quality signals. It enables researchers and companies
+  to train competitive LLMs without the data engineering burden, and its permissive
+  Apache-2.0 license avoids legal restrictions that limit other open datasets.
+
+use_cases:
+  - Pre-train large language models on high-quality open data without licensing restrictions
+  - Combine RedPajama with domain-specific data for continued pre-training and domain adaptation
+  - Use quality signal annotations to experiment with data filtering strategies for improved training
+  - Benchmark model performance against a standardized, reproducible pretraining dataset
+  - Augment retrieval datasets with diverse, deduplicated web text for RAG system training

--- a/tools/llm/medusa.yaml
+++ b/tools/llm/medusa.yaml
@@ -1,0 +1,27 @@
+name: Medusa
+description: A framework for accelerating LLM inference by adding multiple decoding heads that predict several tokens simultaneously, enabling 2-3x speedup without quality loss.
+tagline: Speed up LLM inference 2-3x with multiple decoding heads
+
+github_url: https://github.com/FasterDecoding/medusa
+install_command: pip install medusa-llm
+
+category: LLM
+tags: [llm, inference, decoding, acceleration, pytorch, speculative-decoding]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Standard autoregressive LLM decoding generates one token at a time, making inference
+  slow and memory-bound — especially for latency-sensitive applications like chatbots
+  and real-time assistants. Medusa adds multiple lightweight decoding heads that predict
+  several future tokens in parallel, combined with a tree-based attention mechanism that
+  validates candidates efficiently. This speculative decoding approach achieves 2-3x
+  wall-clock speedup without degrading output quality or requiring a separate draft model.
+
+use_cases:
+  - Accelerate chatbot inference to reduce perceived latency in interactive applications
+  - Speed up batch LLM inference for document processing pipelines and bulk generation
+  - Reduce per-token latency in real-time agentic workflows that require fast turn-around
+  - Enable cost-effective LLM serving by processing more tokens per second on existing hardware
+  - Integrate speculative decoding into existing inference pipelines with minimal code changes

--- a/tools/llm/t5.yaml
+++ b/tools/llm/t5.yaml
@@ -1,0 +1,29 @@
+name: T5
+description: Google's Text-to-Text Transfer Transformer, a unified framework that treats every NLP task as a text-to-text problem, achieving state-of-the-art results on summarization, translation, QA, and classification.
+tagline: Unified text-to-text framework for all NLP tasks
+
+github_url: https://github.com/google-research/text-to-text-transfer-transformer
+install_command: pip install t5
+
+category: LLM
+tags: [llm, nlp, text-generation, transformer, google, encoder-decoder, summarization]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Traditional NLP required separate model architectures for different tasks —
+  sequence-to-sequence for translation, BERT for classification, causal LMs for
+  generation — leading to fragmented research and engineering. T5 unifies all
+  NLP tasks into a single text-to-text framework: every problem is cast as
+  "input text → output text" with a task-specific prefix. This lets a single
+  encoder-decoder Transformer, pre-trained on the massive C4 corpus, achieve
+  competitive or state-of-the-art results across translation, summarization,
+  question answering, and classification with minimal task-specific adaptation.
+
+use_cases:
+  - Fine-tune a single model for multiple NLP tasks including summarization, translation, and QA
+  - Build multilingual translation systems with a unified encoder-decoder architecture
+  - Perform few-shot and zero-shot text classification with text prompts and task prefixes
+  - Generate abstractive summaries of long documents with contextual understanding
+  - Serve as a backbone model for NLP research and transfer learning across diverse benchmarks

--- a/tools/other/distil-whisper.yaml
+++ b/tools/other/distil-whisper.yaml
@@ -1,0 +1,29 @@
+name: Distil-Whisper
+description: A distilled version of OpenAI's Whisper speech recognition model that is six times faster and 49% smaller while retaining within 1% word error rate, enabling efficient and accurate speech transcription on edge devices.
+tagline: Fast, accurate speech recognition distilled from Whisper
+
+github_url: https://github.com/huggingface/distil-whisper
+website_url: https://huggingface.co/distil-whisper
+install_command: pip install transformers accelerate
+
+category: Other
+tags: [speech-recognition, whisper, distillation, audio, huggingface, transformers, edge]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  OpenAI's Whisper provides state-of-the-art speech recognition but its large model
+  sizes and high latency make it impractical for real-time or edge deployment.
+  Distil-Whisper applies knowledge distillation — training a smaller student model
+  to mimic the teacher's output — to produce a model that runs six times faster
+  and uses half the parameters while retaining within 1% word error rate of the
+  original. This makes accurate, multilingual speech transcription feasible on
+  CPU, mobile devices, and low-power hardware without compromising quality.
+
+use_cases:
+  - Transcribe audio in real-time on edge devices with limited compute and memory
+  - Run speech recognition on CPU servers at reduced cost compared to full Whisper models
+  - Build privacy-preserving voice interfaces that process audio locally without cloud APIs
+  - Integrate fast, accurate transcription into live captioning and meeting recording pipelines
+  - Deploy multilingual speech-to-text on mobile apps with minimal battery and latency impact


### PR DESCRIPTION
## Tools added

- **Medusa** — Accelerate LLM inference 2-3x with multiple decoding heads (speculative decoding without a draft model)
- **T5** — Google's Text-to-Text Transfer Transformer, unifying all NLP tasks into a single framework
- **RedPajama** — Open dataset with 30 trillion tokens for LLM training, with comprehensive quality signals
- **Deequ** — Unit tests for data quality at scale on Apache Spark
- **Distil-Whisper** — Fast, distilled speech recognition model (6x faster, 49% smaller, within 1% WER of Whisper)

All tools validated with `npx tsx scripts/validate-tool.ts` locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Deequ, an Apache Spark-based data quality library, with details on testing, monitoring, schema validation, and compliance use cases.
  - Added RedPajama dataset information, including project details, licensing, and practical applications.
  - Added Medusa for optimized language-model inference, covering chat, batch generation, and real-time serving.
  - Added T5 language model information, including installation and text-to-text use cases.
  - Added Distil-Whisper speech recognition model details, links, installation guidance, and supported applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->