### PR TITLE
Add Flask, Koog, Kibana, Logstash, Terraform to catalog

### DIFF
--- a/tools/data/logstash.yaml
+++ b/tools/data/logstash.yaml
@@ -1,0 +1,24 @@
+name: Logstash
+description: Server-side data processing pipeline from Elastic that ingests, transforms, and ships data from multiple sources simultaneously. Logstash enables collecting logs, metrics, and application data from AI systems and routing them to Elasticsearch for analysis and visualization.
+tagline: Ingest, transform, and ship data to Elasticsearch and beyond
+
+github_url: https://github.com/elastic/logstash
+website_url: https://www.elastic.co/logstash
+docs_url: https://www.elastic.co/guide/en/logstash/current
+install_command: brew install logstash
+
+category: Data
+tags: [data-ingestion, etl, log-processing, data-pipeline, elastic, observability]
+pricing: free
+is_open_source: true
+license: Elastic-2.0
+
+problem_solved: |
+  AI systems generate massive amounts of log data from model servers, training jobs, data pipelines, and monitoring agents — but collecting, parsing, and routing this data to storage and analysis tools requires custom integration work for each source. Logstash solves this by providing a pluggable pipeline architecture with hundreds of input, filter, and output plugins that can ingest data from files, TCP/UDP, Kafka, and cloud services, transform it with grok patterns and enrichment, and ship it to Elasticsearch or dozens of other destinations.
+
+use_cases:
+  - Collect and parse application logs from ML model serving endpoints for performance monitoring and debugging
+  - Ingest training job metrics from distributed training frameworks and route them to visualization platforms
+  - Transform and enrich raw log data from AI pipeline components before storage in Elasticsearch or data lakes
+  - Aggregate monitoring data from multiple model deployment environments into a centralized observability platform
+  - Build real-time data pipelines that feed processed logs into alerting and anomaly detection systems

--- a/tools/dev-tools/flask.yaml
+++ b/tools/dev-tools/flask.yaml
@@ -1,0 +1,24 @@
+name: Flask
+description: Lightweight Python web framework designed for quick development of web APIs and applications. Flask's minimal core and extensive ecosystem of extensions make it the most widely used framework for wrapping ML models, providing inference endpoints, and building AI service backends.
+tagline: Lightweight Python web framework for APIs and web applications
+
+github_url: https://github.com/pallets/flask
+website_url: https://flask.palletsprojects.com
+docs_url: https://flask.palletsprojects.com
+install_command: pip install flask
+
+category: Dev Tools
+tags: [python, web-framework, api, backend, microservices, model-serving]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  AI/ML engineers often need to expose trained models as web APIs so applications, dashboards, and other services can use them — but building a full web framework from scratch is time-consuming and error-prone. Flask solves this by providing a simple, well-documented Python web framework that can wrap a model inference function into a REST endpoint in under 50 lines of code, with built-in development server, request routing, and support for popular extensions covering authentication, databases, and async processing.
+
+use_cases:
+  - Wrap ML model inference into REST APIs for serving predictions to web and mobile applications
+  - Build lightweight internal dashboards and data exploration tools with minimal front-end overhead
+  - Create webhook endpoints for triggering AI pipeline steps and model retraining jobs
+  - Develop prototype applications and proof-of-concept demos that demonstrate model capabilities
+  - Serve as the application backbone for small-to-medium data science tools with SQLAlchemy and other ORM extensions

--- a/tools/dev-tools/koog.yaml
+++ b/tools/dev-tools/koog.yaml
@@ -1,0 +1,23 @@
+name: Koog
+description: JVM framework from JetBrains for building predictable, fault-tolerant, enterprise-ready AI agents across platforms including backend services, Android, iOS, and browser environments. Koog provides proven patterns for complex LLM and AI problems based on JetBrains' AI product expertise.
+tagline: JetBrains' JVM framework for building production AI agents
+
+github_url: https://github.com/JetBrains/koog
+website_url: https://koog.ai
+docs_url: https://github.com/JetBrains/koog
+
+category: Dev Tools
+tags: [jvm, kotlin, java, ai-agents, llm, enterprise, jetbrains, framework]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building production-grade AI agents on the JVM requires handling complex challenges like tool calling, conversation management, agent orchestration, and fault tolerance — all while integrating with existing Java and Kotlin enterprise codebases. Koog solves this by providing a structured Kotlin-first framework with type-safe DSLs for agent definitions, built-in LLM provider abstractions, conversation memory management, and platform targets ranging from Android and iOS to backend services and browser environments.
+
+use_cases:
+  - Build Kotlin-native AI agents with type-safe DSLs for tool definitions, conversation flows, and multi-agent orchestration
+  - Integrate LLM capabilities into existing JVM enterprise applications with Kotlin coroutines for async agent execution
+  - Deploy AI agents on Android and iOS platforms using Kotlin Multiplatform compilation targets
+  - Create server-side agent services with structured prompt management, retry logic, and observability hooks
+  - Develop fault-tolerant agent pipelines with built-in conversation persistence and error recovery patterns

