### PR TITLE
Add NGINX, Apache Hive, Pulumi to catalog

### DIFF
--- a/tools/data/apache-hive.yaml
+++ b/tools/data/apache-hive.yaml
@@ -1,0 +1,27 @@
+name: Apache Hive
+description: A distributed data warehouse infrastructure built on Hadoop that provides SQL-like querying (HiveQL) for petabyte-scale datasets used in ML feature engineering and analytics.
+tagline: SQL-on-Hadoop data warehouse for big data analytics
+github_url: https://github.com/apache/hive
+website_url: https://hive.apache.org
+docs_url: https://cwiki.apache.org/confluence/display/Hive
+
+category: Data
+tags: [data-warehouse, sql, big-data, hadoop, apache, analytics]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  ML feature engineering on petabyte-scale clickstream, log, and behavioral data
+  requires SQL-like query capabilities that traditional databases cannot handle.
+  Hive translates SQL queries into MapReduce, Tez, or Spark jobs that run across
+  Hadoop clusters, enabling data scientists to extract, aggregate, and transform
+  massive datasets using familiar SQL syntax. Its ACID support, partition pruning,
+  and ORC/Parquet columnar storage make it practical for building training datasets
+  and feature tables from web-scale event data without custom MapReduce code.
+
+use_cases:
+  - Extract and aggregate training datasets from petabyte-scale clickstream and log data
+  - Build feature tables for ML models using SQL transformations on Hadoop clusters
+  - Run ad-hoc analytical queries on large-scale behavioral datasets for feature discovery
+  - Create partitioned, columnar-format training data for distributed ML training jobs

--- a/tools/dev-tools/nginx.yaml
+++ b/tools/dev-tools/nginx.yaml
@@ -1,0 +1,30 @@
+name: NGINX
+description: A high-performance HTTP server, reverse proxy, load balancer, and API gateway widely used to serve and scale ML model inference endpoints in production.
+tagline: High-performance web server and reverse proxy
+github_url: https://github.com/nginx/nginx
+website_url: https://nginx.org
+docs_url: https://nginx.org/en/docs
+
+category: Dev Tools
+tags: [web-server, reverse-proxy, load-balancing, api-gateway, model-serving, infrastructure]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+problem_solved: |
+  ML model serving endpoints need a production-grade HTTP layer that handles TLS
+  termination, request routing, load balancing across model replicas, rate limiting
+  to prevent abuse, and access logging — all without adding latency. NGINX provides
+  an event-driven, non-blocking architecture that can handle tens of thousands of
+  concurrent inference requests on a single machine, route requests to different
+  model versions by URL path, and cache responses for stateless models. ML teams
+  commonly deploy NGINX in front of Triton Inference Server, TorchServe, or custom
+  FastAPI/Flask serving endpoints.
+
+use_cases:
+  - Load balance inference requests across multiple model server replicas for high availability
+  - Route requests to different model versions or serving backends by URL path
+  - Terminate TLS and add rate limiting to protect model serving endpoints from abuse
+  - Cache inference responses for stateless models to reduce serving latency
+
+install_command: brew install nginx

--- a/tools/dev-tools/pulumi.yaml
+++ b/tools/dev-tools/pulumi.yaml
@@ -1,0 +1,30 @@
+name: Pulumi
+description: An infrastructure-as-code platform that lets ML teams define cloud infrastructure — GPU clusters, model serving endpoints, data pipelines — using familiar programming languages like Python, TypeScript, and Go.
+tagline: Infrastructure as code in real programming languages
+github_url: https://github.com/pulumi/pulumi
+website_url: https://pulumi.com
+docs_url: https://www.pulumi.com/docs
+
+category: Dev Tools
+tags: [infrastructure-as-code, cloud, devops, automation, terraform-alternative, python]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Provisioning ML infrastructure — GPU instances, vector databases, model serving
+  endpoints, and data pipelines — typically requires either clicking through cloud
+  consoles or learning HCL (Terraform's domain-specific language). Pulumi lets ML
+  teams define infrastructure using standard programming languages they already know,
+  enabling loops, conditionals, functions, and shared libraries. A Python-trained
+  team can define their training cluster, model registry, and serving infrastructure
+  in Python with full IDE support, unit testing, and package management — without
+  learning a new configuration language.
+
+use_cases:
+  - Provision GPU training clusters with spot instances, auto-scaling, and persistent storage
+  - Deploy vector database instances (Pinecone, Qdrant, Weaviate) as infrastructure-as-code
+  - Define and deploy model serving stacks with load balancers, TLS, and monitoring
+  - Manage multi-cloud ML infrastructure (AWS+Azure+GCP) from a single codebase
+
+install_command: brew install pulumi


### PR DESCRIPTION
Add 3 tools to the Agentic AI For Good catalog:

- **NGINX** — High-performance HTTP server and reverse proxy for model serving infrastructure (31.2k★, nginx/nginx)
- **Apache Hive** — Distributed data warehouse for SQL-on-Hadoop analytics and ML feature engineering (6k★, apache/hive)
- **Pulumi** — Infrastructure-as-code in Python/TypeScript/Go for ML infrastructure provisioning (25.5k★, pulumi/pulumi)
