### PR TITLE
Add MySQL, StatsD, Telegraf, Graphite, VictoriaMetrics to catalog

### DIFF
--- a/tools/data/mysql.yaml
+++ b/tools/data/mysql.yaml
@@ -1,0 +1,28 @@
+name: MySQL
+description: The world's most popular open-source relational database management system, powering countless AI and ML data pipelines with reliable, ACID-compliant storage.
+tagline: The world's most popular open-source database
+
+github_url: https://github.com/mysql/mysql-server
+website_url: https://www.mysql.com
+docs_url: https://dev.mysql.com/doc
+
+category: Data
+tags: [database, relational-database, sql, oltp, storage]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  AI and ML pipelines need reliable, performant storage for structured data —
+  feature tables, experiment metadata, user profiles, event logs, and inference
+  results. MySQL provides ACID-compliant transactional storage with SQL querying,
+  indexing, replication, and clustering that scales from single-node development
+  to multi-region production deployments, serving as the operational data layer
+  that feeds ML training and inference pipelines.
+
+use_cases:
+  - Store feature tables and training labels with ACID guarantees for ML experiment reproducibility
+  - Serve as the operational database for AI applications requiring transactional consistency
+  - Power data ingestion pipelines that collect and transform event data for model training
+  - Store user profiles, session data, and A/B experiment assignments for personalization models
+  - Act as the backend for ML workflow orchestrators that track pipeline state and metadata

--- a/tools/monitoring/graphite.yaml
+++ b/tools/monitoring/graphite.yaml
@@ -1,0 +1,32 @@
+name: Graphite
+description: A scalable time-series monitoring system that stores numeric metrics, renders on-demand graphs, and provides a powerful function API for data transformation and aggregation.
+tagline: Scalable time-series metrics storage and graphing
+
+github_url: https://github.com/graphite-project/graphite-web
+website_url: https://graphiteapp.org
+docs_url: https://graphite.readthedocs.io
+
+category: Monitoring
+tags: [monitoring, time-series, metrics, visualization, graphing]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install graphite-web
+
+problem_solved: |
+  AI applications emit millions of time-series data points — per-request latency,
+  model accuracy drift, GPU utilization, cache miss rates — that need to be stored
+  and queried historically without overwhelming the monitoring pipeline. Graphite
+  provides a purpose-built time-series database (Whisper) that stores numeric data
+  at configurable retention granularities, a rendering engine that generates graphs
+  on demand, and a powerful function API for aggregating, smoothing, and transforming
+  metrics at query time. Its simple text-based protocol and wide backend support
+  make it the standard storage layer for StatsD-collected metrics.
+
+use_cases:
+  - Store and visualize historical GPU utilization metrics across weeks of training runs
+  - Track model inference latency trends over time with moving averages and percentile aggregations
+  - Monitor embedding cache hit ratios with Graphite's consolidation and rollup functions
+  - Compare A/B deployment metrics (error rate, throughput, tail latency) across model versions
+  - Alert on metric anomalies using Graphite's data transformation functions for baseline deviation detection

--- a/tools/monitoring/statsd.yaml
+++ b/tools/monitoring/statsd.yaml
@@ -1,0 +1,29 @@
+name: StatsD
+description: A network daemon for aggregating application metrics (counters, timers, gauges) and forwarding them to backend monitoring systems with minimal overhead.
+tagline: Simple, lightweight metric aggregation for applications
+
+github_url: https://github.com/statsd/statsd
+docs_url: https://github.com/statsd/statsd/wiki
+
+category: Monitoring
+tags: [monitoring, metrics, observability, aggregation, instrumentation]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI applications generate high-cardinality metrics — request latencies, token
+  counts, cache hit rates, queue depths, error rates — that need to be collected
+  without impacting application performance. StatsD provides a lightweight UDP-based
+  protocol and daemon that receives metrics from thousands of application instances,
+  aggregates them over configurable flush intervals, and forwards the aggregated
+  data to backend stores like Graphite, Prometheus, or Datadog. Its stateless,
+  fire-and-forget design means even high-throughput inference services can emit
+  metrics with near-zero overhead.
+
+use_cases:
+  - Track LLM inference latency (time-to-first-token, tokens-per-second) as StatsD timers aggregated across replicas
+  - Monitor model serving error rates and request queue depths with StatsD gauges and counters
+  - Collect cache hit/miss ratios for embedding caches and KV caches in production AI services
+  - Aggregate GPU utilization and memory pressure metrics across a cluster of inference nodes
+  - Instrument batch inference pipelines to track throughput and job completion rates per model version

