### PR TITLE
Add Apache Kafka, Apache Parquet, Bokeh, ColPali, Flet to catalog

### DIFF
--- a/tools/data/apache-parquet.yaml
+++ b/tools/data/apache-parquet.yaml
@@ -1,0 +1,28 @@
+name: Apache Parquet
+description: An open-source columnar storage format optimized for analytics workloads, providing efficient compression and encoding schemes that are essential for storing large-scale ML training datasets and feature stores.
+tagline: Columnar storage format for analytics and ML
+
+github_url: https://github.com/apache/parquet-java
+website_url: https://parquet.apache.org
+docs_url: https://parquet.apache.org/docs
+
+install_command: pip install pyarrow
+
+category: Data
+tags: [data-storage, columnar, analytics, big-data, arrow, compression]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Storing large ML datasets in row-oriented formats like CSV or JSON wastes storage 
+  and slows down read-heavy workloads because queries scan entire rows even when only 
+  a few columns are needed. Apache Parquet's columnar layout, predicate pushdown, and 
+  advanced compression reduce storage footprint by up to 75% while enabling scans that 
+  are orders of magnitude faster for analytical queries and feature engineering.
+
+use_cases:
+  - Store and query large-scale training datasets with efficient column pruning for faster data loading into ML pipelines
+  - Power feature stores and data lakes where columnar compression reduces storage costs while maintaining high read throughput
+  - Enable efficient data exchange between distributed query engines like Spark, Trino, and DuckDB for ETL workflows
+  - Archive model training logs, evaluation metrics, and experiment artifacts in a compressed, self-describing format

--- a/tools/dev-tools/bokeh.yaml
+++ b/tools/dev-tools/bokeh.yaml
@@ -1,0 +1,28 @@
+name: Bokeh
+description: An interactive visualization library for Python that generates browser-based dashboards and plots with real-time streaming support, enabling AI practitioners to build custom monitoring UIs without web development expertise.
+tagline: Interactive visualizations for Python in the browser
+
+github_url: https://github.com/bokeh/bokeh
+website_url: https://bokeh.org
+docs_url: https://docs.bokeh.org
+
+install_command: pip install bokeh
+
+category: Dev Tools
+tags: [visualization, dashboard, interactive, python, plotting, streaming]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  ML practitioners need custom dashboards and interactive plots to visualize training 
+  metrics, model outputs, and data distributions, but building web-based UIs typically 
+  requires frontend development skills. Bokeh lets data scientists create interactive, 
+  browser-ready visualizations directly from Python — with support for linked panning, 
+  streaming data updates, and server-backed dashboards — without writing HTML or JavaScript.
+
+use_cases:
+  - Build real-time training dashboards that stream loss curves, accuracy metrics, and gradient statistics during model runs
+  - Create interactive model evaluation reports with linked scatter plots, histograms, and confusion matrices for stakeholder review
+  - Develop custom monitoring UIs for deployed models that display prediction distributions, drift metrics, and data quality alerts
+  - Embed interactive visualizations into Jupyter notebooks and standalone web applications for exploratory data analysis

--- a/tools/dev-tools/flet.yaml
+++ b/tools/dev-tools/flet.yaml
@@ -1,0 +1,28 @@
+name: Flet
+description: A Python framework for building real-time web, mobile, and desktop apps using Flutter widgets, enabling AI developers to create polished user interfaces for demos, tools, and internal dashboards without JavaScript.
+tagline: Build interactive multi-platform apps in Python
+
+github_url: https://github.com/flet-dev/flet
+website_url: https://flet.dev
+docs_url: https://flet.dev/docs
+
+install_command: pip install flet
+
+category: Dev Tools
+tags: [ui, app-development, python, flutter, cross-platform, dashboard]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI developers often need to ship interactive frontends for prototypes, demos, or 
+  internal tools but lack the time or expertise to build web UIs with JavaScript 
+  frameworks. Flet lets you write the UI entirely in Python using Flutter's widget 
+  model — producing responsive, real-time apps that run in the browser, on desktop, 
+  or on mobile — with automatic state synchronization and built-in input handling.
+
+use_cases:
+  - Build polished AI demo interfaces with streaming chat outputs, file uploads, and real-time parameter controls
+  - Create internal dashboards that display model predictions, training progress, and inference logs with live updates
+  - Develop cross-platform data labeling tools and annotation UIs that work on desktop and tablet for annotator teams
+  - Rapidly prototype web-based tools for prompt engineering, dataset browsing, and model comparison without frontend expertise

