### PR TITLE
Add GitHub Actions, Google BigQuery, Bazel, Ansible, HashiCorp Vault to catalog

### DIFF
--- a/tools/data/google-bigquery.yaml
+++ b/tools/data/google-bigquery.yaml
@@ -1,0 +1,28 @@
+name: Google BigQuery
+description: Google Cloud's serverless, highly scalable data warehouse with built-in ML capabilities (BigQuery ML) that lets you train and run models using SQL queries on petabyte-scale datasets.
+tagline: Serverless data warehouse with built-in machine learning
+website_url: https://cloud.google.com/bigquery
+docs_url: https://cloud.google.com/bigquery/docs
+
+category: Data
+tags: [data-warehouse, analytics, sql, big-data, google-cloud, serverless]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Training ML models on large datasets traditionally requires moving data out of
+  a data warehouse into a separate ML environment, incurring ETL costs and latency.
+  BigQuery ML eliminates this by supporting model training directly in SQL — CREATE
+  MODEL statements that train linear regression, logistic regression, matrix
+  factorization, time series, and imported TensorFlow models without data export.
+  Combined with BigQuery's serverless architecture, analysts can train models on
+  terabytes of data using familiar SQL syntax, and data scientists can query
+  feature stores and inference results without managing infrastructure.
+
+use_cases:
+  - Train ML models directly on petabyte-scale data using SQL without data movement
+  - Build and serve real-time ML inference pipelines using BigQuery ML models
+  - Analyze feature distributions and perform exploratory data analysis on large datasets
+  - Create materialized feature views for training and serving in production ML systems
+
+install_command: pip install google-cloud-bigquery

--- a/tools/dev-tools/ansible.yaml
+++ b/tools/dev-tools/ansible.yaml
@@ -1,0 +1,29 @@
+name: Ansible
+description: Red Hat's open-source IT automation platform for configuration management, application deployment, and infrastructure provisioning — widely used to orchestrate ML infrastructure at scale.
+tagline: Simple, agentless IT automation for ML infrastructure
+github_url: https://github.com/ansible/ansible
+docs_url: https://docs.ansible.com
+
+category: Dev Tools
+tags: [automation, configuration-management, devops, infrastructure, orchestration]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Managing ML infrastructure — GPU servers, model serving clusters, data pipelines,
+  and experiment tracking environments — requires consistent, repeatable configuration
+  across potentially hundreds of machines. Ansible provides agentless automation using
+  SSH and YAML playbooks, making it easy to provision GPU drivers, configure CUDA
+  libraries, deploy ML serving containers, and manage experiment tracking
+  infrastructure without installing agents on target hosts. Its push-based model
+  and idempotent operations make it ideal for teams that need infrastructure
+  reproducibility but aren't ready for full Kubernetes adoption.
+
+use_cases:
+  - Provision GPU servers with CUDA, cuDNN, NCCL, and container runtimes for ML training
+  - Deploy and configure ML serving infrastructure (Triton, MLflow, BentoML) across clusters
+  - Automate experiment tracking environment setup with W&B, MLflow, or Neptune agents
+  - Manage multi-node Ray clusters for distributed training and hyperparameter tuning
+
+install_command: pip install ansible

--- a/tools/dev-tools/bazel.yaml
+++ b/tools/dev-tools/bazel.yaml
@@ -1,0 +1,28 @@
+name: Bazel
+description: Google's fast, scalable build system that supports multi-language monorepos with hermetic builds, incremental compilation, and remote caching — used by TensorFlow, PyTorch, and major ML frameworks.
+tagline: Fast, correct builds for monorepos and ML frameworks
+github_url: https://github.com/bazelbuild/bazel
+docs_url: https://bazel.build
+
+category: Dev Tools
+tags: [build-system, compilation, monorepo, tensorflow, pytorch, automation]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Large ML codebases spanning Python, C++, CUDA, and protobuf definitions need a
+  build system that can handle cross-language dependencies, GPU-specific compilation,
+  and massive monorepos without full rebuilds. Bazel provides hermetic, reproducible
+  builds with automatic dependency tracking, remote caching, and distributed execution.
+  TensorFlow, PyTorch, and JAX all use Bazel to manage their complex build graphs
+  spanning CPU/GPU/TPU backends. Without it, ML teams resort to fragile Makefiles or
+  lose days to incremental build breaks in multi-language projects.
+
+use_cases:
+  - Build TensorFlow, PyTorch, or JAX from source with custom hardware backends
+  - Manage cross-language monorepos with Python, C++, CUDA, and protocol buffers
+  - Leverage remote build caching to accelerate CI pipelines for ML framework development
+  - Create hermetic, reproducible builds for ML model serving binaries
+
+install_command: npm install -g @bazel/bazelisk

