### PR TITLE
Add statsmodels, Featuretools, tsfresh, Seaborn, Altair to catalog

### DIFF
--- a/tools/data/altair.yaml
+++ b/tools/data/altair.yaml
@@ -1,0 +1,24 @@
+name: Altair
+description: "A declarative statistical visualization library for Python, built on the Vega-Lite grammar of interactive graphics, enabling concise and reproducible multi-view plots with interactive selection, brushing, and linked views."
+tagline: "Declarative interactive visualizations in Python"
+github_url: https://github.com/vega/altair
+website_url: https://altair-viz.github.io
+docs_url: https://altair-viz.github.io/getting_started/overview.html
+install_command: "pip install altair"
+category: Data
+tags:
+  - data-visualization
+  - interactive-plots
+  - python
+  - vega-lite
+  - statistical-graphics
+  - exploratory-data-analysis
+  - declarative-visualization
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Building interactive, multi-view statistical graphics in Python typically requires deep knowledge of rendering libraries (D3.js, Bokeh) and manual event-handling code for interactions like brushing, zooming, and linked selection across views. Altair solves this with a declarative API based on the Vega-Lite grammar — users specify data columns, mark types, and encoding channels (x, y, color, size, tooltip) without writing rendering logic. Interactive multi-view dashboards with cross-filtering and linked brushing are expressed as concise visual specifications, making exploratory data analysis and dashboard prototyping dramatically faster."
+use_cases:
+  - "Build interactive scatter plot matrices, bar charts, and line charts with tooltips, zoom, and pan for exploratory data analysis in Jupyter notebooks"
+  - "Create linked multi-view dashboards where brushing in one chart filters or highlights data across all other charts for coordinated multivariate exploration"
+  - "Generate reproducible statistical graphics with the Vega-Lite grammar for sharing interactive visualizations as standalone HTML files or embedding in web applications"

--- a/tools/data/featuretools.yaml
+++ b/tools/data/featuretools.yaml
@@ -1,0 +1,24 @@
+name: Featuretools
+description: "An open-source Python library for automated feature engineering using deep feature synthesis (DFS), which automatically generates hundreds of relevant features from relational and temporal datasets for machine learning pipelines."
+tagline: "Automated feature engineering for ML"
+github_url: https://github.com/alteryx/featuretools
+website_url: https://www.featuretools.com
+docs_url: https://featuretools.alteryx.com
+install_command: "pip install featuretools"
+category: Data
+tags:
+  - feature-engineering
+  - automated-ml
+  - data-preparation
+  - python
+  - relational-data
+  - time-series
+  - feature-synthesis
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Feature engineering is the most time-consuming and domain-expertise-intensive step in ML pipelines, requiring practitioners to manually write dozens of aggregation, transformation, and encoding operations across relational tables. This manual process is slow, inconsistent, and often misses high-value features. Featuretools automates this with deep feature synthesis — automatically creating features by traversing relationships between tables, applying stacking transformations (group-by means, trends, time-since-last), and generating hundreds of candidate features from multi-table datasets in minutes."
+use_cases:
+  - "Automatically generate hundreds of features from multi-table relational datasets (transactions, customers, products) for fraud detection, credit scoring, and customer churn prediction"
+  - "Combine automated feature engineering with feature selection to build robust ML pipelines that capture complex temporal patterns without manual feature coding"
+  - "Integrate into existing ML workflows as a scikit-learn-compatible transformer for production feature engineering with reproducible, version-controlled feature definitions"

--- a/tools/data/seaborn.yaml
+++ b/tools/data/seaborn.yaml
@@ -1,0 +1,24 @@
+name: Seaborn
+description: "A Python statistical data visualization library built on Matplotlib, providing a high-level interface for drawing attractive and informative statistical graphics — distribution plots, relational plots, categorical plots, regression plots, and multi-plot grids."
+tagline: "Statistical data visualization in Python"
+github_url: https://github.com/mwaskom/seaborn
+website_url: https://seaborn.pydata.org
+docs_url: https://seaborn.pydata.org/tutorial.html
+install_command: "pip install seaborn"
+category: Data
+tags:
+  - data-visualization
+  - statistical-plots
+  - python
+  - matplotlib
+  - exploratory-data-analysis
+  - plotting
+  - data-exploration
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Matplotlib produces publication-quality figures but requires verbose code for common statistical visualizations — creating grouped bar charts, distribution comparisons, correlation heatmaps, or regression scatter plots with confidence bands involves complex styling and layout configuration. Seaborn provides concise, statistically-informed plotting functions that automatically handle aggregation (means, confidence intervals, bootstrapping), categorical encoding (hue, style, size), and faceted layouts (multi-plot grids), enabling data scientists to explore complex multivariate relationships and communicate findings with minimal code."
+use_cases:
+  - "Visualize distributions, correlations, and pairwise relationships in exploratory data analysis using pair plots, heatmaps, and distribution plots for dataset understanding"
+  - "Create publication-ready statistical figures with grouped bar charts, box plots, violin plots, and regression scatter plots styled with built-in color palettes and themes"
+  - "Explore categorical and multivariate relationships using faceted grid plots (FacetGrid, PairGrid, JointGrid) that automatically break down data by multiple grouping variables"

