### PR TITLE
Add Helm, gRPC to catalog

### DIFF
--- a/tools/dev-tools/grpc.yaml
+++ b/tools/dev-tools/grpc.yaml
@@ -1,0 +1,24 @@
+name: gRPC
+description: High-performance remote procedure call framework by Google that enables efficient communication between services using HTTP/2, Protocol Buffers, and bidirectional streaming. gRPC is the standard transport layer for production ML model serving, enabling low-latency inference at scale.
+tagline: High-performance RPC framework for microservices and model serving
+
+github_url: https://github.com/grpc/grpc
+website_url: https://grpc.io
+docs_url: https://grpc.io/docs
+install_command: pip install grpcio
+
+category: Dev Tools
+tags: [rpc, protocol-buffers, microservices, api, model-serving, http2, streaming]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Serving ML model predictions to production applications requires a transport protocol that balances latency, throughput, and type safety — traditional REST/JSON often adds parsing overhead and lacks built-in streaming for real-time use cases. gRPC solves this by using Protocol Buffers for strongly-typed schema definition and HTTP/2 for multiplexed, bidirectional streaming, enabling clients to send inference requests and receive streaming responses with lower latency and higher throughput than REST, while automatically generating client libraries in 11+ languages from a single .proto file.
+
+use_cases:
+  - Serve ML model predictions via gRPC endpoints with Protocol Buffer schemas for type-safe, low-latency inference
+  - Enable bidirectional streaming for real-time AI applications like speech recognition, video analysis, and chatbot conversations
+  - Generate multi-language client libraries from a single proto definition, enabling model consumption from Python, Go, Java, and more
+  - Implement server-side streaming for batch inference results and model health monitoring telemetry
+  - Build microservice-based AI pipelines where gRPC provides efficient service-to-service communication with deadline propagation and load balancing

--- a/tools/dev-tools/helm.yaml
+++ b/tools/dev-tools/helm.yaml
@@ -1,0 +1,24 @@
+name: Helm
+description: Kubernetes package manager for defining, installing, and upgrading complex Kubernetes applications. Helm charts encapsulate AI/ML deployment configurations — including model servers, vector databases, and monitoring stacks — into reusable, versioned packages that can be deployed with a single command.
+tagline: The package manager for Kubernetes
+
+github_url: https://github.com/helm/helm
+website_url: https://helm.sh
+docs_url: https://helm.sh/docs
+install_command: brew install helm
+
+category: Dev Tools
+tags: [kubernetes, package-manager, devops, deployment, charts, infrastructure, mlops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Deploying complex AI/ML applications on Kubernetes involves managing dozens of interrelated resources — deployments, services, config maps, secrets, persistent volumes, and ingress rules — making manual management error-prone and hard to reproduce. Helm solves this by packaging Kubernetes resources into reusable charts with templated configuration, dependency management, and versioned releases, enabling teams to deploy a complete ML inference stack or a vector database cluster with a single helm install command and upgrade it predictably over time.
+
+use_cases:
+  - Deploy and upgrade complex ML inference stacks on Kubernetes with single-command helm install and rollback
+  - Package model serving configurations with Prometheus monitoring, GPU resource limits, and horizontal pod autoscaling as reusable charts
+  - Install vector databases, feature stores, and model registries from public Helm chart repositories with reproducible configurations
+  - Manage dependencies between AI infrastructure components — database, cache, model server, monitoring — as a unified Helm release
+  - Version-control AI deployment configurations using Chart.yaml, values files, and release history for audit and rollback


### PR DESCRIPTION
Add Helm and gRPC to the Agentic AI For Good tool catalog.

**New tools:**
- **Helm** (Dev Tools) — The Kubernetes package manager for deploying and managing AI/ML application configurations. 30,026★ OSS.
- **gRPC** (Dev Tools) — Google's high-performance RPC framework, the standard transport for production model serving. 45,201★ OSS.
