### PR TITLE
Add Git LFS, Ceph, Alluxio, TensorFlow Datasets, JuiceFS to catalog

### DIFF
--- a/tools/data/alluxio.yaml
+++ b/tools/data/alluxio.yaml
@@ -1,0 +1,24 @@
+name: Alluxio
+description: |-
+  Alluxio is a distributed data orchestration and virtualization layer that unifies access to diverse storage systems — S3, HDFS, NFS, and cloud object stores — under a single namespace with intelligent caching. It accelerates AI/ML workloads by bringing training data closer to compute, reducing data access latency by orders of magnitude across GPU clusters.
+tagline: Distributed data orchestration and caching layer
+
+github_url: https://github.com/Alluxio/alluxio
+website_url: https://www.alluxio.io
+docs_url: https://docs.alluxio.io
+
+category: Data
+tags: [data-orchestration, caching, data-virtualization, storage, infrastructure, devops, performance]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI training and inference workloads need fast, consistent access to training data stored across multiple remote storage systems — S3 buckets, HDFS clusters, NFS servers, and cloud object stores — each with different access patterns, latency profiles, and performance characteristics. Reading data directly from remote storage for every training epoch causes severe I/O bottlenecks, GPU starvation, and extended training times. Alluxio solves this with a distributed caching and virtualization layer that exposes remote storage through a POSIX-compatible file system interface, caches frequently accessed data on local SSDs or memory on compute nodes, provides namespace unification across heterogeneous storage backends, and supports active data loading for pre-staging entire datasets before training begins — reducing data access latency from seconds to microseconds for cached data and eliminating GPU idle time waiting for I/O.
+
+use_cases:
+  - Accelerate distributed ML training by caching training datasets on GPU cluster-local SSDs through Alluxio's transparent read caching across thousands of nodes
+  - Unify data access under a single namespace when training data spans S3, HDFS, and NFS storage backends, eliminating manual data copy and location management
+  - Pre-load large training datasets into Alluxio's distributed cache before training jobs begin, ensuring GPU-saturating I/O throughput from epoch one
+  - Share preprocessed feature data between training and inference pipelines with consistent reads through Alluxio's write-once, read-many caching semantics
+  - Reduce cloud egress costs by caching frequently accessed training data on ephemeral GPU cluster storage rather than re-reading from remote S3 for each training run

--- a/tools/data/ceph.yaml
+++ b/tools/data/ceph.yaml
@@ -1,0 +1,24 @@
+name: Ceph
+description: |-
+  Ceph is a unified, distributed storage system that provides object, block, and file storage from a single cluster. It powers AI infrastructure with petabyte-scale storage for training datasets, model artifacts, and inference logs — offering self-healing, automatic replication, and no single point of failure across commodity hardware.
+tagline: Unified distributed storage for object, block, and file
+
+github_url: https://github.com/ceph/ceph
+website_url: https://ceph.io
+docs_url: https://docs.ceph.com
+
+category: Data
+tags: [distributed-storage, object-storage, block-storage, file-storage, infrastructure, devops, data-platform]
+pricing: free
+is_open_source: true
+license: LGPL-2.1
+
+problem_solved: |
+  AI infrastructure generates massive volumes of data — training datasets, model checkpoints, experiment artifacts, inference logs, and vector indexes — that must be stored durably, accessed with low latency, and scaled cost-effectively across GPU clusters. Traditional storage solutions are either expensive (enterprise SAN/NAS), single-point-of-failure (NFS servers), or lack the performance to keep GPU nodes saturated with data. Ceph solves this with a unified software-defined storage platform that runs on commodity hardware, provides S3-compatible object storage (RADOS Gateway) for model artifacts and datasets, block storage (RBD) for database volumes powering vector databases, and POSIX-compatible file storage (CephFS) for shared workspace access across training nodes — all with automatic data replication, self-healing, and online scaling without downtime.
+
+use_cases:
+  - Deploy petabyte-scale S3-compatible object storage for training datasets, model checkpoints, and experiment artifacts accessible from any GPU node
+  - Provision high-performance block storage volumes for vector databases and model serving infrastructure with automatic replication across failure domains
+  - Share training data and model outputs across a GPU cluster via CephFS POSIX mounts with consistent snapshots and tiered access controls
+  - Store and retrieve large-scale ML training logs and inference telemetry with Ceph's RADOS object store and radosgw-admin tooling
+  - Scale AI storage infrastructure incrementally by adding commodity servers to the Ceph cluster without downtime or data migration

