### PR TITLE
Add CuPy, FasterTransformer to catalog

### DIFF
--- a/tools/data/cupy.yaml
+++ b/tools/data/cupy.yaml
@@ -1,0 +1,24 @@
+name: CuPy
+description: "A NumPy/SciPy-compatible array library for GPU-accelerated computing on NVIDIA CUDA and AMD ROCm platforms, providing drop-in replacements for NumPy functions, GPU-optimized linear algebra, FFT, sparse matrix operations, and seamless integration with deep learning frameworks for high-performance numerical computing."
+tagline: "NumPy-compatible GPU-accelerated array library"
+github_url: https://github.com/cupy/cupy
+website_url: https://cupy.dev
+docs_url: https://docs.cupy.dev
+install_command: "pip install cupy"
+category: Data
+tags:
+  - gpu-computing
+  - numerical-computing
+  - cuda
+  - linear-algebra
+  - array-operations
+  - python
+  - hpc
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Data scientists and ML engineers working with large numerical datasets on GPUs are forced to choose between PyTorch/TensorFlow's tensor APIs (which add auto-differentiation overhead and framework lock-in) or writing custom CUDA kernels — neither suitable for general-purpose numerical computing. CuPy provides a drop-in NumPy/SciPy-compatible API that runs on NVIDIA and AMD GPUs, enabling practitioners to accelerate array operations, linear algebra, FFT, and sparse matrix computations by 10-100x on GPU hardware without rewriting their data pipelines or learning CUDA programming."
+use_cases:
+  - "Accelerate NumPy-based data preprocessing and feature engineering pipelines by replacing `import numpy as np` with `import cupy as cp` for GPU execution with minimal code changes"
+  - "Perform GPU-accelerated linear algebra (matrix multiplication, eigendecomposition, SVD) and FFT on large scientific and ML datasets using familiar NumPy-style APIs"
+  - "Build hybrid CPU-GPU data pipelines where CuPy and NumPy arrays share memory seamlessly, enabling selective acceleration of bottleneck computations without full GPU adoption"

--- a/tools/dev-tools/fastertransformer.yaml
+++ b/tools/dev-tools/fastertransformer.yaml
@@ -1,0 +1,23 @@
+name: FasterTransformer
+description: "NVIDIA's optimized transformer inference and training backend providing highly optimized CUDA kernels for transformer model architectures (BERT, GPT, Llama, T5, ViT) with support for INT8/FP8 quantization, sparse attention, tensor parallelism, and multi-GPU inference across PyTorch, TensorRT, and standalone C++ deployments."
+tagline: "NVIDIA's optimized transformer inference and training backend"
+github_url: https://github.com/NVIDIA/FasterTransformer
+website_url: https://github.com/NVIDIA/FasterTransformer
+docs_url: https://github.com/NVIDIA/FasterTransformer/wiki
+category: Dev Tools
+tags:
+  - transformer-inference
+  - gpu-optimization
+  - cuda
+  - model-serving
+  - quantization
+  - nvidia
+  - deep-learning
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Deploying large transformer models (BERT, GPT, Llama, T5) for production inference on NVIDIA GPUs requires hand-tuned CUDA kernels for attention, feed-forward layers, and quantization — each model architecture and GPU generation needing separate optimization work. FasterTransformer provides a consolidated library of highly optimized CUDA kernels covering encoder and decoder transformer architectures with INT8/FP8 quantization, sparse attention, and tensor parallelism, delivering up to 3x inference speedup over naive PyTorch implementations across single and multi-GPU deployments."
+use_cases:
+  - "Deploy large language models (GPT, Llama, BLOOM) for production inference with INT8/FP8 quantization and tensor parallelism across multiple NVIDIA GPUs for maximum throughput"
+  - "Accelerate BERT and BERT-like encoder models for latency-sensitive NLP pipelines (search, classification, question answering) using FasterTransformer's fused multi-head attention kernels"
+  - "Integrate FasterTransformer as a custom backend in PyTorch and TensorRT pipelines to replace naive transformer implementations with optimized CUDA kernels for batched inference"


### PR DESCRIPTION
Adds CuPy (Data) and FasterTransformer (Dev Tools) to the catalog:
- **CuPy** (Data) — 12k★, MIT. NumPy-compatible GPU array library for CUDA/ROCm.
- **FasterTransformer** (Dev Tools) — 6.4k★, Apache-2.0. NVIDIA optimized transformer inference kernels.
