### PR TITLE
Add Joblib, Protocol Buffers, Apache Avro, Apache Calcite, Apache PDFBox to catalog

### DIFF
--- a/tools/data/apache-avro.yaml
+++ b/tools/data/apache-avro.yaml
@@ -1,0 +1,26 @@
+name: Apache Avro
+description: >-
+  Compact binary data serialization framework with JSON-defined schemas and built-in schema evolution support. Optimized for big data pipelines with splittable container files, compression, and seamless integration with Apache Kafka and Hadoop ecosystems. Supports automatic code generation in Python, Java, C++, and other languages with full backward and forward compatibility for evolving data structures.
+tagline: Binary serialization with schema evolution for big data
+
+github_url: https://github.com/apache/avro
+website_url: https://avro.apache.org
+docs_url: https://avro.apache.org/docs
+
+install_command: pip install avro
+
+category: Data
+tags: [serialization, data-format, binary, kafka, hadoop, big-data, schema-registry]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Big data pipelines need a serialization format that is compact for efficient storage, splittable for distributed processing, and supports schema evolution as data structures change over time without breaking downstream consumers. Apache Avro solves this with a compact binary format that stores the schema alongside the data for self-describing records, supports full schema evolution with both backward and forward compatibility, and produces splittable container files optimized for Hadoop MapReduce and Kafka streaming — making it the standard serialization format for big data and stream processing ecosystems.
+
+use_cases:
+  - Serialize streaming data in Kafka topics with schema evolution and compatibility guarantees
+  - Store big data in Hadoop with splittable compressed container files for distributed processing
+  - Exchange structured data between microservices with JSON-defined schemas
+  - Encode high-throughput event streams with compact binary format and built-in compression
+  - Build data pipelines with schema registry for consistent data governance and validation

--- a/tools/data/apache-calcite.yaml
+++ b/tools/data/apache-calcite.yaml
@@ -1,0 +1,24 @@
+name: Apache Calcite
+description: >-
+  Dynamic data management framework providing SQL parsing, cost-based query optimization, and query execution across heterogeneous data sources. Provides a SQL parser, hundreds of built-in optimization rules, and a JDBC driver that enables querying any backend with a Calcite adapter. Powers SQL engines for Apache Flink, Drill, Hive, and dozens of other big data platforms.
+tagline: Unified SQL optimization across heterogeneous data sources
+
+github_url: https://github.com/apache/calcite
+website_url: https://calcite.apache.org
+docs_url: https://calcite.apache.org/docs
+
+category: Data
+tags: [sql, query-optimization, data-querying, big-data, federated-query, apache, jdbc]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Querying data across multiple heterogeneous sources — relational databases, NoSQL stores, file systems, and streaming platforms — typically requires separate query languages, optimization strategies, and connection logic for each backend. Apache Calcite solves this with a unified SQL parsing and optimization framework that applies hundreds of cost-based and rule-based optimizations across any data source with a Calcite adapter — enabling federated queries across databases, files, streams, and NoSQL stores through a single standard SQL interface.
+
+use_cases:
+  - Execute federated SQL queries across multiple databases, file formats, and streaming sources
+  - Optimize complex analytical queries with hundreds of cost-based optimization rules
+  - Build custom SQL query engines for new data sources using the Calcite adapter framework
+  - Parse and rewrite SQL queries for schema mapping and data governance enforcement
+  - Power SQL interfaces for streaming platforms with Calcite's streaming query optimization

--- a/tools/data/apache-pdfbox.yaml
+++ b/tools/data/apache-pdfbox.yaml
@@ -1,0 +1,24 @@
+name: Apache PDFBox
+description: >-
+  Open-source Java library for working with PDF documents, providing high-fidelity text extraction, metadata parsing, and document creation. Supports interactive form filling, digital signatures, encryption, and conversion of PDF pages to images. The standard library for PDF content extraction in document processing pipelines for enterprise RAG, data extraction, and document automation workflows.
+tagline: Java PDF library for text extraction and document processing
+
+github_url: https://github.com/apache/pdfbox
+website_url: https://pdfbox.apache.org
+docs_url: https://pdfbox.apache.org/docs
+
+category: Data
+tags: [pdf, document-processing, text-extraction, java, data-extraction, ocr, document-parsing]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  PDF documents are notoriously difficult to parse programmatically — layouts vary widely, text may be stored as rendering instructions rather than content streams, and many tools produce garbled output from complex multi-column or scanned PDFs. Apache PDFBox solves this with a robust Java library that extracts text and metadata with high fidelity across diverse PDF formats, handles encrypted and digitally signed PDFs, and provides full programmatic creation and manipulation of PDF documents — making it the standard for PDF processing in enterprise data extraction and document intelligence pipelines.
+
+use_cases:
+  - Extract text and metadata from PDF documents for RAG and document search pipelines
+  - Parse invoices, financial reports, and forms for automated data extraction workflows
+  - Create PDF documents programmatically with precise layout and formatting control
+  - Fill and process interactive PDF forms for enterprise document automation
+  - Convert PDF pages to images for document archival and AI-based document analysis

