### PR TITLE
Add Dataiku, DataRobot, H2O.ai, KNIME, Labelbox to catalog

### DIFF
--- a/tools/data/dataiku.yaml
+++ b/tools/data/dataiku.yaml
@@ -1,0 +1,17 @@
+name: Dataiku
+tagline: Enterprise AI platform for data science and ML teams
+description: Dataiku is an enterprise AI platform that unifies data science, machine learning, and AI operations. It provides a collaborative environment for data preparation, model building, deployment, and monitoring — supporting everything from visual analytics to full-code Python development and MLOps.
+website_url: https://www.dataiku.com
+docs_url: https://doc.dataiku.com
+category: Data
+tags: [data-science, machine-learning, mlops, data-preparation, enterprise-ai, data-engineering]
+pricing: paid
+is_open_source: false
+problem_solved: |
+  Data science teams often operate in silos with fragmented toolchains for data preparation, model building, deployment, and monitoring, leading to poor collaboration and slow iteration. Dataiku solves this by providing a unified, collaborative AI platform where data analysts, data scientists, and ML engineers can work together — from data ingestion and feature engineering to model deployment and monitoring — all within a single governed environment.
+use_cases:
+  - "Collaborative data preparation: clean, transform, and enrich data using visual recipes or Python/R code with shared datasets and versioning"
+  - "ML model development: build and compare models using AutoML, visual ML, or full-code frameworks like scikit-learn, TensorFlow, and PyTorch"
+  - "Model deployment and MLOps: deploy models to production APIs, batch scoring jobs, or edge devices with automated monitoring and retraining"
+  - "Data governance: manage data lineage, access controls, and audit trails across the entire AI lifecycle for compliance"
+  - "AI factory: scale AI initiatives across teams with reusable components, project templates, and centralized infrastructure"

--- a/tools/data/datarobot.yaml
+++ b/tools/data/datarobot.yaml
@@ -1,0 +1,19 @@
+name: DataRobot
+tagline: Enterprise AI platform for building, deploying, and managing ML at scale
+description: DataRobot is an enterprise AI platform that automates and accelerates the end-to-end machine learning lifecycle. From automated feature engineering and model selection to deployment and monitoring, DataRobot enables organizations to build production-grade ML models with speed and governance.
+website_url: https://www.datarobot.com
+docs_url: https://docs.datarobot.com
+install_command: pip install datarobot
+github_url: https://github.com/datarobot/datarobot-python
+category: Data
+tags: [machine-learning, auto-ml, mlops, enterprise-ai, model-deployment, data-science]
+pricing: paid
+is_open_source: false
+problem_solved: |
+  Building and deploying production ML models requires deep expertise across data engineering, feature engineering, model selection, hyperparameter tuning, and MLOps — skills that are scarce and expensive. DataRobot solves this by automating the ML lifecycle, providing automated feature discovery, model comparison, explainability, and one-click deployment, making it accessible for organizations to build and scale AI initiatives without requiring a team of PhD-level data scientists.
+use_cases:
+  - "Automated ML: upload a dataset and let DataRobot automatically build, evaluate, and rank hundreds of models across algorithms and preprocessing pipelines"
+  - "Model governance: track model versions, monitor drift, manage approvals, and maintain compliance with built-in explainability and audit trails"
+  - "Time series forecasting: leverage automated time-aware feature engineering and hierarchical forecasting for demand, inventory, and financial predictions"
+  - "Deploy and monitor: deploy models as REST APIs, batch scoring jobs, or edge containers with automated monitoring for data drift and performance degradation"
+  - "Collaborative data science: enable business analysts and data scientists to work together with visual workflows, Python notebooks, and shared model repositories"

--- a/tools/data/h2o-ai.yaml
+++ b/tools/data/h2o-ai.yaml
@@ -1,0 +1,20 @@
+name: H2O.ai
+tagline: Open-source distributed machine learning platform
+description: H2O.ai is an open-source, distributed in-memory machine learning platform that supports building and deploying ML models at scale. With APIs in Python, R, Java, and Scala, H2O provides AutoML, feature engineering, model explainability, and production deployment capabilities for structured and unstructured data.
+website_url: https://h2o.ai
+github_url: https://github.com/h2oai/h2o-3
+docs_url: https://docs.h2o.ai
+install_command: pip install h2o
+category: Data
+tags: [machine-learning, auto-ml, distributed-ml, python, r, data-science, gradient-boosting, deep-learning]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Building scalable machine learning models requires significant infrastructure and expertise, often forcing teams to choose between ease of use and production performance. H2O solves this by providing a distributed, in-memory ML platform that scales from a laptop to large clusters, with automatic feature engineering, model tuning, and deployment — all accessible through simple APIs in Python, R, Java, and Scala.
+use_cases:
+  - "Automated machine learning: run AutoML to automatically train, tune, and stack hundreds of models across algorithms including GBM, XGBoost, Deep Learning, and GLM"
+  - "Model interpretability: generate SHAP, LIME, and partial dependence plots to understand model predictions and build stakeholder trust"
+  - "Real-time scoring: deploy models as REST endpoints or MOJO (Model Object, Optimized) for low-latency production inference"
+  - "Big data ML: train on datasets that exceed memory using distributed H2O clusters across multiple nodes with in-memory processing"
+  - "Enterprise ML pipeline: integrate with MLflow, Kubernetes, and cloud storage for end-to-end model lifecycle management"

