### PR TITLE
Add Chatbox, NVIDIA RAPIDS, Traceloop, NVIDIA DALI, Voyager to catalog

### DIFF
--- a/tools/data/nvidia-dali.yaml
+++ b/tools/data/nvidia-dali.yaml
@@ -1,0 +1,31 @@
+name: NVIDIA DALI
+description: A GPU-accelerated data loading and preprocessing library that optimizes the input pipeline bottleneck in deep learning workflows by offloading decoding, augmentation, and transformation operations to the GPU.
+tagline: GPU-accelerated data pipelines for deep learning
+
+github_url: https://github.com/NVIDIA/DALI
+website_url: https://developer.nvidia.com/dali
+docs_url: https://docs.nvidia.com/deeplearning/dali/user-guide
+
+category: Data
+tags: [gpu, data-loading, preprocessing, computer-vision, audio, deep-learning, cuda, pipeline]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install nvidia-dali-cuda120
+
+problem_solved: |
+  In deep learning workflows, data loading and preprocessing often become the training
+  bottleneck — CPUs struggle to decode images, apply augmentations, and feed data fast
+  enough to keep GPUs fully utilized. NVIDIA DALI offloads these operations entirely to
+  the GPU, performing parallel decoding, random cropping, color jittering, audio
+  spectrogram generation, and other transformations at hardware acceleration speeds.
+  The result is dramatically higher GPU utilization and shorter training times without
+  changing the model architecture.
+
+use_cases:
+  - Accelerate image loading and augmentation pipelines for computer vision training to saturate GPU compute
+  - Build real-time audio preprocessing pipelines for speech recognition and sound classification models
+  - Decode and transform video frames on-GPU for video understanding models without CPU round-trips
+  - Integrate with PyTorch, TensorFlow, and JAX data loaders for transparent GPU acceleration
+  - Process large-scale datasets with dynamic batching and parallel I/O to maximize training throughput

--- a/tools/data/nvidia-rapids.yaml
+++ b/tools/data/nvidia-rapids.yaml
@@ -1,0 +1,30 @@
+name: NVIDIA RAPIDS
+description: A suite of GPU-accelerated data science and machine learning libraries that enables end-to-end data processing, model training, and graph analytics entirely on NVIDIA GPUs without leaving the Python ecosystem.
+tagline: GPU-accelerated data science from DataFrame to deployment
+
+github_url: https://github.com/rapidsai/cudf
+website_url: https://rapids.ai
+docs_url: https://docs.rapids.ai
+
+category: Data
+tags: [gpu, data-science, dataframe, machine-learning, analytics, python, cuda, visualization]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install cudf-cu12 cuml-cu12 cugraph-cu12
+
+problem_solved: |
+  Traditional CPU-based data processing becomes the bottleneck in ML pipelines handling
+  large datasets — pandas DataFrames, scikit-learn models, and NetworkX graphs struggle
+  to scale past memory or take minutes per operation. RAPIDS provides drop-in GPU
+  replacements for these libraries (cuDF for pandas, cuML for scikit-learn, cuGraph for
+  NetworkX) so data scientists can accelerate their existing workflows 10-50x without
+  rewriting code or learning new APIs.
+
+use_cases:
+  - Accelerate pandas DataFrame operations on large datasets by switching to cuDF with minimal code changes
+  - Train and evaluate scikit-learn compatible ML models on GPU with cuML for faster iteration
+  - Analyze large-scale graph networks with cuGraph for community detection, PageRank, and pathfinding
+  - Build end-to-end GPU-accelerated data pipelines that load, clean, transform, and model data without CPU transfer
+  - Visualize billion-row datasets interactively using cuXfilter for real-time dashboarding

--- a/tools/monitoring/traceloop.yaml
+++ b/tools/monitoring/traceloop.yaml
@@ -1,0 +1,31 @@
+name: Traceloop
+description: An open-source LLM observability platform built on OpenTelemetry that traces LLM API calls, vector database operations, and framework interactions for debugging, monitoring, and improving AI applications in production.
+tagline: OpenTelemetry-native observability for LLM applications
+
+github_url: https://github.com/traceloop/openllmetry
+website_url: https://traceloop.com
+docs_url: https://docs.traceloop.com
+
+category: Monitoring
+tags: [llm, observability, tracing, opentelemetry, monitoring, python, evaluation]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install traceloop-sdk
+
+problem_solved: |
+  LLM applications are notoriously difficult to debug and monitor because each API call,
+  vector search, and prompt template interaction happens inside framework abstractions
+  with no visibility. When an AI agent returns wrong answers or degrades over time,
+  developers have no way to trace the root cause. Traceloop instruments the entire
+  LLM stack via OpenTelemetry — from the user request through prompt construction,
+  retrieval, LLM inference, and response — providing traces, metrics, and evaluation
+  in a unified dashboard.
+
+use_cases:
+  - Trace end-to-end LLM inference requests across model providers, vector databases, and prompt templates to debug failures
+  - Monitor token usage, latency, and cost per request across all LLM calls in production
+  - Detect regressions in response quality by comparing traces against evaluation metrics over time
+  - Instrument RAG pipelines to see which documents were retrieved and how they influenced the final response
+  - Set up alerts on LLM performance degradation using OpenTelemetry-standard metrics and thresholds

