### PR TITLE
Add torchao, Triton to catalog

### DIFF
--- a/tools/dev-tools/triton.yaml
+++ b/tools/dev-tools/triton.yaml
@@ -1,0 +1,28 @@
+name: Triton
+description: An open-source, Python-embedded programming language and compiler for writing high-performance custom GPU kernels with productivity far exceeding CUDA.
+tagline: GPU programming language and compiler for custom deep learning kernels
+
+github_url: https://github.com/openai/triton
+website_url: https://triton-lang.org
+docs_url: https://triton-lang.org/main/index.html
+install_command: pip install triton
+
+category: Dev Tools
+tags: [gpu, compiler, kernel, cuda-alternative, high-performance, deep-learning]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Writing efficient GPU kernels for deep learning primitives normally requires expert CUDA
+  programming — a steep learning curve that limits how many researchers can contribute to
+  kernel-level optimizations. Triton is a Python-embedded language and compiler that lets
+  developers write custom GPU kernels at CUDA-level performance using intuitive Python syntax,
+  dramatically lowering the barrier to high-performance deep learning primitives.
+
+use_cases:
+  - Write custom GPU kernels for novel attention mechanisms beyond standard implementations
+  - Implement fused operations that combine multiple tensor operations into a single GPU kernel
+  - Prototype and benchmark new deep learning primitives without writing low-level CUDA code
+  - Optimize inference bottlenecks by replacing framework operations with custom Triton kernels
+  - Build high-performance custom layers for research experiments and production deployments

--- a/tools/fine-tuning/torchao.yaml
+++ b/tools/fine-tuning/torchao.yaml
@@ -1,0 +1,27 @@
+name: torchao
+description: PyTorch's architecture optimization library for quantizing, pruning, and applying low-precision techniques to accelerate model training and inference on PyTorch models.
+tagline: Architecture optimization for PyTorch models
+
+github_url: https://github.com/pytorch/ao
+website_url: https://pytorch.org/blog/architecture-optimization/
+install_command: pip install torchao
+
+category: Fine-tuning
+tags: [quantization, optimization, pytorch, fine-tuning, compression, int8]
+pricing: free
+is_open_source: true
+license: NOASSERTION
+
+problem_solved: |
+  Applying quantization, pruning, and low-precision optimizations to PyTorch models typically
+  requires custom code and deep knowledge of hardware-specific formats. torchao provides a
+  unified API for architecture optimization — INT4, INT8, FP8 quantization, structured
+  pruning, and weight-only compression — that works across PyTorch models with minimal code
+  changes, making optimization accessible without specialized hardware expertise.
+
+use_cases:
+  - Quantize PyTorch LLMs to INT8 or INT4 for 2-4x faster inference with minimal accuracy loss
+  - Apply structured pruning to reduce model size and memory footprint during inference
+  - Use FP8 training to reduce memory usage and speed up large model fine-tuning
+  - Compress model weights with AO-specific formats for efficient deployment on edge hardware
+  - Benchmark and compare optimization strategies across different PyTorch model architectures


### PR DESCRIPTION
Add 2 tools to the Agentic AI For Good catalog:

| Tool | Category | Stars | Repo | License |
|---|---|---|---|---|
| torchao | Fine-tuning | 2,906 | pytorch/ao | — |
| Triton | Dev Tools | 19,726 | openai/triton | MIT |

Both YAML files validated locally with `npx tsx scripts/validate-tool.ts`.
