### PR TITLE
Add MTEB, Fluent Bit, Syslog-ng to catalog

### DIFF
--- a/tools/monitoring/fluent-bit.yaml
+++ b/tools/monitoring/fluent-bit.yaml
@@ -1,0 +1,23 @@
+name: Fluent Bit
+description: A lightweight, multi-platform log processor and forwarder from the CNCF ecosystem — designed for high-throughput log collection, parsing, filtering, and routing to over 50 output destinations including Elasticsearch, Loki, S3, Kafka, and OpenTelemetry.
+tagline: CNCF-graduated log processor for cloud-native observability
+
+github_url: https://github.com/fluent/fluent-bit
+website_url: https://fluentbit.io
+docs_url: https://docs.fluentbit.io
+
+category: Monitoring
+tags: [monitoring, logging, observability, cloud-native, cncf, metrics, data-pipeline]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Collecting, parsing, and routing logs at scale from distributed systems is a fundamental observability challenge. Traditional log shippers are resource-heavy, hard to configure for diverse environments, or lack support for modern data formats and output destinations. Fluent Bit solves this with a lightweight, high-performance log processor (under 1MB binary size) that collects from 25+ input sources, parses and filters with minimal CPU overhead, and routes to 50+ output destinations — container-native, edge-optimized, and Kubernetes-friendly. It is the most widely deployed log processor in the CNCF ecosystem, trusted for collecting telemetry from millions of workloads.
+
+use_cases:
+  - Collect and route application logs from Kubernetes clusters to centralized observability backends
+  - Build lightweight log pipelines that parse, filter, and transform high-volume log streams in real time
+  - Forward infrastructure telemetry from edge devices and IoT deployments to cloud monitoring systems
+  - Aggregate distributed system logs through a unified collector before shipping to Elasticsearch or Loki
+  - Enrich log events with metadata and route to multiple destinations for compliance and debugging

--- a/tools/monitoring/syslog-ng.yaml
+++ b/tools/monitoring/syslog-ng.yaml
@@ -1,0 +1,23 @@
+name: Syslog-ng
+description: A high-performance, multi-platform log management solution for collecting, parsing, classifying, and forwarding syslog and application logs to centralized destinations — trusted in enterprise and carrier-grade environments for decades.
+tagline: Enterprise-grade log management and syslog daemon
+
+github_url: https://github.com/syslog-ng/syslog-ng
+website_url: https://syslog-ng.com
+docs_url: https://syslog-ng.github.io
+
+category: Monitoring
+tags: [monitoring, logging, syslog, enterprise, data-pipeline, observability]
+pricing: free
+is_open_source: true
+license: NOASSERTION
+
+problem_solved: |
+  Enterprise infrastructure produces logs in diverse formats from routers, switches, firewalls, servers, containers, and applications — each with different syslog standards, message formats, and transport protocols. Standard syslog implementations lack the parsing flexibility, performance, and reliability needed for modern observability at scale. Syslog-ng solves this with a high-performance log processing engine that supports RFC 3164, RFC 5424, and JSON formats, provides advanced message parsing and classification, TLS encryption, reliable disk-based buffering, and can forward to 30+ destinations including Elasticsearch, Kafka, MongoDB, and database backends.
+
+use_cases:
+  - Centralize syslog collection from thousands of network devices and servers into a unified monitoring platform
+  - Parse and classify unstructured log messages using pattern databases for automated alerting and routing
+  - Securely forward enterprise logs with TLS encryption and disk-based buffering for reliable delivery
+  - Integrate legacy syslog infrastructure with modern observability stacks through multiple output plugins
+  - Filter, rewrite, and enrich log streams in transit to normalize formats across heterogeneous systems

--- a/tools/rag/mteb.yaml
+++ b/tools/rag/mteb.yaml
@@ -1,0 +1,25 @@
+name: MTEB
+description: The Massive Text Embedding Benchmark — a unified evaluation framework for text embedding models across 100+ datasets covering classification, clustering, pair classification, reranking, retrieval, STS, and summarization tasks.
+tagline: The standard benchmark for evaluating text embedding models
+
+github_url: https://github.com/embeddings-benchmark/mteb
+website_url: https://huggingface.co/mteb
+docs_url: https://github.com/embeddings-benchmark/mteb#readme
+
+install_command: pip install mteb
+
+category: RAG
+tags: [python, evaluation, embeddings, benchmark, retrieval, rag, nlp]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  The embedding model landscape is crowded and rapidly evolving — dozens of new models are released weekly, each claiming state-of-the-art performance on different benchmarks measured by different methodologies. Without a standardized evaluation framework, it is impossible to objectively compare embedding models for retrieval, clustering, classification, or semantic search tasks. MTEB solves this by providing a unified, community-maintained benchmark spanning over 100 datasets and 7 task categories — enabling researchers and practitioners to compare embedding models on equal footing, with reproducible scoring and standardized leaderboards.
+
+use_cases:
+  - Compare and select the best text embedding model for a specific task using standardized evaluation metrics
+  - Benchmark new embedding models against community baselines across 100+ diverse datasets
+  - Validate embedding quality for RAG pipelines by evaluating retrieval and reranking performance
+  - Track embedding model improvements over time with reproducible evaluation pipelines
+  - Research embedding model strengths and weaknesses across different languages, domains, and task types


### PR DESCRIPTION
MTEB: Massive Text Embedding Benchmark — unified evaluation framework for text embedding models (3,375★, Apache-2.0). Add to rag/mteb.yaml.
Fluent Bit: CNCF-graduated lightweight log processor and forwarder (7,996★, Apache-2.0). Add to monitoring/fluent-bit.yaml.
Syslog-ng: Enterprise-grade log management and syslog daemon (2,359★, open source). Add to monitoring/syslog-ng.yaml.
