### PR TITLE
Add Poetry, Conda, HTTPX, Cython to catalog

### DIFF
--- a/tools/dev-tools/conda.yaml
+++ b/tools/dev-tools/conda.yaml
@@ -1,0 +1,33 @@
+name: Conda
+description: An open-source package management and environment management system that installs and manages software packages across platforms. Conda works with any language and is the standard environment manager for the scientific Python and data science ecosystem.
+tagline: Cross-platform package and environment management
+
+github_url: https://github.com/conda/conda
+website_url: https://docs.conda.io
+docs_url: https://docs.conda.io
+
+category: Dev Tools
+tags: [python, package-manager, environment-management, data-science, cross-platform, developer-tools]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: brew install --cask miniconda
+
+problem_solved: |
+  Python environments on HPC clusters and data science workstations need
+  non-Python dependencies (CUDA, BLAS, OpenMP, HDF5) that pip cannot install,
+  and system package managers (apt, brew) install incompatible versions. Conda
+  provides language-agnostic package management with pre-built binaries for
+  Linux, macOS, and Windows. It resolves and installs Python packages AND
+  their native library dependencies (cuDNN, MKL, libgcc) in isolated
+  environments. The result is reproducible scientific computing stacks that
+  include C/C++/Fortran libraries, GPU toolkits, and Python packages in one
+  atomic operation.
+
+use_cases:
+  - Install and isolate ML environments with GPU dependencies (CUDA, cuDNN, NCCL) alongside PyTorch or TensorFlow in one command
+  - Manage Python versions and package sets for Jupyter notebook environments on shared HPC or academic compute clusters
+  - Create reproducible conda environment YAML files for research projects that pin both Python and C library versions
+  - Distribute scientific Python software that depends on native C/C++/Fortran libraries (GDAL, netCDF, VTK) across platforms
+  - Build and deploy containerized data science pipelines using conda-pack for portable environment snapshots

--- a/tools/dev-tools/cython.yaml
+++ b/tools/dev-tools/cython.yaml
@@ -1,0 +1,32 @@
+name: Cython
+description: The de-facto standard Python-to-C compiler that translates annotated Python code into C extensions. Cython combines Python's ease of use with C's performance, supporting static type declarations, direct C library calls, and NumPy array integration.
+tagline: Optimizing Python-to-C compiler for high-performance extensions
+
+github_url: https://github.com/cython/cython
+website_url: https://cython.org
+docs_url: https://cython.readthedocs.io
+
+category: Dev Tools
+tags: [python, c, compiler, performance, numpy, c-extension, developer-tools]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install cython
+
+problem_solved: |
+  Python's interpreted nature makes tight numerical loops, buffer manipulation,
+  and C library binding 10-100x slower than native code. Writing C extensions
+  manually requires deep CPython API knowledge and verbose boilerplate. Cython
+  accepts .pyx files that look like Python but allow optional static type
+  declarations (cdef, cpdef, C structs). It compiles them to C and then to
+  shared objects (.so) that import as normal Python modules. Critical inner
+  loops can match C speed while the rest of the file remains pure Python,
+  providing a smooth gradient from prototype to production performance.
+
+use_cases:
+  - Speed up Python data processing pipelines by annotating hot loops with static C types for 10-100x performance gains
+  - Wrap existing C/C++ libraries (signal processing, computer vision, serialization) as importable Python modules without writing CPython API code
+  - Build high-performance NumPy-aware algorithms with typed memory views that operate on array data without Python overhead
+  - Create custom PyTorch CUDA extensions by combining Cython's integration with CUDA Python and pybind11 for training loop optimizations
+  - Optimize ML preprocessing and feature engineering steps that cannot be vectorized with NumPy, replacing loops with C-speed compiled code

