### PR TITLE
Add libSQL, Prodigy, SQLite to catalog

### DIFF
--- a/tools/data/libsql.yaml
+++ b/tools/data/libsql.yaml
@@ -1,0 +1,37 @@
+name: libSQL
+description: An open-source, open-contribution SQLite fork from Turso that adds vector search, replication, branching, and server-side capabilities. libSQL is compatible with the SQLite file format while extending it with features needed for modern AI applications — vector search, remote replication, read replicas, and a client-server protocol.
+tagline: Open-source SQLite fork with vector search and replication
+
+github_url: https://github.com/tursodatabase/libsql
+website_url: https://turso.tech/libsql
+docs_url: https://docs.turso.tech
+
+install_command: pip install libsql-client
+
+category: Data
+tags:
+  - database
+  - sqlite
+  - vector-search
+  - embedded
+  - serverless
+  - replication
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  SQLite is the world's most deployed database but lacks features critical for AI
+  applications — no vector search for embeddings, no native replication, and no
+  client-server protocol. Building AI features on SQLite requires bolting on vector
+  indexing, replication layers, and custom networking. libSQL extends SQLite with
+  vector search (cosine, Euclidean, dot product), WASM-based user-defined functions,
+  snapshot-based replication, and a standalone server mode while maintaining full
+  SQLite compatibility.
+
+use_cases:
+  - Store and query AI embeddings alongside application data in a single embedded database
+  - Run a local vector database with SQLite compatibility for edge and mobile AI apps
+  - Deploy a replicated database cluster that syncs to on-device SQLite for offline-first AI
+  - Use libSQL as a drop-in replacement for SQLite with added vector search capabilities
+  - Build serverless AI backends with Turso's managed libSQL platform

--- a/tools/data/prodigy.yaml
+++ b/tools/data/prodigy.yaml
@@ -1,0 +1,35 @@
+name: Prodigy
+description: A paid, human-in-the-loop annotation tool by the spaCy team (Explosion) for creating training data for machine learning models. Prodigy provides an active learning workflow where models suggest the most informative examples to annotate next, dramatically reducing the labeled data needed for NER, text classification, image annotation, and LLM fine-tuning.
+tagline: Active learning-powered data annotation by the spaCy team
+
+website_url: https://prodi.gy
+docs_url: https://prodi.gy/docs
+
+category: Data
+tags:
+  - annotation
+  - labeling
+  - active-learning
+  - spaCy
+  - training-data
+  - ner
+  - text-classification
+pricing: paid
+is_open_source: false
+license: Proprietary
+
+problem_solved: |
+  Creating high-quality labeled training data is the most expensive and time-consuming
+  step in building ML models. Traditional annotation tools label randomly, wasting effort
+  on examples the model already handles well. Prodigy uses active learning — the model
+  highlights uncertain predictions, and the annotator labels only those edge cases. This
+  reduces labeled data requirements by 50-80% while improving model quality. Prodigy is
+  built by the spaCy team and integrates deeply with spaCy pipelines, featuring keyboard-first
+  workflows, recipes for 50+ common annotation tasks, and a web-based annotation interface.
+
+use_cases:
+  - Build a custom NER training dataset with active learning to minimize labeled examples needed
+  - Annotate text classification examples by correcting model predictions rather than labeling from scratch
+  - Create training data for LLM fine-tuning by curating high-quality prompt-response pairs
+  - Label image classification data with bounding boxes and relationships for vision models
+  - Rapidly iterate on annotation recipes with live updates and instant model retraining

--- a/tools/data/sqlite.yaml
+++ b/tools/data/sqlite.yaml
@@ -1,0 +1,34 @@
+name: SQLite
+description: The world's most widely deployed database engine — a self-contained, serverless, zero-configuration SQL database engine that is embedded into every smartphone, browser, and operating system. SQLite is the standard embedded database for AI applications, used for model metadata, caching, embeddings, and local data storage in LLM pipelines and agent frameworks.
+tagline: The most deployed database engine in the world
+
+website_url: https://sqlite.org
+docs_url: https://sqlite.org/docs.html
+
+category: Data
+tags:
+  - database
+  - embedded
+  - sql
+  - serverless
+  - zero-config
+  - local-storage
+pricing: free
+is_open_source: true
+license: Public Domain
+
+problem_solved: |
+  AI applications need local, persistent storage for model metadata, conversation history,
+  embedding caches, and configuration — without the overhead of running a database server.
+  Traditional databases require installation, configuration, and a running daemon, which is
+  impractical for embedded and edge AI. SQLite is a self-contained C library that reads and
+  writes directly to a single file on disk with full SQL support, ACID transactions, and no
+  setup. It is the standard embedded database for LLM frameworks (LangChain, LlamaIndex),
+  agent memory, and local-first AI applications.
+
+use_cases:
+  - Store LLM conversation history and agent memory in a zero-config local database
+  - Cache LLM responses and embeddings for offline-first AI applications
+  - Persist model metadata, evaluation results, and configuration in edge deployments
+  - Store and query structured data alongside AI features in embedded systems
+  - Replace flat files and JSON blobs with a proper SQL database for AI pipeline state


### PR DESCRIPTION
Add 3 embedded database and annotation tools to the catalog:

- **libSQL** (16,983★) — Open-source SQLite fork with vector search, replication, and client-server protocol. Built by Turso for modern AI application data. Data category.

- **Prodigy** — Powerful annotation tool by the spaCy team (Explosion) with active learning workflows for NER, text classification, and image annotation. Paid product with recipes repo. Data category.

- **SQLite** — The world's most deployed database engine. Self-contained, serverless, zero-config SQL database used by LLM frameworks (LangChain, LlamaIndex), agent memory, and local-first AI. Data category.