--- a/tools/other/chatbox.yaml
+++ b/tools/other/chatbox.yaml
@@ -1,0 +1,29 @@
+name: Chatbox
+description: A powerful desktop AI assistant that supports multiple LLM providers including OpenAI, Claude, Gemini, and Ollama with a clean native interface for chat, file management, and image recognition.
+tagline: Your all-in-one desktop AI companion
+
+github_url: https://github.com/Bin-Huang/chatbox
+website_url: https://chatboxai.app
+docs_url: https://chatboxai.app/docs
+
+category: Other
+tags: [llm, chat, desktop, multi-provider, cross-platform, local, ollama]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+install_command: brew install --cask chatbox
+
+problem_solved: |
+  Users who work with multiple LLMs (OpenAI, Claude, Gemini, local models via Ollama)
+  need a unified desktop interface instead of juggling browser tabs, each with different
+  chat histories, context limits, and interfaces. Chatbox provides a single native app
+  with consistent UX across providers, persistent conversation history, file uploads,
+  and image analysis — all running locally without a browser.
+
+use_cases:
+  - Switch between GPT-4, Claude, and local Ollama models from a single desktop interface without losing context
+  - Upload documents and images for AI analysis with automatic provider routing
+  - Maintain persistent chat histories organized by project or topic across sessions
+  - Run local models through Ollama integration for private, offline AI interactions
+  - Compare responses from different LLMs side-by-side for the same prompt

--- a/tools/vector-databases/voyager.yaml
+++ b/tools/vector-databases/voyager.yaml
@@ -1,0 +1,29 @@
+name: Voyager
+description: An approximate nearest-neighbor search library from Spotify designed for vector similarity search with a focus on ease of use, simplicity, and production deployability across Python and Java applications.
+tagline: Simple, production-ready vector similarity search
+
+github_url: https://github.com/spotify/voyager
+website_url: https://github.com/spotify/voyager
+
+category: Vector DB
+tags: [vector-search, nearest-neighbor, similarity-search, hnsw, python, java, embeddings, knn]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install voyager
+
+problem_solved: |
+  Production vector similarity search is often complex to set up and maintain —
+  many ANN libraries require C++ compilation, heavy dependencies, or dedicated server
+  infrastructure. Voyager provides a simple Python and Java library that embeds directly
+  into existing applications with a single pip install, supporting HNSW-based
+  approximate nearest neighbor search with configurable recall-speed tradeoffs, index
+  persistence, and thread-safe concurrent queries.
+
+use_cases:
+  - Build semantic search into applications by indexing text embeddings and querying with natural language vectors
+  - Power recommendation systems that find similar items by embedding proximity in real-time
+  - Implement near-duplicate detection by comparing document or image embeddings at high throughput
+  - Enable retrieval-augmented generation (RAG) pipelines with fast vector lookup against document embeddings
+  - Deploy on-device vector search without external database infrastructure or network dependencies


### PR DESCRIPTION
## Tools added

- **Chatbox** — Desktop AI assistant supporting multiple LLM providers (OpenAI, Claude, Gemini, Ollama) with a clean native interface.
- **NVIDIA RAPIDS** — Suite of GPU-accelerated data science libraries (cuDF, cuML, cuGraph) for end-to-end ML pipelines on GPU.
- **Traceloop** — OpenTelemetry-native LLM observability platform for tracing, monitoring, and debugging AI applications.
- **NVIDIA DALI** — GPU-accelerated data loading and preprocessing library for deep learning training pipelines.
- **Voyager** — Approximate nearest-neighbor search library from Spotify for production vector similarity search.

### Category distribution
- Data: NVIDIA RAPIDS, NVIDIA DALI
- Monitoring: Traceloop
- Other: Chatbox
- Vector DB: Voyager

### Validation
All 5 tools pass `scripts/validate-tool.ts` validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for NVIDIA DALI, NVIDIA RAPIDS, Traceloop, Chatbox, and Voyager.
  * Included descriptions, documentation and source links, categories, tags, licensing, pricing, installation details, and documented use cases.
  * Expanded the catalog to cover GPU data processing, LLM observability, desktop AI tools, and vector databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->