--- a/tools/dev-tools/terraform.yaml
+++ b/tools/dev-tools/terraform.yaml
@@ -1,0 +1,23 @@
+name: Terraform
+description: Infrastructure-as-Code platform by HashiCorp for provisioning and managing cloud and on-premises resources. Terraform enables AI and ML teams to define GPU clusters, data pipelines, model serving infrastructure, and networking as declarative configuration that is version-controlled, repeatable, and auditable.
+tagline: Provision and manage infrastructure as declarative code
+
+github_url: https://github.com/hashicorp/terraform
+website_url: https://www.terraform.io
+docs_url: https://developer.hashicorp.com/terraform/docs
+
+category: Dev Tools
+tags: [infrastructure-as-code, cloud, devops, automation, provisioning, mlops]
+pricing: freemium
+is_open_source: true
+license: BUSL-1.1
+
+problem_solved: |
+  Setting up AI/ML infrastructure — GPU clusters, vector databases, model serving endpoints, data pipelines — requires manual cloud console steps that are error-prone, unrepeatable, and hard to audit. Terraform solves this by letting teams define their entire infrastructure as declarative configuration files that can be version-controlled, peer-reviewed, and automatically applied across clouds, ensuring that training environments, deployment targets, and supporting services are always provisioned consistently and reproducibly.
+
+use_cases:
+  - Provision GPU compute clusters with attached storage, networking, and IAM policies for distributed ML training
+  - Deploy and manage vector databases, model registries, and feature stores as infrastructure with automated scaling
+  - Create reproducible environments for ML experimentation with consistent cloud resource configurations
+  - Manage multi-cloud AI infrastructure spanning AWS, GCP, and Azure from a single declarative configuration
+  - Automate deployment of model serving infrastructure with load balancers, auto-scaling groups, and monitoring

--- a/tools/other/kibana.yaml
+++ b/tools/other/kibana.yaml
@@ -1,0 +1,23 @@
+name: Kibana
+description: Data visualization and exploration platform for Elasticsearch that enables building interactive dashboards, charts, and graphs for log analytics, monitoring, and ML observability. Kibana provides the visual layer for the Elastic Stack with search, aggregation, and alerting capabilities.
+tagline: Visualize and explore Elasticsearch data with interactive dashboards
+
+github_url: https://github.com/elastic/kibana
+website_url: https://www.elastic.co/kibana
+docs_url: https://www.elastic.co/guide/en/kibana/current
+
+category: Other
+tags: [data-visualization, dashboards, monitoring, observability, logging, analytics, elastic]
+pricing: free
+is_open_source: true
+license: Elastic-2.0
+
+problem_solved: |
+  Teams running AI systems need to visualize logs, metrics, and model performance data to understand system behavior and troubleshoot issues, but raw Elasticsearch queries require deep technical knowledge. Kibana solves this by providing an intuitive visualization interface where users can build dashboards with charts, maps, and graphs from Elasticsearch data without writing complex queries, enabling real-time monitoring of AI application health and performance.
+
+use_cases:
+  - Build dashboards that visualize ML model inference latency, error rates, and throughput across deployment environments
+  - Explore and analyze log data from AI pipeline components to debug failures and identify performance bottlenecks
+  - Create alerting rules that trigger when model performance metrics deviate from expected ranges
+  - Monitor distributed AI system health with unified views across training, serving, and data pipeline stages
+  - Use machine learning features within Kibana to detect anomalies in time-series application metrics automatically


### PR DESCRIPTION
Add Flask, Koog, Kibana, Logstash, and Terraform to the Agentic AI For Good tool catalog.

**New tools:**
- **Flask** (Dev Tools) — Lightweight Python web framework, the standard for wrapping ML models as APIs. 72,000★ OSS.
- **Koog** (Dev Tools) — JetBrains' JVM framework for building enterprise AI agents in Kotlin/Java. 4,471★ OSS.
- **Kibana** (Other) — Elastic's data visualization platform for monitoring AI system health and performance. 21,210★ OSS.
- **Logstash** (Data) — Elastic's server-side data processing pipeline for ingesting and transforming AI system logs. 14,906★ OSS.
- **Terraform** (Dev Tools) — HashiCorp's Infrastructure-as-Code platform for provisioning AI/ML infrastructure. 49,262★ OSS.