--- a/tools/dev-tools/httpx.yaml
+++ b/tools/dev-tools/httpx.yaml
@@ -1,0 +1,32 @@
+name: HTTPX
+description: A fully featured Python HTTP client library with an async API built on h11/h2 for HTTP/1.1 and HTTP/2 support. HTTPX provides a modern requests-compatible interface with async/await, connection pooling, and HTTP/2 by default.
+tagline: Modern Python HTTP client with async and HTTP/2 support
+
+github_url: https://github.com/encode/httpx
+website_url: https://www.python-httpx.org
+docs_url: https://www.python-httpx.org
+
+category: Dev Tools
+tags: [python, http-client, async, http2, api-client, networking, developer-tools]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install httpx
+
+problem_solved: |
+  Calling REST APIs and LLM inference endpoints from Python requires an HTTP
+  client that handles connection pooling, retries, timeouts, and streaming
+  efficiently. The standard urllib is low-level and verbose, while requests is
+  synchronous-only and lacks HTTP/2. HTTPX provides a familiar requests-style
+  API with native async/await, HTTP/2 multiplexing, connection keep-alive, and
+  rich timeout/retry configuration. Code written with HTTPX works identically
+  in sync and async contexts, and its h11/h2 stack gives fine-grained control
+  over the HTTP protocol without sacrificing convenience.
+
+use_cases:
+  - Call LLM provider APIs (OpenAI, Anthropic, Together) with async streaming, connection pooling, and automatic retry for production inference
+  - Build async web scrapers and data ingestion pipelines that multiplex hundreds of concurrent HTTP requests over HTTP/2 connections
+  - Replace requests in existing codebases for a drop-in upgrade to HTTP/2 and async support with minimal API changes
+  - Implement API client wrappers with automatic JSON serialization, auth headers, and custom transport layers for mock testing
+  - Stream server-sent events (SSE) from real-time AI inference endpoints with on-the-fly decoding and backpressure handling

--- a/tools/dev-tools/poetry.yaml
+++ b/tools/dev-tools/poetry.yaml
@@ -1,0 +1,32 @@
+name: Poetry
+description: A Python dependency management and packaging tool that uses pyproject.toml for configuration. Poetry handles virtual environments, dependency resolution, building, and publishing to PyPI with a single consistent CLI.
+tagline: Modern Python dependency and packaging management
+
+github_url: https://github.com/python-poetry/poetry
+website_url: https://python-poetry.org
+docs_url: https://python-poetry.org/docs
+
+category: Dev Tools
+tags: [python, dependency-management, packaging, pyproject-toml, virtualenv, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install poetry
+
+problem_solved: |
+  Python projects suffer from dependency conflicts, missing lock files, and
+  inconsistent environment reproduction across machines. Poetry replaces pip,
+  virtualenv, setuptools, and twine with a single tool: it creates and manages
+  virtual environments, resolves dependencies with a SAT solver that produces
+  deterministic lock files, and builds and publishes packages to PyPI from a
+  single pyproject.toml. The lock file and resolver guarantee that every
+  developer and CI environment installs identical dependency trees, eliminating
+  "works on my machine" failures and transitive-dependency surprises.
+
+use_cases:
+  - Manage Python AI/ML project dependencies with deterministic lock files that reproduce identically across dev, CI, and production
+  - Publish Python packages (client SDKs, utility libraries, model wrappers) to PyPI with a single `poetry publish` command
+  - Isolate project environments automatically without manual venv activation or conda environment switching
+  - Build Docker containers with poetry export --without-hashes for pip-installable requirements.txt files
+  - Manage monorepo Python packages with workspace support, shared lock file, and editable installs across packages


### PR DESCRIPTION
This PR adds 4 new tool entries to the catalog:

- **Poetry** (Dev Tools) — Modern Python dependency and packaging management
- **Conda** (Dev Tools) — Cross-platform package and environment management
- **HTTPX** (Dev Tools) — Modern Python HTTP client with async and HTTP/2 support
- **Cython** (Dev Tools) — Optimizing Python-to-C compiler for high-performance extensions
