### PR TITLE
Add VITS, Segment Anything 2, Encodec to catalog

### DIFF
--- a/tools/other/encodec.yaml
+++ b/tools/other/encodec.yaml
@@ -1,0 +1,29 @@
+name: Encodec
+description: A high-fidelity neural audio codec from Meta that compresses audio to extremely low bitrates (1.5-24 kbps) using a streaming encoder-decoder architecture with a residual vector quantizer and a language model for bandwidth-aware compression.
+tagline: Neural audio compression at ultra-low bitrates
+
+github_url: https://github.com/facebookresearch/encodec
+website_url: https://github.com/facebookresearch/encodec
+install_command: pip install encodec
+
+category: Other
+tags: [audio-compression, neural-codec, audio, deep-learning, pytorch, speech-synthesis, music-generation, real-time]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Traditional audio codecs like MP3 and Opus use hand-engineered psychoacoustic models
+  that degrade rapidly at very low bitrates and do not adapt to the content type. EnCodec
+  uses a learned end-to-end neural network with a residual vector quantizer (RVQ) and a
+  transformer-based language model to compress audio at bitrates from 1.5 kbps to 24 kbps.
+  It maintains perceptual audio quality far below the bitrates where traditional codecs
+  break down, supports both mono and stereo streaming, and runs in real time on consumer
+  hardware — enabling applications like high-quality music streaming over limited bandwidth
+  and efficient storage of large audio datasets.
+
+use_cases:
+  - Compress high-quality audio for streaming at very low bitrates (as low as 1.5 kbps) without perceptible quality loss
+  - Reduce storage requirements for large audio datasets used in machine learning training pipelines
+  - Enable real-time audio compression for live streaming applications on consumer hardware
+  - Serve as the acoustic compression backbone for generative audio models (MusicGen, AudioGen)

--- a/tools/other/segment-anything-2.yaml
+++ b/tools/other/segment-anything-2.yaml
@@ -1,0 +1,29 @@
+name: Segment Anything 2
+description: Meta's next-generation promptable segmentation model that achieves improved accuracy and significantly faster inference than SAM 1, with hierarchical mask decoding, support for multiple masks per prompt, and video segmentation capabilities through a memory-aware architecture.
+tagline: Next-generation promptable segmentation for images and video
+
+github_url: https://github.com/facebookresearch/sam2
+website_url: https://segment-anything.com
+docs_url: https://github.com/facebookresearch/sam2#readme
+
+category: Other
+tags: [image-segmentation, video-segmentation, computer-vision, pytorch, promptable-segmentation, zero-shot, meta, deep-learning]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  The original Segment Anything Model (SAM) achieved zero-shot segmentation but had
+  limitations in mask fidelity, inference speed, and could only handle still images,
+  requiring frame-by-frame processing for video without temporal consistency. SAM 2
+  introduces a hierarchical mask decoder with three output levels, simultaneous
+  prediction of multiple masks per prompt, and a memory mechanism that propagates
+  segmentation across video frames. It achieves up to 6× faster inference than SAM 1
+  while producing more accurate and detailed masks, and extends promptable segmentation
+  to video with tracking across frame sequences.
+
+use_cases:
+  - Segment objects in images with higher accuracy than SAM 1 using the hierarchical decoder with multiple mask outputs per prompt
+  - Track objects across video frames with the memory-aware architecture for consistent video segmentation without per-frame prompting
+  - Power real-time interactive segmentation applications with up to 6× faster inference than the previous generation
+  - Build automated data annotation pipelines that generate high-quality segmentation masks for both images and video datasets

--- a/tools/other/vits.yaml
+++ b/tools/other/vits.yaml
@@ -1,0 +1,27 @@
+name: VITS
+description: A conditional variational autoencoder with adversarial learning for end-to-end text-to-speech that combines variational inference, normalizing flows, and adversarial training to produce more natural-sounding speech than traditional two-stage TTS systems, with a stochastic duration predictor for diverse speaking rhythms.
+tagline: End-to-end TTS with variational inference and adversarial learning
+
+github_url: https://github.com/jaywalnut310/vits
+website_url: https://jaywalnut310.github.io/vits-demo/index.html
+docs_url: https://github.com/jaywalnut310/vits#readme
+
+category: Other
+tags: [text-to-speech, variational-autoencoder, adversarial-learning, pytorch, audio-generation, speech-synthesis, deep-learning]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Traditional text-to-speech systems use two-stage pipelines with separate text-to-spectrogram
+  and spectrogram-to-audio components, each requiring independent training and careful alignment.
+  VITS unifies both stages in a single end-to-end model using a conditional variational autoencoder
+  with adversarial learning and normalizing flows. This produces more natural-sounding speech with
+  diverse rhythms and pitches from the same text input, matching ground-truth audio quality in
+  human evaluation while enabling parallel sampling at inference time.
+
+use_cases:
+  - Generate natural-sounding speech from text for audiobooks, voiceovers, and accessibility tools
+  - Produce multiple speaking styles and rhythms from the same text input using the stochastic duration predictor
+  - Serve as a backbone for fine-tuning custom voices with minimal data through transfer learning on pretrained checkpoints
+  - Enable real-time on-device TTS inference on consumer GPUs with the compact single-model architecture


### PR DESCRIPTION
# Add VITS, Segment Anything 2, Encodec to catalog

## Tools added

### VITS
- **Category:** Other
- **Repo:** [jaywalnut310/vits](https://github.com/jaywalnut310/vits) (7.9k★, MIT)
- **Description:** A conditional variational autoencoder with adversarial learning for end-to-end text-to-speech

### Segment Anything 2
- **Category:** Other
- **Repo:** [facebookresearch/sam2](https://github.com/facebookresearch/sam2) (19.5k★, Apache-2.0)
- **Description:** Meta's next-generation promptable segmentation for images and video

### Encodec
- **Category:** Other
- **Repo:** [facebookresearch/encodec](https://github.com/facebookresearch/encodec) (4k★, MIT)
- **Description:** High-fidelity neural audio codec with ultra-low bitrate compression

## Pre-submit checklist
- [x] Validation passed for all 3 files
- [x] Verified tools not already in catalog
- [x] Repos verified active (not archived)
- [x] `pip install encodec` confirmed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Encodec, Segment Anything 2, and VITS.
  * Included descriptions, links, licensing and pricing details, tags, use cases, and problem statements for each tool.
  * Added coverage for neural audio compression, image and video segmentation, and end-to-end text-to-speech applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->