--- a/tools/monitoring/telegraf.yaml
+++ b/tools/monitoring/telegraf.yaml
@@ -1,0 +1,29 @@
+name: Telegraf
+description: A plugin-driven server agent for collecting, processing, and sending metrics and events from infrastructure, applications, and IoT sources.
+tagline: Plugin-driven metrics collection agent
+
+github_url: https://github.com/influxdata/telegraf
+docs_url: https://docs.influxdata.com/telegraf
+
+category: Monitoring
+tags: [monitoring, metrics, observability, data-collection, infrastructure]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  ML infrastructure generates metrics from heterogeneous sources — GPU utilization
+  from NVIDIA tools, model serving logs from HTTP endpoints, system metrics from
+  the OS, database connection pools, and custom application metrics — all in
+  different formats. Telegraf provides a single, plugin-based agent with 300+
+  input plugins (CPU, disk, nvidia-smi, Kafka, HTTP, Prometheus, MQTT, etc.) that
+  collect metrics from every layer of the stack, transform and enrich them, and
+  output to any monitoring backend (InfluxDB, Prometheus, Graphite, Datadog,
+  CloudWatch). This eliminates the need for separate collection agents per source.
+
+use_cases:
+  - Collect GPU utilization, memory, and temperature metrics from NVIDIA GPUs across a training cluster
+  - Ingest model serving latency and throughput metrics from HTTP endpoints and message queues
+  - Monitor training job resource usage (CPU, memory, disk, network) across distributed workers
+  - Aggregate infrastructure health metrics from Kubernetes, Docker, and host-level sensors
+  - Forward collected metrics to multiple backends simultaneously (InfluxDB for storage, Prometheus for alerting)

--- a/tools/monitoring/victoriametrics.yaml
+++ b/tools/monitoring/victoriametrics.yaml
@@ -1,0 +1,30 @@
+name: VictoriaMetrics
+description: A high-performance, cost-effective time-series database and monitoring solution compatible with Prometheus, Graphite, and OpenTSDB query APIs.
+tagline: High-performance time-series database for observability
+
+github_url: https://github.com/VictoriaMetrics/VictoriaMetrics
+website_url: https://victoriametrics.com
+docs_url: https://docs.victoriametrics.com
+
+category: Monitoring
+tags: [monitoring, time-series, metrics, prometheus-compatible, observability]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Traditional time-series databases like Prometheus struggle with high-cardinality
+  metrics at scale — they consume excessive memory, storage, and CPU when ingesting
+  millions of unique time series from distributed AI infrastructure. VictoriaMetrics
+  is a drop-in replacement for Prometheus that handles 10x more data with 10x less
+  storage by using custom compression, efficient index structures, and a clustered
+  architecture. It ingests Prometheus remote writes, Graphite plaintext, InfluxDB
+  line protocol, and OpenTSDB telnet/HTTP, making it a universal backend for any
+  metrics pipeline without rewriting instrumentation.
+
+use_cases:
+  - Replace Prometheus for large-scale ML infrastructure monitoring with 10x less storage and memory overhead
+  - Ingest GPU and training job metrics at high cardinality from thousands of inference nodes
+  - Store long-term metrics history (months to years) with automated data downsampling and retention
+  - Serve as a unified metrics backend for heterogeneous environments mixing Prometheus, StatsD, and Graphite protocols
+  - Query infrastructure metrics across hundreds of model deployments with sub-second response times at billion-series scale


### PR DESCRIPTION
Add 5 new tools to the catalog, focusing on data infrastructure and monitoring:

- **MySQL** — The world's most popular open-source relational database (12.4k★, GPL-2.0)
- **StatsD** — Lightweight UDP-based metric aggregation daemon (18k★, MIT)
- **Telegraf** — Plugin-driven metrics collection agent (17.7k★, MIT)
- **Graphite** — Scalable time-series metrics storage and graphing (6.1k★, Apache-2.0)
- **VictoriaMetrics** — High-performance Prometheus-compatible time-series DB (17.4k★, Apache-2.0)

Category distribution: Data (1), Monitoring (4)
