### PR TITLE
Add Bun, PM2, Nomad, Packer, Rancher to catalog

### DIFF
--- a/tools/dev-tools/bun.yaml
+++ b/tools/dev-tools/bun.yaml
@@ -1,0 +1,24 @@
+name: Bun
+description: An all-in-one JavaScript runtime, bundler, transpiler, and package manager designed for speed. Bun replaces Node.js, npm, npx, and ts-node with a single fast binary — significantly reducing startup time and dependency management overhead in AI/ML web application development.
+tagline: Fast all-in-one JavaScript runtime and toolkit
+
+github_url: https://github.com/oven-sh/bun
+website_url: https://bun.sh
+docs_url: https://bun.sh/docs
+install_command: curl -fsSL https://bun.sh/install | bash
+
+category: Dev Tools
+tags: [javascript, runtime, bundler, package-manager, typescript, nodejs, web-development]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI application front-ends, model serving dashboards, and interactive demos often rely on JavaScript toolchains that are slow to start and complex to configure — Node.js startup overhead, npm install times, and separate tools for bundling and transpilation add friction to rapid prototyping. Bun solves this by providing a drop-in replacement for Node.js that starts 4x faster, implements 90% of the Node.js API, and replaces npm, npx, ts-node, and Webpack-style bundling in a single binary — streamlining the development loop for AI web applications.
+
+use_cases:
+  - Run interactive AI demo applications and model-serving dashboards with significantly faster cold-start times than Node.js
+  - Bundle and transpile TypeScript-based front-ends for AI application UIs without separate build tooling
+  - Manage npm dependencies for AI web projects with faster install times and built-in package resolution
+  - Run JavaScript-based data processing scripts for AI pipeline orchestration with near-instant startup
+  - Serve HTTP-based AI model endpoints using Bun's built-in web server API for rapid prototyping

--- a/tools/dev-tools/nomad.yaml
+++ b/tools/dev-tools/nomad.yaml
@@ -1,0 +1,23 @@
+name: Nomad
+description: HashiCorp Nomad is a flexible workload orchestrator for deploying and managing containerized and non-containerized applications across on-premise and cloud environments. It schedules batch ML training jobs, model serving microservices, and data pipeline workers across distributed infrastructure with a single unified workflow.
+tagline: Flexible workload orchestrator for any application at any scale
+
+github_url: https://github.com/hashicorp/nomad
+website_url: https://www.nomadproject.io
+docs_url: https://developer.hashicorp.com/nomad/docs
+
+category: Dev Tools
+tags: [orchestration, scheduling, batch-jobs, devops, containers, infrastructure, resource-management]
+pricing: freemium
+is_open_source: true
+license: BSL-1.1
+
+problem_solved: |
+  AI teams running diverse workloads — long-running model serving endpoints, batch training jobs, data pipeline workers, and GPU-accelerated tasks — either maintain separate orchestrators for each workload type or force everything through Kubernetes, which adds significant operational complexity. Nomad solves this with a single lightweight orchestrator that handles containers, standalone binaries, Java JARs, and raw executables using a declarative job specification. It integrates natively with HashiCorp Consul for service discovery and Vault for secrets management, providing a simpler alternative to Kubernetes for ML workloads that don't need its full container orchestration surface.
+
+use_cases:
+  - Schedule batch ML training jobs across a heterogeneous cluster of GPU and CPU nodes with resource-aware placement
+  - Deploy long-running model inference microservices with health checking, automatic restart, and rolling updates
+  - Run data pipeline workers as batch jobs that execute on schedule or on-demand with parameterized job specifications
+  - Co-locate GPU-accelerated training workloads with supporting services on the same cluster using a single orchestrator
+  - Orchestrate distributed hyperparameter sweeps and multi-node model evaluation tasks with Nomad parameterized jobs

--- a/tools/dev-tools/packer.yaml
+++ b/tools/dev-tools/packer.yaml
@@ -1,0 +1,23 @@
+name: Packer
+description: HashiCorp Packer automates the creation of machine images for multiple platforms from a single declarative template. It enables AI teams to build consistent, reproducible VM images and container base images with pre-installed ML dependencies — eliminating configuration drift across environments.
+tagline: Automated machine image builder for consistent infrastructure
+
+github_url: https://github.com/hashicorp/packer
+website_url: https://www.packer.io
+docs_url: https://developer.hashicorp.com/packer/docs
+
+category: Dev Tools
+tags: [image-building, infrastructure-as-code, vm, containers, devops, automation, immutable-infrastructure]
+pricing: free
+is_open_source: true
+license: BSL-1.1
+
+problem_solved: |
+  AI infrastructure teams frequently deploy ML environments across AWS, GCP, Azure, and on-premise — each requiring platform-specific machine images with the same set of GPU drivers, CUDA libraries, Python packages, and ML frameworks. Building and maintaining these images separately leads to configuration drift and fragile deployment pipelines. Packer solves this with a single HCL template that builds identical images for multiple platforms simultaneously, supporting post-processing steps for image optimization, and integrating with configuration management tools like Ansible and Chef for software provisioning.
+
+use_cases:
+  - Build golden VM images with pre-installed NVIDIA drivers, CUDA toolkits, and ML frameworks for consistent training environments
+  - Create multi-platform base images for GPU-enabled model serving across AWS, GCP, and Azure from a single Packer template
+  - Generate Docker base images as part of an immutable infrastructure pipeline for ML deployment reproducibility
+  - Automate quarterly refresh of ML development workstation images with updated Python packages and ML library versions
+  - Integrate with Ansible playbooks to provision and configure complex ML software stacks during image building

