### PR TITLE
Add Docker, Kubernetes, Tableau, Power BI, Domino Data Lab to catalog

### DIFF
--- a/tools/data/domino-data-lab.yaml
+++ b/tools/data/domino-data-lab.yaml
@@ -1,0 +1,22 @@
+name: Domino Data Lab
+description: Enterprise MLOps platform for building, deploying, and managing data science and machine learning workloads at scale. Domino provides a unified environment for collaborative data science, reproducible research, model deployment, and governance across the AI lifecycle.
+tagline: Enterprise MLOps platform for collaborative data science and model management
+
+website_url: https://www.dominodatalab.com
+docs_url: https://docs.dominodatalab.com
+install_command: pip install dominodatalab
+
+category: Data
+tags: [mlops, data-science, machine-learning, model-deployment, collaboration, enterprise]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Enterprise data science teams struggle with fragmented toolchains, inconsistent environments, and limited collaboration mechanisms that slow model development and prevent reproducibility. Domino Data Lab solves this by providing a centralized platform where data scientists can develop models in reproducible environments (R, Python, Julia), collaborate with version-controlled code and data, deploy models as APIs with one click, and manage the full model lifecycle with governance and audit trails — all within enterprise security requirements.
+
+use_cases:
+  - Provide data scientists with pre-configured, reproducible compute environments with GPUs, ensuring models train identically across team members
+  - Deploy models as REST APIs, batch jobs, or scheduled pipelines with automated scaling and version management
+  - Track experiment history, model versions, and dataset lineage for compliance and reproducibility in regulated industries
+  - Enable team collaboration with shared workspaces, code reviews, and project-level access controls for enterprise AI initiatives
+  - Automate MLOps workflows with CI/CD pipelines, model monitoring, and automated retraining triggers

--- a/tools/data/power-bi.yaml
+++ b/tools/data/power-bi.yaml
@@ -1,0 +1,22 @@
+name: Power BI
+description: Microsoft's enterprise business analytics platform for visualizing data, building interactive dashboards, and sharing insights across organizations. Power BI integrates deeply with Azure, Office 365, and hundreds of data sources to provide AI-powered analytics at scale.
+tagline: Enterprise data visualization and business intelligence from Microsoft
+
+website_url: https://powerbi.microsoft.com
+docs_url: https://learn.microsoft.com/power-bi
+install_command: pip install powerbiclient
+
+category: Data
+tags: [business-intelligence, data-visualization, analytics, dashboards, microsoft, reporting]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Business users and data teams often work with siloed tools for reporting, dashboards, and ad-hoc analysis, making it hard to get a unified view of business performance and AI system outputs. Power BI solves this by providing a single platform that connects to hundreds of data sources, transforms data with Power Query, and creates interactive dashboards with AI-powered visuals, natural language queries, and mobile-ready reports — all within an organization's existing Microsoft ecosystem.
+
+use_cases:
+  - Build executive dashboards that combine ML model outputs, business metrics, and operational data into a single pane of glass
+  - Enable natural-language querying of AI model performance data using Power BI's Q&A feature for non-technical stakeholders
+  - Schedule automated refresh of dashboards that track data pipeline health, feature store usage, and model drift alerts
+  - Embed analytics into custom AI applications using Power BI Embedded to provide end-user reporting
+  - Analyze A/B test results and experiment outcomes with interactive filters, drill-downs, and custom visualizations

--- a/tools/data/tableau.yaml
+++ b/tools/data/tableau.yaml
@@ -1,0 +1,22 @@
+name: Tableau
+description: Enterprise analytics and business intelligence platform for visualizing, exploring, and sharing data insights with interactive dashboards. Tableau connects to hundreds of data sources and enables self-service analytics for data-driven decision-making across organizations.
+tagline: Visual analytics and business intelligence platform for data-driven organizations
+
+website_url: https://www.tableau.com
+docs_url: https://help.tableau.com
+install_command: pip install tableauserverclient
+
+category: Data
+tags: [business-intelligence, data-visualization, analytics, dashboards, reporting, enterprise]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Organizations generate massive amounts of data but struggle to turn it into actionable insights because traditional reporting tools are slow and require heavy IT involvement. Tableau solves this by enabling anyone to connect to data, create interactive visualizations, and build dashboards with drag-and-drop simplicity. Its live query engine and in-memory data engine deliver fast exploration without requiring pre-built aggregates or complex ETL pipelines.
+
+use_cases:
+  - Build executive dashboards that track ML model performance metrics, data drift, and business KPIs in real time
+  - Enable self-service analytics so data scientists and business analysts can explore training data distributions and feature correlations
+  - Create operational dashboards for monitoring AI pipeline health, resource utilization, and deployment metrics
+  - Publish and share interactive data stories that communicate model behavior and business impact to non-technical stakeholders
+  - Embed analytics into AI applications to provide end-users with transparent visualization of model inputs and outputs

