### PR TITLE
Add Apache Camel, Apache Storm, etcd, Apache ZooKeeper to catalog

### DIFF
--- a/tools/data/apache-camel.yaml
+++ b/tools/data/apache-camel.yaml
@@ -1,0 +1,27 @@
+name: Apache Camel
+description: An enterprise integration framework with hundreds of connectors for routing, transforming, and mediating data between systems in machine learning and data pipelines.
+tagline: Enterprise integration for AI data pipelines
+
+github_url: https://github.com/apache/camel
+website_url: https://camel.apache.org
+docs_url: https://camel.apache.org/manual/
+
+category: Data
+tags: [integration, data-pipeline, etl, messaging, streaming, enterprise]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building AI and data pipelines often requires connecting disparate systems — databases,
+  message queues, APIs, file systems, and cloud services — each with different protocols and
+  data formats. Apache Camel provides a unified integration framework with hundreds of
+  pre-built connectors that route and transform data between systems using enterprise
+  integration patterns, dramatically reducing custom plumbing code.
+
+use_cases:
+  - Build data ingestion pipelines that connect databases, APIs, and message queues for ML training data
+  - Route and transform streaming data between AI model serving infrastructure and monitoring systems
+  - Orchestrate multi-step ETL workflows that prepare data for model training and inference
+  - Connect real-time inference outputs to downstream analytics and alerting platforms
+  - Automate data movement between on-premise and cloud infrastructure for hybrid AI deployments

--- a/tools/data/apache-storm.yaml
+++ b/tools/data/apache-storm.yaml
@@ -1,0 +1,27 @@
+name: Apache Storm
+description: A distributed real-time stream processing system for processing large volumes of data with fault-tolerant, horizontally scalable topologies for streaming AI workloads.
+tagline: Distributed real-time stream processing at scale
+
+github_url: https://github.com/apache/storm
+website_url: https://storm.apache.org
+docs_url: https://storm.apache.org/documentation.html
+
+category: Data
+tags: [stream-processing, real-time, data-pipeline, distributed-systems, streaming]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Processing real-time data streams for AI inference and monitoring requires systems that can
+  handle high throughput with low latency while providing fault tolerance. Apache Storm
+  processes unbounded data streams in real-time using distributed topologies of spouts and
+  bolts, making it possible to run streaming feature engineering, real-time model scoring, and
+  online learning pipelines at production scale.
+
+use_cases:
+  - Run real-time feature engineering on streaming data for online ML model inference
+  - Build streaming ETL pipelines that prepare and transform data for model training
+  - Process live telemetry streams for AI model monitoring and drift detection
+  - Implement online learning pipelines that update models in real-time from data streams
+  - Orchestrate real-time alerting and anomaly detection across distributed data sources

--- a/tools/data/apache-zookeeper.yaml
+++ b/tools/data/apache-zookeeper.yaml
@@ -1,0 +1,27 @@
+name: Apache ZooKeeper
+description: A distributed coordination service for maintaining configuration, naming, synchronization, and group services in large-scale distributed ML and data systems.
+tagline: Distributed coordination for large-scale ML systems
+
+github_url: https://github.com/apache/zookeeper
+website_url: https://zookeeper.apache.org
+docs_url: https://zookeeper.apache.org/doc/current/
+
+category: Data
+tags: [coordination, distributed-systems, service-discovery, configuration, synchronization]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Distributed AI and data systems — from model training clusters to streaming pipelines —
+  need a reliable way to coordinate nodes, elect leaders, track membership, and distribute
+  configuration. ZooKeeper provides a highly reliable coordination service that handles these
+  primitives with strong consistency guarantees, enabling distributed ML platforms to operate
+  reliably without building custom consensus and coordination mechanisms.
+
+use_cases:
+  - Coordinate leader election and failover for distributed model training orchestration
+  - Manage service discovery and health monitoring for model serving cluster nodes
+  - Store and synchronize pipeline configuration, feature definitions, and model metadata
+  - Provide distributed locking for concurrent data processing and model update workflows
+  - Track worker membership and task assignments in distributed ML training and inference jobs

--- a/tools/data/etcd.yaml
+++ b/tools/data/etcd.yaml
@@ -1,0 +1,27 @@
+name: etcd
+description: A distributed, reliable key-value store used for service discovery, configuration management, and distributed coordination in cloud-native AI and machine learning platforms.
+tagline: Distributed key-value store for cloud-native AI infrastructure
+
+github_url: https://github.com/etcd-io/etcd
+website_url: https://etcd.io
+docs_url: https://etcd.io/docs
+
+category: Data
+tags: [key-value-store, distributed-systems, service-discovery, coordination, cloud-native]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Distributed AI systems — model serving clusters, training orchestrators, and feature stores —
+  require reliable coordination and configuration management across many nodes. etcd provides
+  a strongly consistent, highly available key-value store that serves as the backbone for
+  service discovery, leader election, and configuration distribution in cloud-native AI
+  infrastructure, enabling reliable distributed model serving and training coordination.
+
+use_cases:
+  - Store and distribute model configuration, feature definitions, and pipeline metadata across ML clusters
+  - Manage service discovery for distributed model serving infrastructure with multiple replicas
+  - Coordinate leader election and distributed locking for training job orchestrators
+  - Store and watch configuration changes for real-time model serving stack updates
+  - Provide a reliable metadata store for feature stores, model registries, and ML platform components


### PR DESCRIPTION
Add 4 tools to the Agentic AI For Good catalog:

| Tool | Category | Stars | Repo | License |
|---|---|---|---|---|
| Apache Camel | Data | 6,267 | apache/camel | Apache-2.0 |
| Apache Storm | Data | 6,692 | apache/storm | Apache-2.0 |
| etcd | Data | 52,005 | etcd-io/etcd | Apache-2.0 |
| Apache ZooKeeper | Data | 12,782 | apache/zookeeper | Apache-2.0 |

All YAML files validated locally with `npx tsx scripts/validate-tool.ts`.