--- a/tools/other/apache-kafka.yaml
+++ b/tools/other/apache-kafka.yaml
@@ -1,0 +1,28 @@
+name: Apache Kafka
+description: An open-source distributed event streaming platform for building real-time data pipelines and streaming applications, widely used as the backbone for AI training data ingestion, model serving, and monitoring event buses.
+tagline: Distributed event streaming for data pipelines and AI
+
+github_url: https://github.com/apache/kafka
+website_url: https://kafka.apache.org
+docs_url: https://kafka.apache.org/documentation
+
+install_command: pip install kafka-python
+
+category: Other
+tags: [streaming, event-driven, data-pipeline, pub-sub, distributed-systems, real-time]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building reliable, scalable data pipelines for AI workloads requires a durable, 
+  fault-tolerant way to move data between systems in real time. Apache Kafka provides 
+  a distributed commit log that decouples data producers from consumers, enabling 
+  high-throughput event streaming with exactly-once semantics for training data 
+  ingestion, model inference logs, and monitoring telemetry.
+
+use_cases:
+  - Stream training data from distributed sources into ML pipelines and feature stores for real-time model updates
+  - Collect and transport model inference logs, serving metrics, and drift detection events for monitoring and observability
+  - Build event-driven AI workflows that react to data changes with low latency using Kafka Streams or ksqlDB
+  - Serve as a central event bus connecting microservices, databases, and analytics platforms in AI infrastructure

--- a/tools/rag/colpali.yaml
+++ b/tools/rag/colpali.yaml
@@ -1,0 +1,29 @@
+name: ColPali
+description: A retrieval model that indexes documents using vision-language understanding rather than text extraction, enabling RAG systems to search across charts, tables, diagrams, and dense layouts with the ColBERT late-interaction scoring mechanism.
+tagline: Vision-language document retrieval for RAG
+
+github_url: https://github.com/illuin-tech/colpali
+website_url: https://github.com/illuin-tech/colpali
+docs_url: https://github.com/illuin-tech/colpali#readme
+
+install_command: pip install colpali-engine
+
+category: RAG
+tags: [rag, vision, embedding, document-retrieval, multimodal, colbert, OCR]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Traditional RAG systems rely on text extraction pipelines that fail on visually rich 
+  documents — PDFs with complex layouts, slides with diagrams, scanned invoices, and 
+  charts embedded in reports. ColPali uses a vision-language model to encode document 
+  pages directly as visual embeddings, then applies ColBERT-style late interaction for 
+  efficient retrieval, eliminating fragile OCR and layout parsing from the document 
+  search pipeline.
+
+use_cases:
+  - Search across slide decks, academic posters, and technical diagrams where text extraction misses critical visual information
+  - Power document retrieval in enterprise RAG systems handling scanned forms, invoices, and handwritten notes
+  - Enable question answering over charts and infographics that are impossible to represent through text alone
+  - Build multimodal search indexes over mixed-format document collections without per-format parsing pipelines


### PR DESCRIPTION
## What's new

Adding 5 tools to the Agentic AI For Good catalog:

| Tool | Category | Description |
|------|----------|-------------|
| Apache Kafka | Other | Distributed event streaming platform |
| Apache Parquet | Data | Columnar storage format for analytics |
| Bokeh | Dev Tools | Interactive Python visualization library |
| ColPali | RAG | Vision-language document retrieval model |
| Flet | Dev Tools | Python multi-platform UI framework |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apache Parquet as a data storage option, with details for ML datasets, feature stores, analytics, ETL, and experiment archiving.
  * Added Bokeh and Flet developer tool entries, covering interactive visualizations, dashboards, and cross-platform app interfaces.
  * Added Apache Kafka for event-driven pipelines, monitoring, and AI workflows.
  * Added ColPali as a retrieval-augmented generation model with installation details, categorization, and supported use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->