### PR TITLE
Add VerneMQ, Apache ActiveMQ to catalog

### DIFF
--- a/tools/data/activemq.yaml
+++ b/tools/data/activemq.yaml
@@ -1,0 +1,23 @@
+name: Apache ActiveMQ
+description: Apache ActiveMQ is a high-performance open-source message broker supporting JMS, AMQP, MQTT, STOMP, and OpenWire protocols. It provides reliable messaging between distributed AI services, microservices, and data pipeline components with support for transactions, persistence, and clustering.
+tagline: Open-source multi-protocol message broker for enterprise messaging
+
+github_url: https://github.com/apache/activemq
+website_url: https://activemq.apache.org
+docs_url: https://activemq.apache.org/documentation
+
+category: Data
+tags: [messaging, broker, jms, amqp, enterprise, distributed-systems, integration, openwire, stomp]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Enterprise AI systems need to integrate heterogeneous services — model servers, feature stores, data pipelines, monitoring agents — that speak different messaging protocols and require guaranteed delivery semantics. Standalone point-to-point integrations become brittle as the system grows. ActiveMQ solves this by providing a unified message broker that supports JMS, AMQP, MQTT, STOMP, and OpenWire on a single server, with broker clustering, message persistence via KahaDB or JDBC, and XA transactions for reliable message processing across distributed ML workflows.
+
+use_cases:
+  - Bridge legacy enterprise systems with new AI microservices by routing messages between different protocols
+  - Implement reliable request-reply messaging between model inference servers and feature stores with guaranteed delivery
+  - Create durable, transactional message queues for ML training job orchestration across distributed compute clusters
+  - Route real-time alerts from ML monitoring systems to downstream incident management platforms via AMQP
+  - Build event-driven AI pipelines with message persistence that survives broker restarts and network partitions

--- a/tools/data/vernemq.yaml
+++ b/tools/data/vernemq.yaml
@@ -1,0 +1,23 @@
+name: VerneMQ
+description: A high-performance distributed MQTT message broker designed for IoT, edge, and mobile messaging at scale. VerneMQ provides horizontal scalability, data persistence, and enterprise-grade security — making it suitable for connecting large fleets of AI-powered edge devices.
+tagline: Distributed MQTT broker for scalable IoT and mobile messaging
+
+github_url: https://github.com/vernemq/vernemq
+website_url: https://vernemq.com
+docs_url: https://docs.vernemq.com
+
+category: Data
+tags: [mqtt, messaging, iot, distributed-systems, edge-computing, pub-sub, broker]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Scaling MQTT-based IoT and edge AI deployments beyond a single broker node requires clustering, data replication, and seamless failover — features that simple standalone brokers lack. VerneMQ solves this with a distributed, multi-node MQTT broker that provides automatic clustering, session data replication across nodes, and full MQTT v5 compliance. It handles millions of concurrent sessions with consensus-based metadata storage via LevelDB, enabling IoT fleets to grow without re-architecting the messaging layer.
+
+use_cases:
+  - Connect and manage millions of edge AI devices under a clustered, fault-tolerant MQTT broker infrastructure
+  - Distribute IoT sensor data streams across multiple broker nodes for high-availability telemetry ingestion
+  - Enable seamless failover for mission-critical edge AI messaging without losing session state or queued messages
+  - Bridge MQTT device data to Kafka, webhooks, or data lakes for downstream ML training and analytics
+  - Implement fine-grained authentication and authorization for device-to-cloud messaging in regulated AI deployments


### PR DESCRIPTION
## Tools Added

This PR adds 2 tools to the Agentic AI For Good catalog:

- **VerneMQ** (Data) — High-performance distributed MQTT message broker for IoT and edge messaging at scale
- **Apache ActiveMQ** (Data) — Multi-protocol message broker supporting JMS, AMQP, MQTT, STOMP, and OpenWire
