### PR TITLE
Add Apache POI, Stanford CoreNLP to catalog

### DIFF
--- a/tools/data/apache-poi.yaml
+++ b/tools/data/apache-poi.yaml
@@ -1,0 +1,24 @@
+name: Apache POI
+description: >-
+  Java library for reading and writing Microsoft Office file formats including Word (DOCX), Excel (XLSX), PowerPoint (PPTX), and Visio (VSX). Provides programmatic access to document content for text extraction, data parsing, and document generation. Used extensively in enterprise data pipelines for extracting structured data from Office documents, spreadsheets, and presentations.
+tagline: Java library for Microsoft Office document processing
+
+github_url: https://github.com/apache/poi
+website_url: https://poi.apache.org
+docs_url: https://poi.apache.org/documentation
+
+category: Data
+tags: [document-processing, office, excel, word, powerpoint, java, data-extraction, text-extraction]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Extracting structured data from Microsoft Office documents — Word, Excel, PowerPoint — is essential for enterprise RAG and document AI pipelines, but these binary formats are opaque and poorly documented. Apache POI solves this with a mature Java library that reads and writes Office Open XML (OOXML) and OLE2 formats, providing high-fidelity access to document content including text, tables, charts, images, and formulas — making it the standard for Office document processing in enterprise data extraction and document intelligence workflows.
+
+use_cases:
+  - Extract text and tables from Word and Excel documents for enterprise RAG pipelines
+  - Parse financial spreadsheets for automated data extraction and analysis workflows
+  - Generate Office documents programmatically for reporting and document automation
+  - Convert PowerPoint presentations to text for content indexing and search
+  - Process batch Office documents in enterprise data ingestion and archival systems

--- a/tools/other/stanford-corenlp.yaml
+++ b/tools/other/stanford-corenlp.yaml
@@ -1,0 +1,26 @@
+name: Stanford CoreNLP
+description: >-
+  Comprehensive natural language processing toolkit providing tokenization, part-of-speech tagging, named entity recognition, sentiment analysis, dependency parsing, coreference resolution, relation extraction, and anaphora resolution in multiple languages. Combines statistical and neural NLP models with a Java-based server and Python client interface for production-scale text annotation and analysis.
+tagline: Production NLP toolkit from Stanford NLP group
+
+github_url: https://github.com/stanfordnlp/CoreNLP
+website_url: https://stanfordnlp.github.io/CoreNLP
+docs_url: https://stanfordnlp.github.io/CoreNLP
+
+install_command: pip install stanfordcorenlp
+
+category: Other
+tags: [nlp, tokenization, named-entity-recognition, sentiment-analysis, dependency-parsing, coreference, text-analysis, java]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: >-
+  Building production NLP pipelines requires combining multiple annotation types — tokenization, NER, parsing, coreference, sentiment — which traditionally means stitching together separate libraries with incompatible interfaces and output formats. Stanford CoreNLP solves this with a unified, extensible pipeline that provides 15+ linguistic annotations through a single framework, serving them via an efficient Java server with Python, Scala, and JavaScript clients — making it the most widely adopted NLP toolkit for research and production text understanding.
+
+use_cases:
+  - Extract named entities, relationships, and sentiment from documents for knowledge graph construction
+  - Build text preprocessing pipelines for downstream NLP models and ML training
+  - Analyze social media and customer feedback with multilingual sentiment and emotion detection
+  - Parse complex sentence structures with constituency and dependency parse trees
+  - Resolve pronouns and noun phrases to their referents in coreference resolution systems


### PR DESCRIPTION
This PR adds 2 tools to the catalog:

- **Apache POI** (apache/poi, 2,255★) — Java library for reading and writing Microsoft Office formats (DOCX, XLSX, PPTX) for enterprise document processing
- **Stanford CoreNLP** (stanfordnlp/CoreNLP, 10,097★) — Comprehensive NLP toolkit with tokenization, NER, sentiment analysis, dependency parsing, and coreference resolution

All verified: active repos, not archived.