--- a/tools/dev-tools/pm2.yaml
+++ b/tools/dev-tools/pm2.yaml
@@ -1,0 +1,24 @@
+name: PM2
+description: A production-grade Node.js process manager with built-in load balancing, log management, monitoring, and application clustering. PM2 keeps AI backend services — model serving endpoints, API gateways, and data pipeline workers — running reliably with automatic restarts and zero-downtime deployments.
+tagline: Production process manager for Node.js applications
+
+github_url: https://github.com/Unitech/pm2
+website_url: https://pm2.keymetrics.io
+docs_url: https://pm2.keymetrics.io/docs
+install_command: npm install -g pm2
+
+category: Dev Tools
+tags: [nodejs, process-manager, clustering, load-balancing, monitoring, deployment, devops]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  AI backend services built in Node.js — model serving proxies, API gateways, real-time data pipelines, and webhook handlers — need to stay running 24/7, scale across CPU cores, and restart gracefully after failures. Running these with simple node or npm start commands leaves them vulnerable to crashes without recovery. PM2 solves this by providing a battle-tested process manager that keeps applications alive with automatic restarts, supports cluster mode to utilize all CPU cores, provides built-in log rotation and monitoring, and enables zero-downtime reloads for production deployments.
+
+use_cases:
+  - Run Node.js model serving APIs with automatic restart on crash and configurable startup delays between retries
+  - Scale AI backend services across all CPU cores using PM2's cluster mode for higher throughput
+  - Monitor memory and CPU usage of AI application microservices through PM2's built-in dashboard and Keymetrics integration
+  - Deploy AI application stacks across multiple servers with PM2's ecosystem file for consistent startup configuration
+  - Implement zero-downtime reloads for model inference API updates without dropping active connections

--- a/tools/dev-tools/rancher.yaml
+++ b/tools/dev-tools/rancher.yaml
@@ -1,0 +1,23 @@
+name: Rancher
+description: An open-source multi-cluster Kubernetes management platform for deploying and operating Kubernetes clusters across on-premise, cloud, and edge environments. Rancher simplifies AI infrastructure operations with centralized cluster management, RBAC, observability, and application catalog integration.
+tagline: Multi-cluster Kubernetes management for any infrastructure
+
+github_url: https://github.com/rancher/rancher
+website_url: https://www.rancher.com
+docs_url: https://docs.rancher.com
+
+category: Dev Tools
+tags: [kubernetes, cluster-management, multi-cloud, devops, container-orchestration, edge-computing, infrastructure]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI teams running Kubernetes-based ML platforms across multiple environments — on-premise GPU clusters, cloud-based training infrastructure, and edge inference nodes — face significant operational overhead managing each cluster independently. Standard Kubernetes distribution lacks centralized RBAC, observability, and application lifecycle management across clusters. Rancher solves this by providing a unified control plane for importing and managing any CNCF-certified Kubernetes cluster, with built-in monitoring with Prometheus and Grafana, multi-tenant RBAC, GitOps-based continuous delivery with Fleet, and an integrated application catalog for one-click deployment of ML infrastructure tools.
+
+use_cases:
+  - Centrally manage on-premise GPU Kubernetes clusters and cloud-based training clusters from a single Rancher dashboard
+  - Deploy ML infrastructure tools (Prometheus, Grafana, Kubeflow, MLflow) across clusters with Rancher's application catalog
+  - Implement multi-team RBAC for AI platform resources across Kubernetes clusters with AD/LDAP integration
+  - Monitor GPU utilization, cluster health, and ML workload resource consumption across all clusters with built-in observability
+  - Provision and manage Kubernetes clusters on bare-metal, vSphere, and public clouds using Rancher Kubernetes Engine (RKE)


### PR DESCRIPTION
## Tools Added

This PR adds 5 tools to the Agentic AI For Good catalog:

- **Bun** (Dev Tools) — Fast all-in-one JavaScript runtime, bundler, and package manager
- **PM2** (Dev Tools) — Production-grade Node.js process manager with clustering and monitoring
- **Nomad** (Dev Tools) — HashiCorp workload orchestrator for containers and batch jobs
- **Packer** (Dev Tools) — HashiCorp automated machine image builder for consistent infrastructure
- **Rancher** (Dev Tools) — Multi-cluster Kubernetes management platform for any infrastructure
