### PR TITLE
Add Faker, InterpretML, Eli5, TorchGeo, Haiku, Optax to catalog

### DIFF
--- a/tools/data/eli5.yaml
+++ b/tools/data/eli5.yaml
@@ -1,0 +1,31 @@
+name: Eli5
+description: A Python library for debugging and inspecting machine learning classifiers and explaining their predictions using feature attributions, permutation importance, and dependency visualization.
+tagline: Debug ML models with feature importance and prediction explanations
+
+github_url: https://github.com/TeamHG-Memex/eli5
+docs_url: https://eli5.readthedocs.io
+
+category: Data
+tags: [python, explainability, debugging, feature-importance, inspection]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install eli5
+
+problem_solved: |
+  Machine learning models often behave unexpectedly — they rely on spurious
+  correlations, overfit to noise, or fail silently on edge cases. Eli5 provides
+  simple, visual tools for inspecting what a model has learned: it computes
+  per-feature importance weights, highlights which tokens matter in text
+  classifiers, shows decision trees in readable formats, and measures how
+  prediction quality degrades when each feature is shuffled. This makes it easy
+  to catch data leakage, confirm that important features are sensible, and
+  communicate model behavior to non-experts.
+
+use_cases:
+  - Inspect feature weights in a linear classifier to catch unexpected spurious correlations in training data
+  - Highlight the most influential tokens in a text classifier to verify it uses meaningful linguistic patterns
+  - Debug an XGBoost model by comparing permutation importance against built-in feature importance metrics
+  - Explain individual predictions with per-feature contribution breakdowns for auditability
+  - Validate feature engineering by measuring which engineered features actually improve prediction quality

--- a/tools/data/faker.yaml
+++ b/tools/data/faker.yaml
@@ -1,0 +1,28 @@
+name: Faker
+description: A Python library for generating fake data — names, addresses, phone numbers, emails, dates, text, and more — for testing, development, and data anonymization.
+tagline: Generate realistic fake data for testing and development
+
+github_url: https://github.com/joke2k/faker
+docs_url: https://faker.readthedocs.io
+
+category: Data
+tags: [python, synthetic-data, testing, data-generation, anonymization]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install faker
+
+problem_solved: |
+  Real-world data is often unavailable, sensitive, or too structured for effective
+  testing. Faker generates realistic fake data across dozens of providers (names,
+  addresses, phone numbers, emails, dates, company info, text) so developers can
+  build and test data pipelines, populate databases, anonymize datasets, and
+  prototype ML features without exposing real personal information.
+
+use_cases:
+  - Populate a test database with realistic user profiles, addresses, and transaction records
+  - Anonymize sensitive production data by replacing PII fields with synthetic equivalents
+  - Generate training features for ML models that need realistic text, location, or temporal data
+  - Create bulk test datasets for benchmarking data pipeline throughput and correctness
+  - Prototype feature engineering workflows against data that mirrors real-world distributions

--- a/tools/data/interpretml.yaml
+++ b/tools/data/interpretml.yaml
@@ -1,0 +1,30 @@
+name: InterpretML
+description: An open-source Python framework for training interpretable machine learning models and explaining black-box model predictions with glass-box, global, and local explanations.
+tagline: Train interpretable models and explain any black-box ML system
+
+github_url: https://github.com/interpretml/interpret
+website_url: https://interpret.ml
+docs_url: https://interpret.ml/docs
+
+category: Data
+tags: [python, explainability, interpretability, glassbox, model-debugging]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install interpret
+
+problem_solved: |
+  Complex ML models like neural networks and gradient boosting are powerful but
+  opaque — stakeholders can't trust predictions they don't understand. InterpretML
+  provides both glass-box models (Explainable Boosting Machines, decision trees)
+  that are inherently interpretable, and black-box explainers (SHAP, LIME, Morris
+  sensitivity) that shed light on any model. This lets data scientists debug models,
+  justify predictions to regulators, and build trust with non-technical stakeholders.
+
+use_cases:
+  - Debug a gradient-boosted model by identifying which features drive incorrect predictions
+  - Generate global feature importance reports for regulatory compliance in finance or healthcare
+  - Compare a glass-box model's accuracy against a black-box model to decide the interpretability-accuracy tradeoff
+  - Explain individual predictions to end users (loan denial reasons, claim decisions) with human-readable attributions
+  - Detect data drift and concept drift by monitoring how feature importance distributions shift over time

