### PR TITLE
Add Catalyst, Ignite, Vega to catalog

### DIFF
--- a/tools/dev-tools/catalyst.yaml
+++ b/tools/dev-tools/catalyst.yaml
@@ -1,0 +1,24 @@
+name: Catalyst
+description: "A PyTorch framework for reproducible and accelerated deep learning research and development, providing a high-level training API with callbacks, metrics logging, checkpointing, distributed training support, and configuration-driven experiment pipelines."
+tagline: "Accelerated deep learning research with PyTorch"
+github_url: https://github.com/catalyst-team/catalyst
+website_url: https://catalyst-team.github.io/catalyst
+docs_url: https://catalyst-team.github.io/catalyst
+install_command: "pip install catalyst"
+category: Dev Tools
+tags:
+  - deep-learning
+  - pytorch
+  - training
+  - experiment-management
+  - distributed-training
+  - callbacks
+  - reproducible-research
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "PyTorch provides flexible building blocks for deep learning but requires significant boilerplate for training loops, metric tracking, checkpointing, distributed training, and experiment configuration — every project reinvents the same training infrastructure. Catalyst provides a unified training API with configurable callbacks, automatic logging (TensorBoard, MLflow, W&B), checkpoint management, mixed-precision training, and multi-GPU/distributed training support, letting researchers focus on model architecture and data instead of training loop plumbing."
+use_cases:
+  - "Train computer vision and NLP models with a configurable pipeline that handles checkpointing, metric logging, and early stopping without manual loop code"
+  - "Scale training from single GPU to multi-node distributed setups with automatic configuration of DDP, mixed precision (AMP), and gradient accumulation"
+  - "Reproduce experiments across team members using YAML-based configuration files that define the full training pipeline — optimizer, scheduler, augmentations, and callbacks"

--- a/tools/dev-tools/ignite.yaml
+++ b/tools/dev-tools/ignite.yaml
@@ -1,0 +1,24 @@
+name: Ignite
+description: "A high-level PyTorch library for training and evaluating neural networks, providing an abstract Engine class with event-driven handlers for logging, checkpointing, early stopping, distributed training, and hyperparameter tuning."
+tagline: "High-level training library for PyTorch"
+github_url: https://github.com/pytorch/ignite
+website_url: https://pytorch-ignite.ai
+docs_url: https://pytorch-ignite.ai/reference/
+install_command: "pip install pytorch-ignite"
+category: Dev Tools
+tags:
+  - deep-learning
+  - pytorch
+  - training
+  - distributed-training
+  - experiment-tracking
+  - handlers
+  - event-driven
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Training PyTorch models in production requires managing event-driven workflows — checkpointing after every N epochs, logging metrics, running validation, adjusting learning rates, and stopping early — which leads to deeply nested and hard-to-maintain training scripts. Ignite solves this with an event-driven Engine that fires events at each step, epoch, and completion, letting users attach handlers (built-in or custom) for checkpointing, metric computation, logging to TensorBoard/MLflow, distributed training setup, and hyperparameter tuning. Training code becomes a clean composition of handlers rather than procedural loops."
+use_cases:
+  - "Build production training pipelines using the event-driven Engine with handlers for automatic checkpointing, metric computation, and early stopping on plateau"
+  - "Scale training across multiple GPUs and nodes with automatic DDP configuration, gradient clipping, and mixed precision support"
+  - "Integrate experiment tracking (TensorBoard, MLflow, W&B) and hyperparameter optimization (Grid, Random, Optuna) through handler-based composition without modifying training logic"

--- a/tools/other/vega.yaml
+++ b/tools/other/vega.yaml
@@ -1,0 +1,23 @@
+name: Vega
+description: "A declarative grammar of interactive graphics for creating, sharing, and publishing interactive data visualizations on the web. Vega defines visualization designs as JSON specifications that produce rich, interactive multi-view graphics."
+tagline: "Declarative interactive visualization grammar"
+github_url: https://github.com/vega/vega
+website_url: https://vega.github.io/vega
+docs_url: https://vega.github.io/vega/docs
+install_command: "pip install vega"
+category: Other
+tags:
+  - data-visualization
+  - interactive-graphics
+  - declarative-visualization
+  - javascript
+  - web-visualization
+  - grammar-of-graphics
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Building rich, interactive, multi-view web visualizations from scratch requires deep expertise in JavaScript, SVG, Canvas, D3.js, and event handling — a specialized skill most data scientists and analysts do not have. Vega solves this with a declarative JSON grammar that specifies visual marks (bars, lines, points), encoding channels (x, y, color, size), interactions (tooltips, zoom, pan, selection), and multi-view coordination (linked brushing, cross-filtering). Any data professional can create sophisticated interactive graphics by writing a JSON specification, and the Vega ecosystem (Vega-Lite, Altair, Vega-Embed) makes this accessible from Python and other languages."
+use_cases:
+  - "Create interactive multi-view dashboards with linked brushing and cross-filtering where selecting data in one chart automatically highlights related data across all views"
+  - "Design custom interactive visualization specifications as JSON for embedding in web applications, reports, and data journalism with full declarative control over marks, encodings, and interactions"
+  - "Serve as the rendering backend for high-level libraries (Altair, Vega-Lite) that generate Vega specifications programmatically from Python, R, and Julia"


### PR DESCRIPTION
Add Catalyst (3.4k★), Ignite (4.8k★), and Vega (11.9k★) to the catalog — PyTorch training frameworks and a declarative visualization grammar.

- **Catalyst**: Accelerated deep learning R&D framework for PyTorch with callbacks, metrics, checkpointing, and distributed training (Apache-2.0, `pip install catalyst`)
- **Ignite**: Event-driven high-level PyTorch training library with handler-based composition for logging, checkpointing, and distributed training (BSD-3-Clause, `pip install pytorch-ignite`)
- **Vega**: Declarative grammar of interactive graphics for creating rich multi-view visualizations as JSON specifications (BSD-3-Clause, `pip install vega`)