--- a/tools/dev-tools/github-actions.yaml
+++ b/tools/dev-tools/github-actions.yaml
@@ -1,0 +1,25 @@
+name: GitHub Actions
+description: GitHub's built-in CI/CD and automation platform that lets you build, test, and deploy ML models directly from your GitHub repositories using YAML-based workflow files.
+tagline: CI/CD and automation natively integrated with GitHub
+website_url: https://github.com/features/actions
+docs_url: https://docs.github.com/en/actions
+
+category: Dev Tools
+tags: [ci-cd, automation, devops, testing, deployment, github]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  ML teams need automated pipelines to train, test, and deploy models every time
+  code changes, but setting up separate CI infrastructure requires managing runners,
+  secrets, and integrations. GitHub Actions provides event-driven workflows that run
+  directly in your GitHub repository — triggered on push, PR, schedule, or any webhook.
+  With built-in matrix testing, GPU runners for model training, artifact storage for
+  model checkpoints, and 20,000+ community actions for ML-specific tasks (setup Python,
+  deploy to Hugging Face, run DVC), it eliminates the need for an external CI system.
+
+use_cases:
+  - Automate model training, evaluation, and deployment workflows triggered by code pushes
+  - Run matrix tests across Python versions, dependencies, and model configurations in parallel
+  - Schedule nightly regression tests for model accuracy and data drift detection
+  - Deploy model artifacts to Hugging Face Hub, cloud storage, or container registries on release

--- a/tools/dev-tools/hashicorp-vault.yaml
+++ b/tools/dev-tools/hashicorp-vault.yaml
@@ -1,0 +1,27 @@
+name: HashiCorp Vault
+description: A secrets management platform that securely stores, controls access to, and rotates API keys, database credentials, and TLS certificates for ML pipelines and model serving infrastructure.
+tagline: Secrets management and encryption for ML infrastructure
+github_url: https://github.com/hashicorp/vault
+docs_url: https://developer.hashicorp.com/vault/docs
+
+category: Dev Tools
+tags: [security, secrets-management, encryption, devops, infrastructure]
+pricing: freemium
+is_open_source: true
+license: BUSL-1.1
+
+problem_solved: |
+  ML pipelines and model serving systems require access to numerous secrets — API
+  keys for LLM providers, database credentials for feature stores, model registry
+  tokens, and cloud storage keys — each posing a security risk if leaked in code,
+  logs, or environment variables. Vault centralizes secrets management with dynamic
+  credentials (short-lived tokens), automatic rotation, audit logging, and fine-grained
+  access policies. ML teams use Vault to inject ephemeral credentials into training
+  jobs, model serving containers, and CI/CD pipelines without hardcoding secrets
+  in configuration files or worrying about credential expiry.
+
+use_cases:
+  - Securely inject API keys for LLM providers (OpenAI, Anthropic) into training and inference pipelines
+  - Manage short-lived database credentials for feature stores and model registries
+  - Store and rotate TLS certificates for model serving endpoints and ML infrastructure
+  - Audit all credential access across ML pipelines with detailed audit logs


### PR DESCRIPTION
Add 5 tools to the Agentic AI For Good catalog:

- **GitHub Actions** — GitHub's built-in CI/CD and automation platform for ML pipeline workflows
- **Google BigQuery** — Google Cloud's serverless data warehouse with built-in ML (BigQuery ML)
- **Bazel** — Google's fast, hermetic build system used by TensorFlow and PyTorch (25.7k★, bazelbuild/bazel)
- **Ansible** — Red Hat's agentless IT automation platform for ML infrastructure provisioning (69.7k★, ansible/ansible)
- **HashiCorp Vault** — Secrets management platform for ML pipeline credentials and API keys (36k★, hashicorp/vault)
