### PR TITLE
Add FastRAG, BEIR to catalog

### DIFF
--- a/tools/rag/beir.yaml
+++ b/tools/rag/beir.yaml
@@ -1,0 +1,26 @@
+name: BEIR
+description: |-
+  BEIR (Benchmarking Information Retrieval) is a heterogeneous evaluation framework for zero-shot information retrieval. It provides a standardized benchmark across 18 diverse datasets spanning question answering, fact checking, duplicate detection, citation prediction, and entity linking — enabling rigorous evaluation of dense retrieval and reranking models for RAG pipelines.
+tagline: Zero-shot information retrieval benchmark for retrieval evaluation
+
+github_url: https://github.com/beir-cellar/beir
+website_url: https://beir-cellar.github.io/beir
+docs_url: https://beir-cellar.github.io/beir
+
+install_command: pip install beir
+
+category: RAG
+tags: [information-retrieval, benchmark, evaluation, dense-retrieval, nlp, python, research]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Evaluating retrieval models for RAG pipelines requires diverse datasets spanning multiple domains, query types, and difficulty levels — but individual datasets use incompatible formats, evaluation scripts, and metrics, making it nearly impossible to compare retrieval quality across models and approaches. BEIR solves this with a standardized evaluation framework that normalizes 18 diverse benchmark datasets (including TREC, NQ, HotpotQA, FiQA, FEVER, and SciFact) under a single API, provides consistent evaluation metrics (NDCG@10, Recall@K, MAP) across all datasets, supports dense retrievers (DPR, ColBERT, Sentence-BERT), sparse retrievers (BM25, SPLADE), and cross-encoder rerankers through a unified scoring interface, and enables zero-shot evaluation — measuring how well a retrieval model trained on one domain generalizes to unseen domains — giving RAG practitioners a rigorous, reproducible benchmark for comparing retrieval strategies.
+
+use_cases:
+  - Benchmark dense retriever models against BM25 and sparse retrieval baselines across 18 diverse zero-shot retrieval datasets
+  - Evaluate cross-encoder reranker quality by measuring NDCG@10 improvement over base retrieval on BEIR's full benchmark suite
+  - Compare bi-encoder vs. cross-encoder retrieval strategies for specific RAG domains — biomedical, legal, news, or conversational QA
+  - Validate retrieval model generalization by testing on BEIR datasets from different domains than the training corpus
+  - Reproduce published retrieval evaluation results using BEIR's standardized API and consistent metric computation across all 18 datasets

--- a/tools/rag/fastrag.yaml
+++ b/tools/rag/fastrag.yaml
@@ -1,0 +1,26 @@
+name: FastRAG
+description: |-
+  FastRAG is an efficient retrieval-augmented generation framework from Intel Labs that combines large language models with scalable retrieval pipelines. It supports dense and sparse retrievers, multi-step retrieval strategies, and optimized inference on Intel hardware — enabling production RAG applications with low-latency retrieval and generation.
+tagline: Efficient RAG framework with optimized retrieval and generation
+
+github_url: https://github.com/IntelLabs/fastRAG
+website_url: https://intellabs.github.io/fastRAG
+docs_url: https://intellabs.github.io/fastRAG
+
+install_command: pip install fastrag
+
+category: RAG
+tags: [rag, retrieval-augmented-generation, llm, information-retrieval, nlp, python]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building production-ready RAG applications requires integrating multiple components — document retrievers, embedding models, LLMs, and generation pipelines — with careful optimization for latency, relevance, and scalability. Existing RAG frameworks are either too complex to configure or lack optimization for specific hardware platforms. FastRAG solves this by providing a modular RAG framework with built-in support for dense retrievers (DPR, ColBERT, BGE), sparse retrievers (SPLADE, BM25), and hybrid retrieval strategies, multi-step reasoning patterns (query rewriting, HyDE, self-RAG), optimized inference pipelines for Intel CPUs and GPUs with ONNX Runtime and OpenVINO integration, and a clean Python API for composing retrieval and generation workflows — enabling teams to deploy efficient RAG pipelines without deep expertise in each component.
+
+use_cases:
+  - Build production RAG applications with hybrid retrieval combining dense embeddings and sparse keyword search for higher relevance
+  - Deploy low-latency document question answering pipelines on CPU-based infrastructure using FastRAG's OpenVINO-optimized model inference
+  - Implement multi-step RAG strategies like query rewriting and hypothetical document embeddings (HyDE) to improve first-retrieval quality
+  - Create custom RAG pipelines with modular retriever, reranker, and generator components using FastRAG's composable API and pipeline abstractions
+  - Evaluate RAG pipeline quality with FastRAG's built-in benchmarking tools for retrieval precision, generation faithfulness, and end-to-end latency


### PR DESCRIPTION
Add two RAG tools to the catalog:

- **FastRAG** (1.8k★, Intel Labs) — Efficient RAG framework with optimized retrieval and generation for Intel hardware
- **BEIR** (2.3k★) — Zero-shot information retrieval benchmark for evaluating retrieval models