--- a/tools/dev-tools/docker.yaml
+++ b/tools/dev-tools/docker.yaml
@@ -1,0 +1,24 @@
+name: Docker
+description: Industry-standard containerization platform for packaging, distributing, and running applications in isolated environments. Docker ensures consistency across development, testing, and production — making it the backbone of modern AI/ML infrastructure for reproducible model training and deployment.
+tagline: Build, share, and run containerized applications anywhere
+
+github_url: https://github.com/moby/moby
+website_url: https://www.docker.com
+docs_url: https://docs.docker.com
+install_command: pip install docker
+
+category: Dev Tools
+tags: [containers, devops, infrastructure, deployment, virtualization, ci-cd]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI and ML teams face persistent environment reproducibility issues — models that train on one machine fail on another due to dependency mismatches, OS differences, or library version conflicts. Docker solves this by packaging applications with all their dependencies into lightweight, portable containers that run identically on any system, from a developer's laptop to a production Kubernetes cluster. This eliminates "it works on my machine" problems and enables reliable CI/CD pipelines for ML systems.
+
+use_cases:
+  - Containerize ML training environments with pinned dependencies for reproducible experiments across team members
+  - Package model serving APIs into portable containers for consistent deployment across staging, production, and edge
+  - Run isolated development environments for data science notebooks, databases, and vector stores without local installation
+  - Build multi-stage CI/CD pipelines that test, build, and push container images for automated ML workflows
+  - Orchestrate complex microservice-based AI applications combining model servers, caches, and data pipelines

--- a/tools/dev-tools/kubernetes.yaml
+++ b/tools/dev-tools/kubernetes.yaml
@@ -1,0 +1,24 @@
+name: Kubernetes
+description: Production-grade container orchestration platform for automating deployment, scaling, and management of containerized applications. Kubernetes provides the scheduling, service discovery, and self-healing infrastructure that powers large-scale AI/ML workloads across clusters of machines.
+tagline: Automate container deployment, scaling, and operations at scale
+
+github_url: https://github.com/kubernetes/kubernetes
+website_url: https://kubernetes.io
+docs_url: https://kubernetes.io/docs
+install_command: pip install kubernetes
+
+category: Dev Tools
+tags: [container-orchestration, devops, infrastructure, scaling, cloud-native, mlops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Running AI/ML workloads at scale requires managing hundreds of interdependent containers across multiple machines — handling scheduling, resource allocation, load balancing, failover, and rolling updates manually is impractical. Kubernetes solves this by providing a declarative orchestration layer that automatically schedules containers onto cluster nodes, scales services up or down based on demand, restarts failed containers, and manages rollouts without downtime. It has become the de-facto standard for deploying production ML systems.
+
+use_cases:
+  - Deploy and scale model serving infrastructure across multiple nodes with automatic load balancing and failover
+  - Orchestrate distributed training jobs that span multiple GPUs and machines using custom resource definitions and job scheduling
+  - Manage ML platform microservices — model registries, feature stores, vector databases, and monitoring stacks — as a unified deployment
+  - Implement canary deployments and A/B testing for model versions with traffic splitting and gradual rollouts
+  - Run batch inference pipelines as Kubernetes Jobs with automated retry, resource limits, and parallel execution


### PR DESCRIPTION
Add Docker, Kubernetes, Tableau, Power BI, and Domino Data Lab to the Agentic AI For Good tool catalog.

**New tools:**
- **Docker** (Dev Tools) — Industry-standard containerization platform for reproducible AI/ML environments and deployment. 71,892★ OSS.
- **Kubernetes** (Dev Tools) — Production-grade container orchestration for scaling AI/ML workloads. 123,899★ OSS.
- **Tableau** (Data) — Enterprise analytics and business intelligence platform for data visualization and dashboards.
- **Power BI** (Data) — Microsoft's enterprise business analytics platform for interactive dashboards and AI-powered insights.
- **Domino Data Lab** (Data) — Enterprise MLOps platform for collaborative data science and model management.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added directory entries for Domino Data Lab, Power BI, Tableau, Docker, and Kubernetes.
  * Included descriptions, documentation links, installation details, pricing, licensing, tags, and categorized use cases.
  * Added AI/ML-focused use cases covering analytics, dashboards, model serving, containerized workflows, and deployment pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->