### PR TITLE
Add Pandas, Transformers, IPython, SymPy, timm to catalog

### DIFF
--- a/tools/data/ipython.yaml
+++ b/tools/data/ipython.yaml
@@ -1,0 +1,23 @@
+name: IPython
+description: "An enhanced interactive Python shell providing rich output (images, HTML, LaTeX, video), tab completion, magic commands (%timeit, %debug, %run), parallel computing primitives, and deep introspection — serving as the computational kernel behind Jupyter Notebook and JupyterLab for exploratory data science and ML workflows."
+tagline: "Enhanced interactive Python shell and Jupyter kernel"
+github_url: https://github.com/ipython/ipython
+website_url: https://ipython.org
+docs_url: https://ipython.readthedocs.io
+install_command: "pip install ipython"
+category: Data
+tags:
+  - interactive-computing
+  - python
+  - jupyter
+  - repl
+  - notebook
+  - data-science
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Data exploration and model debugging require a tight feedback loop of running code, inspecting variables, visualizing outputs, and adjusting logic — but standard Python REPLs offer limited introspection, no rich media display, and no support for mixing code with documentation. IPython provides a feature-rich interactive shell with tab completion, history, magic commands for profiling and debugging, and rich display protocol that renders images, DataFrames, plots, and videos inline. As the kernel powering Jupyter, it enables millions of data scientists to iterate on analyses, document their work, and share reproducible notebooks."
+use_cases:
+  - "Explore and visualize datasets interactively — load data, run transformations, and inspect intermediate results with rich inline display of tables, plots, and images"
+  - "Debug ML training scripts with %debug post-mortem debugging, %timeit microbenchmarks, and %run to execute scripts in the REPL namespace for variable inspection"
+  - "Power Jupyter Notebook and JupyterLab sessions for reproducible data science workflows that combine code, visualizations, and documentation in a single document"

--- a/tools/data/pandas.yaml
+++ b/tools/data/pandas.yaml
@@ -1,0 +1,23 @@
+name: Pandas
+description: "A fast, powerful, and flexible open-source data analysis and manipulation library for Python, providing DataFrame and Series data structures with intuitive I/O, aggregation, merging, reshaping, and time-series capabilities for structured and tabular data workflows."
+tagline: "Fast, flexible Python data analysis library"
+github_url: https://github.com/pandas-dev/pandas
+website_url: https://pandas.pydata.org
+docs_url: https://pandas.pydata.org/docs
+install_command: "pip install pandas"
+category: Data
+tags:
+  - data-analysis
+  - data-manipulation
+  - python
+  - dataframe
+  - time-series
+  - tabular-data
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Data scientists and ML engineers spend excessive time loading, cleaning, transforming, and aggregating tabular data before they can train models or generate insights. Without a high-level data manipulation library, teams must write verbose loops and SQL queries for every filtering, joining, aggregation, and reshaping operation. Pandas provides expressive DataFrame and Series APIs that handle missing data, time-series alignment, file I/O (CSV, Parquet, Excel, JSON, SQL), and complex group-by operations in concise, readable code — enabling practitioners to iterate on data preparation as quickly as they iterate on modeling."
+use_cases:
+  - "Load, clean, and transform large CSV and Parquet datasets for ML training pipelines — handling missing values, type coercion, and column renaming in a few lines"
+  - "Perform complex group-by aggregations, window functions, and time-series resampling on structured data for feature engineering and business analytics"
+  - "Merge, join, and reshape multiple DataFrames from disparate data sources (databases, APIs, spreadsheets) into unified training datasets"

--- a/tools/data/sympy.yaml
+++ b/tools/data/sympy.yaml
@@ -1,0 +1,23 @@
+name: SymPy
+description: "A comprehensive open-source computer algebra system (CAS) written in pure Python, providing symbolic math capabilities including algebraic simplification, calculus (differentiation, integration, limits), equation solving (linear, polynomial, differential, and systems), matrix operations, and LaTeX output for publication-quality typesetting."
+tagline: "Pure Python computer algebra system for symbolic mathematics"
+github_url: https://github.com/sympy/sympy
+website_url: https://sympy.org
+docs_url: https://docs.sympy.org
+install_command: "pip install sympy"
+category: Data
+tags:
+  - symbolic-math
+  - computer-algebra
+  - calculus
+  - linear-algebra
+  - python
+  - mathematical-modeling
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Researchers and ML engineers working with mathematical models, optimization, or scientific computing often need to manipulate symbolic expressions — differentiating loss functions, solving systems of equations, simplifying algebraic constraints, or deriving gradient expressions — but proprietary CAS tools (Mathematica, Maple) are expensive, closed-source, and hard to integrate into Python-based ML pipelines. SymPy provides a free, pure-Python computer algebra system that integrates seamlessly with NumPy, SciPy, and Jupyter — enabling symbolic differentiation, expression simplification, LaTeX rendering, and code generation without leaving the Python data science ecosystem."
+use_cases:
+  - "Derive and inspect gradient expressions for custom loss functions and regularization terms before implementing them in PyTorch or TensorFlow training loops"
+  - "Simplify and rearrange algebraic constraints for optimization problems in linear programming, quadratic programming, and operations research"
+  - "Generate publication-quality mathematical notation for research papers and documentation using SymPy's LaTeX output and pretty-printing capabilities"