--- a/tools/data/joblib.yaml
+++ b/tools/data/joblib.yaml
@@ -1,0 +1,26 @@
+name: Joblib
+description: >-
+  Lightweight pipelining for Python with transparent disk caching, parallel computing, and efficient NumPy-aware serialization. Provides utilities for caching function outputs with automatic invalidation, parallel execution via thread and multiprocessing backends, and fast serialization of large NumPy arrays. Used extensively in scikit-learn for model persistence and cross-validation pipeline execution.
+tagline: Python pipelining with caching and parallel execution
+
+github_url: https://github.com/joblib/joblib
+website_url: https://joblib.readthedocs.io
+docs_url: https://joblib.readthedocs.io
+
+install_command: pip install joblib
+
+category: Data
+tags: [python, caching, serialization, parallel-computing, scikit-learn, data-processing, ml-pipeline]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: >-
+  Machine learning workflows repeatedly recompute expensive intermediate results and struggle to persist large NumPy arrays efficiently. Joblib solves this with a transparent caching system that automatically caches function outputs with dependency tracking, parallel execution via threading and multiprocessing backends, and a fast NumPy-aware serializer that handles large arrays efficiently — making it the standard library for scikit-learn model persistence, cross-validation, and pipeline execution.
+
+use_cases:
+  - Cache intermediate computation results in ML pipelines to avoid redundant recomputation
+  - Parallelize embarrassingly parallel ML workloads with simple threading decorators
+  - Persist large scikit-learn models and NumPy arrays with efficient serialization
+  - Build reproducible data processing pipelines with transparent function caching
+  - Replace pickle for NumPy-heavy workloads with faster, memory-efficient serialization

--- a/tools/data/protocol-buffers.yaml
+++ b/tools/data/protocol-buffers.yaml
@@ -1,0 +1,26 @@
+name: Protocol Buffers
+description: >-
+  Language-neutral, platform-neutral extensible mechanism for serializing structured data with compact binary format. Defines message schemas in .proto files and generates code in Python, Java, C++, Go, and dozens of other languages for efficient parsing and serialization. Smaller and faster than JSON or XML, widely used in ML pipelines for TFRecord encoding, model serving interfaces, and distributed system communication.
+tagline: Compact binary serialization for structured data
+
+github_url: https://github.com/protocolbuffers/protobuf
+website_url: https://protobuf.dev
+docs_url: https://protobuf.dev
+
+install_command: pip install protobuf
+
+category: Data
+tags: [serialization, data-format, binary, grpc, tfrecord, ml-pipeline, data-exchange]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: >-
+  Data serialization is a bottleneck in distributed ML pipelines — JSON and XML are human-readable but slow, large, and lack schema validation, while custom binary formats are brittle and non-portable across languages. Protocol Buffers solves this with a compact binary format that is 3 to 10 times smaller than JSON, strongly typed schema definitions with backward compatibility, and generated code in 12+ languages for zero-effort cross-platform data exchange — making it the standard for TFRecord storage, gRPC model serving, and distributed system communication.
+
+use_cases:
+  - Encode training data as TFRecords for efficient TensorFlow model training pipelines
+  - Define model serving APIs with strongly typed request and response schemas via gRPC
+  - Exchange structured data between microservices in distributed ML systems
+  - Store configuration and metadata with version-tolerant schema evolution
+  - Replace JSON and XML in high-throughput pipelines for smaller payloads and faster parsing


### PR DESCRIPTION
This PR adds 5 tools to the catalog:

**Data category (5):**
- **Joblib** (joblib/joblib, 4,381★) — Python pipelining with disk caching, parallel execution, and NumPy-aware serialization
- **Protocol Buffers** (protocolbuffers/protobuf, 71,653★) — Compact binary serialization for structured data, used in TFRecord and gRPC
- **Apache Avro** (apache/avro, 3,290★) — Binary data serialization with schema evolution, standard for Kafka and Hadoop
- **Apache Calcite** (apache/calcite, 5,159★) — Unified SQL optimization across heterogeneous data sources
- **Apache PDFBox** (apache/pdfbox, 3,099★) — Java PDF library for text extraction and document processing

All verified: active repos, not archived.
