### PR TITLE
Add SQLAlchemy, Debezium, Elastic APM, MLRun to catalog

### DIFF
--- a/tools/data/debezium.yaml
+++ b/tools/data/debezium.yaml
@@ -1,0 +1,24 @@
+name: Debezium
+description: Open-source distributed platform for change data capture (CDC) that streams database row-level changes into event streams in real-time, enabling reliable data synchronization between databases and data pipelines.
+tagline: Stream database changes to data pipelines in real-time
+
+github_url: https://github.com/debezium/debezium
+website_url: https://debezium.io
+docs_url: https://debezium.io/documentation
+install_command: docker pull debezium/connect
+
+category: Data
+tags: [cdc, change-data-capture, streaming, kafka, data-integration, etl, real-time]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  ML pipelines and data platforms need access to real-time data changes from production databases for feature computation, model retraining triggers, and analytical data synchronization. Traditional batch ETL introduces hours of latency and misses incremental changes. Debezium solves this by capturing every row-level insert, update, and delete from databases like PostgreSQL, MySQL, MongoDB, and SQL Server, streaming them as ordered event streams through Kafka or other messaging systems. This enables ML systems to react to data changes in sub-second real-time without polling or batch processing.
+
+use_cases:
+  - Stream real-time feature updates from production databases into feature stores for online ML model inference with sub-second latency
+  - Trigger automated model retraining pipelines when source data changes reach configurable thresholds in the change stream
+  - Synchronize training data across heterogeneous database environments for consistent multi-source ML datasets
+  - Build event-driven data pipelines that transform database changes into structured feature vectors for real-time ML serving
+  - Replicate production database changes to analytical stores (data warehouses, vector databases) for offline ML training without affecting production workloads

--- a/tools/data/sqlalchemy.yaml
+++ b/tools/data/sqlalchemy.yaml
@@ -1,0 +1,24 @@
+name: SQLAlchemy
+description: The most widely-used Python SQL toolkit and Object-Relational Mapper, providing a full suite of enterprise-level database connectivity, ORM, and SQL expression language for Python data applications.
+tagline: Python SQL toolkit and ORM for database access
+
+github_url: https://github.com/sqlalchemy/sqlalchemy
+website_url: https://www.sqlalchemy.org
+docs_url: https://docs.sqlalchemy.org
+install_command: pip install sqlalchemy
+
+category: Data
+tags: [orm, database, sql, python, data-access, etl, data-engineering]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  ML and data engineering pipelines need to read, write, and transform data from relational databases, but raw SQL is brittle, database-specific, and hard to compose with Python data processing code. SQLAlchemy solves this by providing a high-level SQL abstraction layer that works with 15+ database backends (PostgreSQL, MySQL, SQLite, etc.) while maintaining performance. Its ORM maps Python objects to database tables for intuitive data access, and its Core SQL Expression Language enables programmatic query construction for dynamic ETL pipelines feeding ML training datasets.
+
+use_cases:
+  - Build robust ETL pipelines that extract training data from production databases, transform it into feature tables, and load it into ML-ready formats
+  - Manage ML experiment metadata, hyperparameter runs, and model registry tables with programmatic Python database access
+  - Construct dynamic SQL queries for feature engineering and data aggregation pipelines that adapt to changing data schemas
+  - Support multi-database backends in ML platform infrastructure without rewriting SQL for PostgreSQL, MySQL, SQLite, and cloud databases
+  - Automate database schema migrations and version control for ML application databases with Alembic integration

--- a/tools/dev-tools/mlrun.yaml
+++ b/tools/dev-tools/mlrun.yaml
@@ -1,0 +1,24 @@
+name: MLRun
+description: Open-source MLOps orchestration framework for managing the full ML lifecycle from data ingestion and feature engineering through model training, deployment, and monitoring on Kubernetes.
+tagline: Orchestrate and automate ML pipelines from development to production
+
+github_url: https://github.com/mlrun/mlrun
+website_url: https://www.mlrun.org
+docs_url: https://docs.mlrun.org
+install_command: pip install mlrun
+
+category: Dev Tools
+tags: [mlops, pipelines, orchestration, kubernetes, automation, model-deployment, feature-store]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  ML teams struggle to move from notebook experiments to production because there is no unified platform that handles data preparation, feature computation, model training, deployment, and monitoring as a cohesive workflow. MLRun solves this by providing a serverless MLOps framework that orchestrates the entire ML lifecycle on Kubernetes. It handles automatic ingestion of data sources, real-time and batch feature computation through its integrated feature store, distributed training job submission, model packaging with versioning, automated deployment to serverless or Kubernetes serving runtimes, and real-time model monitoring with drift detection — all through a unified Python API.
+
+use_cases:
+  - Build end-to-end ML pipelines that automate data ingestion, feature engineering, model training, and deployment in a single serverless workflow
+  - Manage online and offline feature computation through an integrated feature store that serves both training and inference with consistent transformations
+  - Deploy ML models to production with one command, automatically packaging them into serverless functions or Kubernetes deployments with auto-scaling
+  - Monitor production model performance with automated drift detection, data quality alerts, and real-time prediction logging
+  - Run distributed hyperparameter tuning and training jobs on Kubernetes clusters with automatic resource management and parallel execution

--- a/tools/monitoring/elastic-apm.yaml
+++ b/tools/monitoring/elastic-apm.yaml
@@ -1,0 +1,24 @@
+name: Elastic APM
+description: Application performance monitoring solution from Elastic that traces requests across distributed services, capturing errors, latency, and throughput metrics with deep code-level visibility for AI-powered applications.
+tagline: Distributed tracing and performance monitoring for modern applications
+
+github_url: https://github.com/elastic/apm-server
+website_url: https://www.elastic.co/observability/apm
+docs_url: https://www.elastic.co/guide/en/apm
+install_command: pip install elastic-apm
+
+category: Monitoring
+tags: [apm, distributed-tracing, observability, performance, elastic, monitoring, troubleshooting]
+pricing: freemium
+is_open_source: false
+license: NOASSERTION
+
+problem_solved: |
+  AI applications composed of multiple microservices — model serving, embedding generation, vector search, prompt processing, and feedback collection — make it extremely difficult to pinpoint performance bottlenecks and error sources across the request chain. Elastic APM solves this by providing end-to-end distributed tracing that follows a single user request through every service, AI model call, and database query. It automatically maps service dependencies, captures request payloads and responses, and surfaces anomalous latency and error rates with code-level context, enabling ML teams to quickly resolve production inference issues.
+
+use_cases:
+  - Trace LLM inference requests end-to-end across the model serving tier, embedding generation, vector search, and prompt preprocessing services
+  - Identify slow model inference endpoints by analyzing per-request breakdowns of model load time, inference time, and response serialization
+  - Monitor AI application error rates with automatic error grouping and code-level stack traces to rapidly diagnose model serving failures
+  - Track throughput and latency SLAs for production AI endpoints with historical trending and anomaly detection on key performance metrics
+  - Map service dependencies in multi-model AI pipelines to understand the blast radius of any single service degradation


### PR DESCRIPTION
This PR adds 4 tools to the catalog:

- **SQLAlchemy** — Python SQL toolkit and ORM for database access in ML data pipelines (12k★, MIT)
- **Debezium** — Open-source change data capture platform for real-time database event streaming (12.9k★, Apache-2.0)
- **Elastic APM** — Application performance monitoring with distributed tracing for AI applications (1.2k★)
- **MLRun** — Open-source MLOps orchestration framework for managing the full ML lifecycle on Kubernetes (1.6k★, Apache-2.0)
