### PR TITLE
Add Google AI Studio, SciPy, Matplotlib to catalog

### DIFF
--- a/tools/data/matplotlib.yaml
+++ b/tools/data/matplotlib.yaml
@@ -1,0 +1,23 @@
+name: Matplotlib
+description: A comprehensive Python plotting library for creating static, animated, and interactive visualizations with publication-quality output. It supports a wide range of plot types including line plots, scatter plots, bar charts, histograms, heatmaps, 3D plots, and custom composite figures for data analysis and machine learning model evaluation.
+tagline: Comprehensive Python plotting library for publication-quality visualizations
+
+github_url: https://github.com/matplotlib/matplotlib
+website_url: https://matplotlib.org
+docs_url: https://matplotlib.org/stable
+
+category: Data
+tags: [visualization, plotting, data-science, python, charts, graphs, dashboards]
+pricing: free
+is_open_source: true
+install_command: pip install matplotlib
+
+problem_solved: |
+  Data scientists and ML engineers need to generate visualizations for exploratory data analysis, model evaluation, and result communication — but building custom plots from scratch with low-level graphics libraries is time-consuming and produces inconsistent results. Matplotlib provides a complete plotting framework with a MATLAB-like API that can produce line plots, scatter plots, histograms, heatmaps, contour plots, 3D visualizations, and multi-panel figures with fine-grained control over every visual element for publication-ready output.
+
+use_cases:
+  - Plot training and validation loss curves to diagnose model convergence, overfitting, and learning rate effects
+  - Create confusion matrices, ROC curves, and precision-recall curves for classifier evaluation and model comparison
+  - Visualize high-dimensional data with scatter matrices and projection plots for exploratory data analysis
+  - Generate publication-quality figures with custom color schemes, annotations, and multi-panel layouts for research papers
+  - Build animated visualizations of model training progress, optimization landscapes, and time-series predictions

--- a/tools/data/scipy.yaml
+++ b/tools/data/scipy.yaml
@@ -1,0 +1,24 @@
+name: SciPy
+description: A foundational Python library for scientific computing built on NumPy, providing modules for optimization, linear algebra, integration, interpolation, signal and image processing, clustering, spatial algorithms, and statistical analysis for data science and machine learning pipelines.
+tagline: Fundamental scientific computing library for Python
+
+github_url: https://github.com/scipy/scipy
+website_url: https://scipy.org
+docs_url: https://docs.scipy.org/doc/scipy
+
+category: Data
+tags: [scientific-computing, optimization, linear-algebra, statistics, signal-processing, python, numerical-computing]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+install_command: pip install scipy
+
+problem_solved: |
+  Scientific and machine learning workflows in Python require robust implementations of optimization algorithms, statistical tests, signal processing, spatial analysis, and numerical integration — functionality that is too complex and error-prone to implement from scratch for each project. SciPy provides a comprehensive collection of battle-tested algorithms for scientific computing, from linear algebra and integration to clustering and signal processing, built on NumPy arrays and optimized for performance with compiled C and Fortran backends.
+
+use_cases:
+  - Optimize machine learning model hyperparameters using SciPy's optimization and minimization routines
+  - Compute statistical significance tests, confidence intervals, and probability distributions for A/B testing and experiment analysis
+  - Process sensor and time-series data with signal filtering, spectral analysis, and Fourier transforms
+  - Perform hierarchical and k-means clustering for exploratory data analysis and feature engineering
+  - Solve differential equations and perform numerical integration for physics-informed neural networks and scientific ML pipelines

--- a/tools/dev-tools/google-ai-studio.yaml
+++ b/tools/dev-tools/google-ai-studio.yaml
@@ -1,0 +1,21 @@
+name: Google AI Studio
+description: A browser-based integrated development environment from Google for prototyping and experimenting with Gemini AI models. It provides a visual interface for prompt design, model tuning, API key management, and rapid iteration with Gemini's multimodal, code generation, and reasoning capabilities.
+tagline: Browser-based IDE for prototyping with Google Gemini models
+
+website_url: https://ai.google.dev/aistudio
+docs_url: https://ai.google.dev/docs
+
+category: Dev Tools
+tags: [google-gemini, prompt-engineering, prototyping, llm, ide, ai-development]
+pricing: free
+is_open_source: false
+
+problem_solved: |
+  Developers exploring Gemini models face friction setting up API clients, managing API keys, and iterating on prompts — each code change requires re-running a script in a terminal. Google AI Studio eliminates this friction by providing a browser-based playground where developers can test prompts, compare model responses, adjust parameters like temperature and top-k, save prompt templates, generate API code snippets, and manage API keys — all without writing a single line of infrastructure code.
+
+use_cases:
+  - Prototype and iterate on Gemini prompts with a visual editor that shows model responses in real-time
+  - Compare outputs across Gemini versions (Pro, Flash, Ultra) with different temperature and safety settings
+  - Generate ready-to-use Python, JavaScript, and cURL code snippets for prompts you've refined in the playground
+  - Manage Gemini API keys, usage quotas, and billing from a single dashboard without setting up Google Cloud Console
+  - Test multimodal prompts combining text, images, audio, and video to evaluate Gemini's reasoning capabilities


### PR DESCRIPTION
This PR adds 3 new tools to the catalog:

- **Google AI Studio** (Dev Tools) — Browser-based IDE from Google for prototyping with Gemini AI models
- **SciPy** (Data) — Foundational scientific computing library for Python (14,840★)
- **Matplotlib** (Data) — Comprehensive Python plotting library for publication-quality visualizations (23,029★)

All files validated with `scripts/validate-tool.ts` — ✅ all valid.
