### PR TITLE
Add SPTAG, StatsForecast to catalog

### DIFF
--- a/tools/data/statsforecast.yaml
+++ b/tools/data/statsforecast.yaml
@@ -1,0 +1,25 @@
+name: StatsForecast
+description: |-
+  A lightning-fast Python library for statistical and econometric time series forecasting, providing optimized implementations of ARIMA, ETS, Theta, CES, and other classical models with parallel and distributed computation.
+tagline: Lightning-fast statistical forecasting with classical econometric models
+
+github_url: https://github.com/Nixtla/statsforecast
+website_url: https://nixtla.io
+docs_url: https://docs.nixtla.io
+
+install_command: pip install statsforecast
+
+category: Data
+tags: [python, time-series, forecasting, statistics, arima, econometrics, nixtla]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |-
+  Classical statistical forecasting methods like ARIMA, ETS, and Theta are well-established but their standard Python implementations are slow for large-scale use. StatsForecast provides highly optimized, parallelized implementations of these models using Numba and distributed computing, achieving orders of magnitude speedup over traditional implementations while maintaining statistical rigor.
+
+use_cases:
+  - Forecast thousands of time series simultaneously using parallel statistical models for inventory planning
+  - Generate baseline forecasts using ARIMA and ETS for comparison with machine learning and deep learning approaches
+  - Perform fast anomaly detection by comparing actual values against statistically modeled confidence intervals
+  - Run large-scale backtesting and cross-validation of statistical models across hundreds of time series

--- a/tools/vector-databases/sptag.yaml
+++ b/tools/vector-databases/sptag.yaml
@@ -1,0 +1,21 @@
+name: SPTAG
+description: |-
+  A distributed approximate nearest neighbor search (ANN) library from Microsoft Research, providing high quality vector index build, search and distributed online serving toolkits for large scale vector search scenarios.
+tagline: Distributed vector similarity search from Microsoft Research
+
+github_url: https://github.com/microsoft/SPTAG
+
+category: Vector DB
+tags: [cpp, python, vector-search, ann, approximate-nearest-neighbor, microsoft, distributed]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |-
+  Performing approximate nearest neighbor search at billion-scale requires specialized data structures that balance search accuracy, index build speed, and memory usage. SPTAG provides both kd-tree based (SPTAG-KDT) and BKT-based (SPTAG-BKT) indexing approaches with distributed serving capabilities, enabling high-recall vector search for large-scale retrieval and recommendation systems.
+
+use_cases:
+  - Build billion-scale semantic search systems with sub-10ms query latency using distributed index serving
+  - Implement high-recall product recommendation engines using vector similarity across millions of items
+  - Power large-scale duplicate detection and near-dup matching pipelines with configurable accuracy thresholds
+  - Serve vector search for RAG applications with huge document collections requiring distributed index sharding


### PR DESCRIPTION
This PR adds 2 tools to the catalog:

- **SPTAG** (Vector DB) — Distributed approximate nearest neighbor search library from Microsoft Research
- **StatsForecast** (Data) — Lightning-fast statistical and econometric time series forecasting from Nixtla