--- a/tools/data/knime.yaml
+++ b/tools/data/knime.yaml
@@ -1,0 +1,19 @@
+name: KNIME
+tagline: Open-source data analytics and ML platform with visual workflows
+description: KNIME Analytics Platform is an open-source data analytics, reporting, and machine learning platform that uses a visual, no-code workflow interface. Users build data pipelines by connecting pre-built nodes for data access, transformation, analysis, and visualization — with support for Python, R, and Java scripting for extensibility.
+website_url: https://www.knime.com
+docs_url: https://docs.knime.com
+install_command: pip install knime
+category: Data
+tags: [data-analytics, data-science, no-code, visual-workflows, machine-learning, python-integration, data-preparation]
+pricing: freemium
+is_open_source: true
+license: GPL-3.0
+problem_solved: |
+  Many data analysis tasks require repetitive coding for data cleaning, transformation, statistical analysis, and visualization — creating friction for non-programmers and slowing down experienced analysts who want to focus on insights, not glue code. KNIME solves this by providing a visual, node-based workflow environment where analysts can build complex data pipelines without writing code, while still allowing full integration with Python, R, and Java for advanced custom analysis.
+use_cases:
+  - "Visual data pipelines: build ETL and data preparation workflows by connecting nodes for CSV parsing, filtering, joins, aggregations, and date transformations"
+  - "Machine learning workflows: train, evaluate, and compare models using nodes for scikit-learn, TensorFlow, Keras, XGBoost, and H2O — all without writing code"
+  - "Automated reporting: schedule and run KNIME workflows to generate Excel, PDF, and HTML reports with integrated charts and dashboards"
+  - "Python and R integration: embed Python or R scripts inline within a workflow to run custom analyses, access libraries, or create visualizations"
+  - "Data science collaboration: share workflows, components, and data across teams with KNIME Server for centralized deployment and governance"

--- a/tools/data/labelbox.yaml
+++ b/tools/data/labelbox.yaml
@@ -1,0 +1,19 @@
+name: Labelbox
+tagline: Data labeling and annotation platform for AI and ML
+description: Labelbox is a data labeling and annotation platform for building high-quality training datasets for machine learning. It offers tools for image, video, text, and audio annotation, with workflows for human-in-the-loop labeling, model-assisted labeling, quality review, and data management — connecting raw data to production-ready training sets.
+website_url: https://labelbox.com
+docs_url: https://docs.labelbox.com
+install_command: pip install labelbox
+github_url: https://github.com/Labelbox/labelbox-python
+category: Data
+tags: [data-labeling, annotation, computer-vision, nlp, training-data, dataset-management, data-curation]
+pricing: paid
+is_open_source: false
+problem_solved: |
+  Building high-quality training datasets for machine learning is time-consuming and error-prone, often requiring custom tooling for annotation, quality control, and data management across different data types. Labelbox solves this by providing a unified platform for annotating images, videos, text, and audio — with model-assisted labeling to reduce manual work, automated quality reviews, and seamless integration with ML training pipelines.
+use_cases:
+  - "Image and video annotation: label bounding boxes, polygons, segmentation masks, keypoints, and classification tags for computer vision datasets"
+  - "Text and NLP annotation: label named entities, relationships, sentiment, classification, and question-answer pairs for natural language models"
+  - "Model-assisted labeling: use existing ML models to pre-label data, then have human annotators review and correct — reducing labeling time by 50-80%"
+  - "Quality management: set up consensus-based labeling, review workflows, and automated quality metrics to ensure high annotation accuracy"
+  - "Dataset management: organize, search, version, and export labeled data with flexible ontology management and cloud storage integrations"


### PR DESCRIPTION
Adds 5 enterprise AI/data platforms to the catalog:

- **Dataiku** — Enterprise AI platform for data science and ML teams
- **DataRobot** — Enterprise AI platform for automated ML lifecycle management
- **H2O.ai** — Open-source distributed machine learning platform (h2o-3)
- **KNIME** — Open-source data analytics and ML platform with visual workflows
- **Labelbox** — Data labeling and annotation platform for AI/ML training data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable catalog entries for Dataiku, DataRobot, H2O.ai, KNIME, and Labelbox.
  * Included descriptions, links, pricing and licensing details, installation information, and representative use cases for each tool.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->