### PR TITLE
Add Nexent, Archestra to catalog

### DIFF
--- a/tools/dev-tools/archestra.yaml
+++ b/tools/dev-tools/archestra.yaml
@@ -1,0 +1,28 @@
+name: Archestra
+description: An enterprise AI platform with guardrails, MCP registry, AI gateway, and multi-agent orchestrator for deploying and managing production AI systems.
+tagline: Enterprise AI platform with MCP gateway and guardrails
+
+github_url: https://github.com/archestra-ai/archestra
+website_url: https://github.com/archestra-ai/archestra
+
+category: Dev Tools
+tags: [python, agents, mcp, gateway, guardrails, orchestrator, enterprise, a2a, acp, multi-agent]
+pricing: free
+is_open_source: true
+license: NOASSERTION
+
+problem_solved: |
+  Enterprises deploying AI face a sprawl of disconnected tools — multiple LLMs, MCP
+  servers, agent frameworks, guardrails, and observability systems — each with its own
+  API and management surface. Archestra unifies them into one platform with an AI
+  gateway for LLM routing, a built-in MCP registry for discovering and connecting MCP
+  servers, guardrails for safety policies, and a multi-agent orchestrator for complex
+  workflows. It runs on Docker, Kubernetes, or bare metal, giving IT teams a single
+  control plane for AI operations.
+
+use_cases:
+  - Deploy an enterprise AI gateway that routes requests across OpenAI, Anthropic, and local models with fallback and load balancing
+  - Register and manage 50+ MCP servers in a central registry, making them discoverable by all agents in the organization
+  - Enforce content safety guardrails across all AI interactions — block prompt injection, filter PII, and audit all requests
+  - Orchestrate a multi-agent customer service workflow where routing, triage, resolution, and escalation agents collaborate via MCP
+  - Build a centralized AI platform for IT operations that monitors usage, manages API keys, and provides audit trails for compliance

--- a/tools/dev-tools/nexent.yaml
+++ b/tools/dev-tools/nexent.yaml
@@ -1,0 +1,30 @@
+name: Nexent
+description: A zero-code platform for auto-generating production-grade AI agents using Harness Engineering principles, with unified tools, skills, memory, and multi-agent orchestration.
+tagline: Zero-code platform for production-grade AI agents
+
+github_url: https://github.com/ModelEngine-Group/nexent
+website_url: https://modelengine-group.github.io/nexent
+docs_url: https://modelengine-group.github.io/nexent/en/quick-start/installation.html
+
+category: Dev Tools
+tags: [python, agents, multi-agent, mcp, rag, workflow, low-code, orchestrator, harness-engineering]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install nexent
+
+problem_solved: |
+  Building production AI agents requires stitching together LLM APIs, tool integrations,
+  memory systems, MCP servers, and orchestration logic — a steep learning curve that
+  slows adoption. Nexent provides a zero-code platform that auto-generates agents from
+  declarative specifications. Teams define goals and constraints, and Nexent produces
+  the complete agent with tools, skills, memory, and multi-agent workflows, dramatically
+  reducing development time while maintaining production-grade reliability.
+
+use_cases:
+  - Generate a customer-facing support agent from a requirements document — Nexent auto-configures tools, MCP servers, and escalation workflows
+  - Deploy a multi-agent research team where a coordinator agent delegates to specialized researcher, writer, and fact-checker agents
+  - Create an internal knowledge agent connected to company docs, databases, and APIs — no manual tool registration needed
+  - Build a RAG pipeline agent that ingests documents, generates embeddings, and responds to queries with source citations
+  - Auto-generate a code review agent with skills for security scanning, performance analysis, and linting — defined in one declarative spec


### PR DESCRIPTION
## Summary

Adds 2 remaining tools to the catalog:

- **Nexent** (Dev Tools) — Zero-code platform for auto-generating production-grade AI agents using Harness Engineering principles
- **Archestra** (Dev Tools) — Enterprise AI platform with guardrails, MCP registry, AI gateway, and multi-agent orchestrator

### Verification
- [x] Both YAML files validated with `npx tsx scripts/validate-tool.ts`
- [x] Star counts verified via GitHub API (Nexent: 5785★, Archestra: 4014★)
- [x] Repos are active (not archived)