--- a/tools/data/juicefs.yaml
+++ b/tools/data/juicefs.yaml
@@ -1,0 +1,24 @@
+name: JuiceFS
+description: |-
+  JuiceFS is a high-performance POSIX file system built on cloud object storage (S3, GCS, Azure Blob) with metadata stored in a separate database (Redis, SQLite, TiKV). It provides fully POSIX-compatible access to petabyte-scale data lakes for AI training, with automatic caching, data compression, and encryption across distributed compute clusters.
+tagline: POSIX file system on cloud object storage with Redis metadata
+
+github_url: https://github.com/juicedata/juicefs
+website_url: https://juicefs.com
+docs_url: https://juicefs.com/docs
+
+category: Data
+tags: [file-system, cloud-storage, posix, data-lake, infrastructure, performance, distributed-storage]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI training workflows expect POSIX file system semantics — random reads and writes, directory listings, file seeks, and concurrent access — but cloud object stores (S3, GCS, Azure Blob) provide only key-value GET/PUT interfaces with no directory operations, no atomic renames, and high per-request latency. This forces teams to either copy datasets to local SSDs before training (wasting storage and transfer time) or sacrifice POSIX compatibility by rewriting data loading code for object store APIs. JuiceFS solves this by presenting a fully POSIX-compatible file system interface on top of your existing cloud object store, storing file metadata in a high-performance Redis or SQLite database for sub-millisecond directory operations, caching hot data on local SSDs for near-local performance, supporting concurrent reads and writes from thousands of clients, and providing built-in data compression and encryption — enabling existing ML training code written for POSIX file systems to run on cloud object storage without any code changes.
+
+use_cases:
+  - Mount training data from cloud object storage as a local POSIX file system on GPU training nodes, enabling unmodified PyTorch/TensorFlow data loaders to stream from S3
+  - Share datasets across a distributed training cluster with concurrent POSIX read/write access and JuiceFS's distributed consistency guarantees
+  - Cache frequently accessed training data on GPU node-local SSDs through JuiceFS's automatic write-back cache for sub-millisecond read latency on hot data
+  - Run model evaluation and inference workloads directly on cloud object storage without pre-downloading datasets, using JuiceFS's FUSE mount for transparent access
+  - Encrypt sensitive training data at rest with JuiceFS's client-side encryption and manage access keys through standard POSIX permission bits and ACLs

