### PR TITLE
Add SynapseML, Vearch to catalog

### DIFF
--- a/tools/data/synapseml.yaml
+++ b/tools/data/synapseml.yaml
@@ -1,0 +1,41 @@
+name: SynapseML
+description: Microsoft's distributed machine learning framework for Apache Spark that simplifies scaling ML pipelines — from classical algorithms to deep learning, cognitive services, and model deployment — across large datasets without leaving the Spark ecosystem.
+tagline: Distributed ML on Apache Spark made simple
+
+github_url: https://github.com/microsoft/SynapseML
+website_url: https://microsoft.github.io/SynapseML
+docs_url: https://microsoft.github.io/SynapseML/docs
+
+install_command: pip install synapseml
+
+category: Data
+tags:
+  - apache-spark
+  - distributed-ml
+  - machine-learning
+  - big-data
+  - microsoft
+  - pyspark
+  - cognitive-services
+  - scala
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Scaling ML workflows across large datasets typically requires moving data out of Spark
+  into separate training frameworks (PyTorch, TensorFlow, Scikit-learn), creating complex
+  data pipelines that break on large data and add engineering overhead. SynapseML (formerly
+  MMLSpark) brings ML directly into the Apache Spark ecosystem. It provides scalable
+  estimators for classification, regression, anomaly detection, and deep learning that
+  run as native Spark ML Pipelines, eliminating data movement. It also integrates
+  Azure Cognitive Services, ONNX model serving, and LightGBM, allowing data scientists
+  to build end-to-end pipelines — from feature engineering to distributed training to
+  model serving — entirely within Spark.
+
+use_cases:
+  - Train XGBoost or LightGBM models on terabytes of Spark DataFrames without exporting data to separate frameworks
+  - Build a scalable OCR pipeline that processes millions of PDFs using Spark to orchestrate Azure Computer Vision calls
+  - Deploy deep learning models (CNNs, BERT) for inference across a Spark cluster with ONNX runtime integration
+  - Create a distributed anomaly detection system that scores streaming telemetry against historical baselines
+  - Orchestrate multi-step ML workflows where data processing, training, and serving all stay inside Spark

--- a/tools/vector-databases/vearch.yaml
+++ b/tools/vector-databases/vearch.yaml
@@ -1,0 +1,39 @@
+name: Vearch
+description: A cloud-native distributed vector database optimized for efficient similarity search of embedding vectors in AI applications, with support for hybrid search, real-time indexing, and horizontal scaling across Kubernetes clusters.
+tagline: Cloud-native vector database for AI-native similarity search
+
+github_url: https://github.com/vearch/vearch
+website_url: https://vearch.github.io
+docs_url: https://vearch.github.io/docs
+
+category: Vector DB
+tags:
+  - vector-database
+  - similarity-search
+  - cloud-native
+  - kubernetes
+  - distributed
+  - hybrid-search
+  - rag
+  - embeddings
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Running vector search at scale requires a database that can store, index, and query
+  billions of embeddings with low latency, while also supporting real-time updates,
+  hybrid search (vector + scalar filters), and horizontal scaling. Most vector search
+  libraries are single-node tools, and cloud-managed solutions can be expensive at
+  scale. Vearch is a distributed, cloud-native vector database built for Kubernetes.
+  It partitions and replicates data across shards automatically, supports IVF_PQ and
+  HNSW indexing, and provides RESTful and gRPC APIs. It handles both dense embeddings
+  and scalar attribute filtering, making it suitable for production RAG pipelines and
+  recommendation systems that need to scale without a per-query high cost.
+
+use_cases:
+  - Build a production RAG pipeline with hybrid search that filters by metadata before vector similarity
+  - Deploy a distributed similarity search service on Kubernetes that scales horizontally as data grows
+  - Power a real-time content recommendation engine with vectors updated as user preferences change
+  - Store and query billions of image embeddings for a visual product search system
+  - Run semantic document retrieval with metadata-aware filtering at enterprise scale


### PR DESCRIPTION
This PR adds 2 tools to the Agentic AI For Good catalog:

- **SynapseML** — Microsoft's distributed machine learning framework for Apache Spark (Data)
- **Vearch** — Cloud-native distributed vector database for similarity search (Vector DB)

All files validated locally.