--- a/tools/data/statsmodels.yaml
+++ b/tools/data/statsmodels.yaml
@@ -1,0 +1,24 @@
+name: statsmodels
+description: "A Python library for statistical modeling, hypothesis testing, and econometric analysis, providing classes and functions for regression (OLS, GLM, GEE, MixedLM), time-series analysis (ARIMA, VAR, state space), and statistical inference (t-tests, ANOVA, chi-square)."
+tagline: "Statistical modeling and inference in Python"
+github_url: https://github.com/statsmodels/statsmodels
+website_url: https://www.statsmodels.org
+docs_url: https://www.statsmodels.org/stable/index.html
+install_command: "pip install statsmodels"
+category: Data
+tags:
+  - statistical-modeling
+  - regression
+  - time-series
+  - econometrics
+  - hypothesis-testing
+  - python
+  - data-analysis
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Data scientists and ML researchers need rigorous statistical testing beyond what ML libraries provide — confidence intervals, hypothesis tests, time-series decomposition, and model diagnostics — but implementing these correctly from scratch is error-prone and time-consuming. statsmodels provides battle-tested implementations of regression models, time-series methods, and statistical tests with standard statistical output (p-values, confidence intervals, R-squared), enabling practitioners to validate findings, test assumptions, and produce publication-ready results without reinventing statistical methodology."
+use_cases:
+  - "Run OLS, logistic, and Poisson regressions with full diagnostic output (p-values, confidence intervals, F-tests, Breusch-Pagan tests) for academic research and business analytics"
+  - "Decompose and forecast time-series data using ARIMA, SARIMA, and state-space models with automated order selection for demand forecasting and economic analysis"
+  - "Perform hypothesis testing (t-tests, chi-square, ANOVA) and effect-size estimation for A/B testing and experimental analysis in production environments"

--- a/tools/data/tsfresh.yaml
+++ b/tools/data/tsfresh.yaml
@@ -1,0 +1,24 @@
+name: tsfresh
+description: "A Python library for automatic extraction of hundreds of features from time-series data, including statistical, temporal, spectral, and wavelet-based features. tsfresh evaluates feature relevance, filters redundant features, and outputs scikit-learn-compatible matrices."
+tagline: "Automatic time-series feature extraction"
+github_url: https://github.com/blue-yonder/tsfresh
+website_url: https://tsfresh.com
+docs_url: https://tsfresh.readthedocs.io
+install_command: "pip install tsfresh"
+category: Data
+tags:
+  - time-series
+  - feature-extraction
+  - feature-engineering
+  - python
+  - signal-processing
+  - machine-learning
+  - data-preparation
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Time-series feature engineering requires extensive domain knowledge in signal processing, statistics, and spectral analysis to extract meaningful patterns — practitioners must manually implement lag features, rolling statistics, Fourier transforms, and peak detection for each use case. tsfresh automates this by extracting 794 pre-defined features from each time series (mean, variance, FFT coefficients, autocorrelation, entropy, wavelet transforms), tests them for significance against the target variable, and filters irrelevant features — enabling non-experts to build high-quality time-series features in minutes."
+use_cases:
+  - "Extract hundreds of statistical and spectral features from sensor time-series data for predictive maintenance, anomaly detection, and equipment failure prediction"
+  - "Automatically filter relevant time-series features for forecasting workloads (demand forecasting, energy load prediction) using the built-in hypothesis-testing feature selector"
+  - "Generate scikit-learn-compatible feature matrices from large collections of time series for classification and regression on sequential data"


### PR DESCRIPTION
Add statsmodels (11.5k★), Featuretools (7.7k★), tsfresh (9.3k★), Seaborn (14k★), and Altair (10.4k★) to the catalog — foundational Python data science and statistical visualization libraries for ML workflows.

- **statsmodels**: Statistical modeling, hypothesis testing, and time-series analysis in Python (BSD-3-Clause, `pip install statsmodels`)
- **Featuretools**: Automated feature engineering via deep feature synthesis for relational and temporal data (BSD-3-Clause, `pip install featuretools`)
- **tsfresh**: Automatic extraction and filtering of 794 time-series features for ML (MIT, `pip install tsfresh`)
- **Seaborn**: High-level statistical data visualization built on Matplotlib (BSD-3-Clause, `pip install seaborn`)
- **Altair**: Declarative interactive visualization based on Vega-Lite grammar (BSD-3-Clause, `pip install altair`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Altair, Featuretools, Seaborn, statsmodels, and tsfresh.
  * Included descriptions, use cases, categories, tags, licensing, pricing, installation commands, and project documentation links for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->