--- a/tools/data/tensorflow-datasets.yaml
+++ b/tools/data/tensorflow-datasets.yaml
@@ -1,0 +1,26 @@
+name: TensorFlow Datasets
+description: |-
+  TensorFlow Datasets (TFDS) is a library of ready-to-use datasets for machine learning with TensorFlow and other Python ML frameworks. It provides a unified API to download, prepare, and load hundreds of datasets — from vision and NLP to audio and reinforcement learning — with automatic versioning, deterministic splits, and efficient streaming pipelines.
+tagline: Ready-to-use datasets for machine learning
+
+github_url: https://github.com/tensorflow/datasets
+website_url: https://www.tensorflow.org/datasets
+docs_url: https://www.tensorflow.org/datasets/overview
+
+install_command: pip install tensorflow-datasets
+
+category: Data
+tags: [datasets, data-loading, tensorflow, machine-learning, data-engineering, python]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  ML practitioners spend significant effort finding, downloading, and preprocessing standard datasets for training and evaluation — each dataset uses a different download URL, format, split convention, and preprocessing pipeline, making it difficult to reproduce experiments across projects and teams. TensorFlow Datasets solves this by providing hundreds of common ML datasets (CIFAR, ImageNet, COCO, WMT, etc.) through a single unified API with automatic download and extraction, deterministic train/validation/test splits, standardized feature dictionaries with typed TensorSpec descriptions, versioning that tracks dataset changes, and efficient streaming data loading that works seamlessly with tf.data pipelines for GPU-bound training — eliminating dataset boilerplate and ensuring reproducibility across experiments.
+
+use_cases:
+  - Quickly load standard benchmark datasets for model evaluation with a single line of code and deterministic train/test splits
+  - Build reproducible ML pipelines by pinning dataset versions through TFDS version specifiers in experiment configuration files
+  - Stream large datasets that exceed available RAM using TFDS's tf.data integration with automatic sharding and prefetching for GPU training
+  - Create custom dataset builders following TFDS conventions to package proprietary data with standardized splits, features, and metadata
+  - Access dataset metadata — feature types, example counts, class distributions — programmatically without downloading the full dataset

--- a/tools/dev-tools/git-lfs.yaml
+++ b/tools/dev-tools/git-lfs.yaml
@@ -1,0 +1,26 @@
+name: Git LFS
+description: |-
+  Git Large File Storage (LFS) is a Git extension that replaces large files such as datasets, model checkpoints, audio samples, and video assets with text pointers while storing the file contents on a remote server. It enables AI/ML teams to version large binary files in Git repositories without bloating the repository size, supporting datasets up to gigabytes per file with seamless push, pull, and clone workflows.
+tagline: Version large files in Git without bloating repositories
+
+github_url: https://github.com/git-lfs/git-lfs
+website_url: https://git-lfs.com
+docs_url: https://github.com/git-lfs/git-lfs/blob/main/docs/man/git-lfs.1.ronn
+
+install_command: brew install git-lfs
+
+category: Dev Tools
+tags: [version-control, git, large-files, data-management, devops, collaboration]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI and ML teams store large binary files — training datasets, model checkpoints, fine-tuned weights, experiment artifacts, and evaluation outputs — alongside their code in version control. Standard Git cannot handle large files efficiently, ballooning repository size with every binary change, causing slow clones, exhausting storage quotas, and making collaboration impractical. Git LFS solves this by replacing large files in the working tree with lightweight text pointers while storing the actual binary content on a remote server, enabling teams to version and distribute multi-gigabyte model artifacts and datasets using standard Git workflows with automatic background uploads and downloads, local and remote caching, and native CI/CD integration.
+
+use_cases:
+  - Store multi-gigabyte ML training datasets and model checkpoints in Git repositories without exceeding GitHub's file size limits
+  - Version fine-tuned model weights alongside experiment code, enabling reproducible training pipelines with exact data-artifact correspondence
+  - Collaborate on large-scale ML projects where team members share model artifacts and evaluation outputs through standard Git clone, pull, and push workflows
+  - Distribute pre-trained model weights and benchmark datasets as part of open-source releases with transparent version tracking and download statistics
+  - Integrate with CI/CD pipelines to automatically cache and download large model artifacts during training, evaluation, and deployment workflows


### PR DESCRIPTION
Add five infrastructure and data tools to the catalog:

- **Git LFS** (14.4k★) — Version large files in Git without bloating repositories
- **Ceph** (16.9k★) — Unified distributed storage for object, block, and file
- **Alluxio** (7.2k★) — Distributed data orchestration and caching layer for AI/ML workloads
- **TensorFlow Datasets** (4.6k★) — Ready-to-use ML datasets with unified API
- **JuiceFS** (14.3k★) — POSIX file system on cloud object storage with Redis metadata

Placed in Dev Tools (Git LFS) and Data (Ceph, Alluxio, TFDS, JuiceFS).