--- a/tools/data/torchgeo.yaml
+++ b/tools/data/torchgeo.yaml
@@ -1,0 +1,31 @@
+name: TorchGeo
+description: A PyTorch domain library for geospatial data — satellite imagery, aerial photos, and digital elevation models — with datasets, samplers, transforms, and pre-trained models.
+tagline: Geospatial deep learning with PyTorch
+
+github_url: https://github.com/microsoft/torchgeo
+docs_url: https://torchgeo.readthedocs.io
+
+category: Data
+tags: [python, pytorch, geospatial, satellite-imagery, remote-sensing, gis]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install torchgeo
+
+problem_solved: |
+  Geospatial machine learning has a high barrier to entry — satellite and aerial
+  imagery come in non-standard formats (GeoTIFFs with coordinate reference
+  systems, multi-band rasters, temporal sequences), standard CV datasets and
+  transforms don't handle them, and pre-trained models rarely transfer. TorchGeo
+  provides PyTorch Dataset and DataLoader classes that natively handle
+  geospatial data: multi-band rasters, geographic sampling (random point
+  sampling, bounding boxes), coordinate transforms, and sensor-specific
+  augmentations. It also bundles pre-trained models on remote sensing benchmarks.
+
+use_cases:
+  - Train a land cover classification model on satellite imagery with proper geographic sampling and augmentation
+  - Detect changes in satellite images over time using temporal sequences of multi-spectral data
+  - Fine-tune pre-trained remote sensing models (ResNet, Swin) on custom aerial photography datasets
+  - Build a crop type mapping pipeline that integrates with Sentinel-2 or Landsat data feeds
+  - Create geospatial embeddings for similarity search across large satellite image archives

--- a/tools/dev-tools/optax.yaml
+++ b/tools/dev-tools/optax.yaml
@@ -1,0 +1,31 @@
+name: Optax
+description: A gradient processing and optimization library for JAX providing composable optimizers, gradient transformations, and learning rate schedules with a functional API.
+tagline: Composable gradient optimization for JAX
+
+github_url: https://github.com/google-deepmind/optax
+docs_url: https://optax.readthedocs.io
+
+category: Dev Tools
+tags: [python, jax, optimization, gradient-processing, deep-learning, deepmind]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install optax
+
+problem_solved: |
+  Training neural networks in JAX requires implementing optimization logic from
+  scratch or adapting frameworks built for eager-execution paradigms. Optax
+  provides a library of composable gradient transformations — Adam, SGD with
+  momentum, RMSProp, gradient clipping, weight decay, learning rate schedules,
+  and more — that combine cleanly via functional composition. Each transformation
+  is a pure function that can be chained, inspected, and debugged independently.
+  This lets researchers experiment with optimizer variants (AdamW, Lion, AdaFactor,
+  schedule-free methods) by composing transformations rather than rewriting loops.
+
+use_cases:
+  - Train a ResNet on ImageNet with a custom optimizer chain combining Adam, gradient clipping, and cosine decay
+  - Experiment with different optimizer schedules (warmup, cosine, step decay) by swapping chain components
+  - Implement distributed training with multiple gradient accumulations and synchronized weight updates
+  - Add gradient noise and norm clipping for privacy-preserving training with differentially private SGD
+  - Debug training instability by tracing per-layer gradient statistics through the transform chain

--- a/tools/other/haiku.yaml
+++ b/tools/other/haiku.yaml
@@ -1,0 +1,31 @@
+name: Haiku
+description: A JAX-based neural network library by DeepMind providing simple, composable modules and transforms for building deep learning models with functional programming patterns.
+tagline: Simple neural network building blocks for JAX
+
+github_url: https://github.com/google-deepmind/haiku
+docs_url: https://dm-haiku.readthedocs.io
+
+category: Other
+tags: [python, jax, neural-networks, deep-learning, deepmind, functional]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install dm-haiku
+
+problem_solved: |
+  JAX's pure-functional, transform-based approach is powerful but requires
+  boilerplate — managing parameter collections, random state, and model
+  initialization manually. Haiku provides a familiar object-oriented API
+  (hiking.Module) on top of JAX that feels like PyTorch or Sonnet but
+  composes cleanly with JAX transforms. It handles parameter initialization,
+  random key splitting, and module wiring automatically while preserving
+  full access to JAX's jit, vmap, pmap, and grad transforms. The result is
+  cleaner code for research-scale neural network experiments in JAX.
+
+use_cases:
+  - Build a transformer encoder with Haiku's Module API and train it end-to-end with JAX's grad and jit transforms
+  - Implement a custom neural network layer that composes with vmap for efficient batch processing
+  - Prototype a deep reinforcement learning policy network with stochastic modules and parameter sharing
+  - Experiment with different network architectures by swapping Haiku module configurations in a training loop
+  - Train a large-scale model across multiple TPUs using Haiku modules with JAX's pmap gradient aggregation


### PR DESCRIPTION
Add 6 new tools to the catalog:

- **Faker** — Generate realistic fake data for testing and development (19.3k★, MIT)
- **InterpretML** — Train interpretable ML models and explain black-box predictions (6.9k★, MIT)
- **Eli5** — Debug and inspect ML classifiers with feature attributions (2.8k★, MIT)
- **TorchGeo** — PyTorch domain library for geospatial deep learning (4.1k★, MIT)
- **Haiku** — DeepMind's JAX neural network library (3.3k★, Apache-2.0)
- **Optax** — Composable gradient optimization library for JAX (2.3k★, Apache-2.0)

Category distribution: Data (4), Other (1), Dev Tools (1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for six AI and Python tools: Eli5, Faker, InterpretML, TorchGeo, Optax, and Haiku.
  * Included descriptions, categories, tags, documentation links, installation instructions, licensing details, and practical use cases for each tool.
  * Added problem-solving summaries to help users evaluate and understand each tool’s capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->