### PR TITLE
Add Hazelcast, Apache Ignite to catalog

### DIFF
--- a/tools/data/apache-ignite.yaml
+++ b/tools/data/apache-ignite.yaml
@@ -1,0 +1,30 @@
+name: Apache Ignite
+description: >-
+  A distributed database, caching, and processing platform designed for high-performance computing with in-memory speed. Provides ACID transactions, SQL querying, machine learning primitives, and compute grid capabilities — deployed as part of data infrastructure for ML feature stores, real-time analytics, and large-scale AI data pipelines.
+tagline: Distributed database and in-memory computing platform
+github_url: https://github.com/apache/ignite
+website_url: https://ignite.apache.org
+docs_url: https://ignite.apache.org/docs/latest/
+
+category: Data
+tags: [in-memory-computing, distributed-database, caching, sql, data-platform, apache, java]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  ML feature stores, real-time inference pipelines, and large-scale data processing need
+  a data platform that combines the speed of in-memory access with the reliability of
+  durable storage and the expressiveness of SQL. Using separate caches, databases, and
+  compute engines creates data movement overhead and operational complexity. Apache Ignite
+  solves this by providing a distributed in-memory data platform with ACID transactions,
+  ANSI SQL support, machine learning primitives, and compute grid capabilities — all in
+  one system. Data stays in memory across the cluster for fast access, while durable
+  storage and distributed computing eliminate the need to shuttle data between tiers.
+
+use_cases:
+  - Power a real-time ML feature store that serves features for online inference from in-memory data with ACID guarantees
+  - Run distributed ML training and scoring jobs directly on in-memory data without moving it to a separate compute cluster
+  - Cache model predictions, embeddings, and intermediate results with sub-millisecond access across an inference serving fleet
+  - Deploy a high-throughput SQL-queryable cache layer for real-time analytics dashboards monitoring model performance
+  - Build a distributed compute grid for large-scale data preprocessing and feature engineering that runs in-place on cached data

--- a/tools/data/hazelcast.yaml
+++ b/tools/data/hazelcast.yaml
@@ -1,0 +1,30 @@
+name: Hazelcast
+description: >-
+  A unified real-time data platform combining stream processing with a fast in-memory data store. Provides distributed computing with partitioning, replication, and elastic scalability for data-intensive applications including real-time ML inference, feature computation, and event-driven AI pipelines.
+tagline: Real-time stream processing and in-memory data grid
+github_url: https://github.com/hazelcast/hazelcast
+website_url: https://hazelcast.com
+docs_url: https://docs.hazelcast.com
+
+category: Data
+tags: [stream-processing, in-memory-data-grid, distributed-computing, caching, data-platform, java]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  AI pipelines that need real-time processing — streaming feature computation, online
+  inference aggregation, or event-driven model scoring — require a platform that combines
+  fast data access with stream processing. Separate databases and stream processors add
+  latency and complexity. Hazelcast solves this by unifying an in-memory data store with
+  embedded stream processing in a single horizontally scalable platform. Data is stored
+  partitioned across the cluster with near-line access, and computations run where the
+  data lives — eliminating serialization overhead and network round trips for real-time
+  ML workloads.
+
+use_cases:
+  - Compute streaming features in real time for online ML inference without round-tripping through a separate database
+  - Aggregate and score incoming events against ML models with sub-millisecond latency for fraud detection and personalization
+  - Build real-time feature engineering pipelines that transform and serve features directly from streaming data
+  - Deploy a distributed cache layer for model predictions, embeddings, and lookup tables across an inference cluster
+  - Run continuous ML inference on event streams with exactly-once processing semantics and elastic scalability


### PR DESCRIPTION
## New Catalog Additions

This PR adds 2 additional tools to the Agentic AI For Good catalog:

| Tool | Category | Description |
|------|----------|-------------|
| **Hazelcast** | Data | Unified real-time data platform combining stream processing with an in-memory data store |
| **Apache Ignite** | Data | Distributed database, caching, and processing platform for high-performance computing |

Both tools have been validated locally with `npx tsx scripts/validate-tool.ts`.