--- a/tools/other/timm.yaml
+++ b/tools/other/timm.yaml
@@ -1,0 +1,24 @@
+name: timm
+description: "A PyTorch image models library (timm) providing 700+ pretrained computer vision architectures including ConvNets (ResNet, ConvNeXt), Vision Transformers (ViT, DeiT, Swin), hybrid models (EfficientNet, MobileNet), and modern architectures (MaxViT, ConvNeXt-V2, MetaFormer) with optimized training recipes, data augmentations, and a unified model factory interface."
+tagline: "700+ pretrained PyTorch vision models"
+github_url: https://github.com/huggingface/pytorch-image-models
+website_url: https://huggingface.co/timm
+docs_url: https://timm.fast.ai
+install_command: "pip install timm"
+category: Other
+tags:
+  - computer-vision
+  - pretrained-models
+  - pytorch
+  - image-classification
+  - vision-transformer
+  - transfer-learning
+  - deep-learning
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Computer vision practitioners need access to hundreds of pretrained model architectures for transfer learning, benchmarking, and production deployment — but each model family (ResNet, ViT, ConvNeXt, EfficientNet) has its own codebase, loading conventions, and preprocessing requirements, making it tedious to compare architectures or swap backbones. timm provides a unified Model.create() and create_model() interface to 700+ pretrained models with consistent weight loading, preprocessing pipelines, and training recipes — enabling researchers and engineers to rapidly benchmark architectures, extract features for downstream tasks, and deploy optimized Vision Transformers or ConvNets without managing separate model repositories."
+use_cases:
+  - "Fine-tune a Vision Transformer (ViT, DeiT, Swin) or ConvNet (ConvNeXt, ResNet, EfficientNet) for custom image classification using timm's built-in training scripts and data augmentations"
+  - "Extract feature embeddings from pretrained vision models for image retrieval, similarity search, and zero-shot classification pipelines"
+  - "Benchmark and compare dozens of model architectures on a target dataset using a consistent API, learning rate schedule, and augmentation pipeline"

--- a/tools/other/transformers.yaml
+++ b/tools/other/transformers.yaml
@@ -1,0 +1,25 @@
+name: Transformers
+description: "Hugging Face Transformers is the de-facto standard library for state-of-the-art natural language processing, computer vision, audio, and multimodal models. It provides thousands of pretrained transformer architectures (BERT, GPT, Llama, CLIP, Whisper, DETR, and more) through a unified API with model hub integration, tokenizers, training utilities, and ONNX/TensorRT export."
+tagline: "State-of-the-art pretrained models for NLP, CV, audio, and multimodal AI"
+github_url: https://github.com/huggingface/transformers
+website_url: https://huggingface.co/docs/transformers
+docs_url: https://huggingface.co/docs/transformers/index
+install_command: "pip install transformers"
+category: Other
+tags:
+  - nlp
+  - computer-vision
+  - audio-processing
+  - multimodal
+  - pretrained-models
+  - model-hub
+  - deep-learning
+  - python
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Applying state-of-the-art transformer models for NLP, vision, and audio tasks typically requires implementing complex architectures from scratch, managing separate model-specific codebases, and handling differences in tokenization, batching, and inference across models. Transformers provides a unified, framework-agnostic API to thousands of pretrained models — from BERT and GPT to Llama, CLIP, Whisper, and more — with automatic model downloads via the Hugging Face Hub, consistent input/output conventions, and built-in training, evaluation, and export utilities. This lets practitioners iterate on model selection and fine-tuning in minutes instead of days."
+use_cases:
+  - "Fine-tune large language models (Llama, GPT, Mistral) for text generation, classification, and summarization using the built-in Trainer API with mixed-precision and distributed training"
+  - "Run zero-shot image classification, object detection, and segmentation using pretrained vision transformers (ViT, DETR, SegFormer) with a single pipeline API"
+  - "Transcribe and translate audio with pretrained speech models (Whisper, Wav2Vec2) and align text-to-speech outputs using unified encoder-decoder pipelines"


### PR DESCRIPTION
Adds 5 foundational data science and ML tools to the catalog:
- **Pandas** (Data) — 49k★, BSD-3-Clause. Core Python data analysis library with DataFrame/Series APIs.
- **Transformers** (Other) — 163k★, Apache-2.0. Hugging Face's de-facto standard pretrained model library.
- **IPython** (Data) — 16.7k★, BSD-3-Clause. Enhanced interactive Python shell and Jupyter kernel.
- **SymPy** (Data) — 14.8k★, BSD-3-Clause. Pure Python computer algebra system.
- **timm** (Other) — 37k★, Apache-2.0. 700+ pretrained PyTorch vision models.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for IPython, Pandas, SymPy, timm, and Transformers.
  * Included descriptions, taglines, categories, use cases, installation instructions, and links to websites and documentation.
  * Added licensing, pricing, open-source status, and problem-solving details to help users evaluate each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->