### PR TITLE
Add FlatBuffers, Cap'n Proto, Chainer, MMCV, T5X to catalog

### DIFF
--- a/tools/data/capn-proto.yaml
+++ b/tools/data/capn-proto.yaml
@@ -1,0 +1,24 @@
+name: Cap'n Proto
+description: |
+  Cap'n Proto is an open-source, high-performance data interchange format and RPC system that provides capabilities-based RPC with zero-copy deserialization. Unlike Protocol Buffers and FlatBuffers, it works everywhere without a separate IDL compilation step, using a native schema language that compiles directly to efficient inline serialization code.
+tagline: High-performance data interchange format with zero-copy deserialization and RPC
+
+github_url: https://github.com/capnproto/capnproto
+website_url: https://capnproto.org
+docs_url: https://capnproto.org/documentation
+
+category: Data
+tags: [serialization, rpc, zero-copy, data-format, performance, capabilities]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Data serialization in ML and real-time systems traditionally requires either parsing overhead (JSON, Protocol Buffers) or complex build-time code generation (FlatBuffers). Cap'n Proto solves this by combining zero-copy deserialization with an intuitive schema language and built-in capabilities-based RPC, enabling efficient data interchange with minimal latency and no runtime parsing in distributed ML pipelines and real-time systems.
+
+use_cases:
+  - Exchange structured tensor metadata and inference results between distributed ML serving nodes with zero-copy deserialization
+  - Implement high-throughput RPC for real-time feature serving and model prediction pipelines
+  - Serialize large structured datasets for streaming between data processing stages with minimal CPU overhead
+  - Build real-time communication systems for multi-agent coordination where message latency is critical
+  - Replace JSON and Protocol Buffers in latency-sensitive embedded AI applications with fixed memory budgets

--- a/tools/data/flatbuffers.yaml
+++ b/tools/data/flatbuffers.yaml
@@ -1,0 +1,26 @@
+name: FlatBuffers
+description: |
+  FlatBuffers is an open-source cross-platform serialization library from Google that provides efficient data interchange without parsing overhead. Unlike Protocol Buffers and JSON, FlatBuffers enables direct access to serialized data without unpacking or allocating secondary structures, making it ideal for performance-critical ML inference pipelines, game engines, and embedded systems.
+tagline: Cross-platform serialization library with zero-copy data access
+
+github_url: https://github.com/google/flatbuffers
+website_url: https://flatbuffers.dev
+docs_url: https://flatbuffers.dev
+
+install_command: pip install flatbuffers
+
+category: Data
+tags: [serialization, cross-platform, zero-copy, data-format, performance, google]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Traditional serialization formats like JSON and Protocol Buffers require parsing the entire payload before accessing individual fields, creating memory allocation overhead and CPU bottlenecks in performance-sensitive applications. FlatBuffers solves this by providing a serialization format that supports direct, zero-copy access to individual fields without parsing, enabling efficient data interchange in latency-critical ML inference, real-time systems, and mobile applications.
+
+use_cases:
+  - Serialize and deserialize ML model metadata and configuration with zero-copy access for low-latency inference pipelines
+  - Exchange structured data between heterogeneous systems in real-time applications with minimal CPU and memory overhead
+  - Store and transmit game engine assets and scene data where parsing latency and memory allocation must be minimized
+  - Implement high-performance data logging and telemetry systems that batch-write serialized buffers without per-message allocation
+  - Serve as a drop-in replacement for JSON or Protocol Buffers in embedded systems with strict memory and latency constraints

--- a/tools/data/mmcv.yaml
+++ b/tools/data/mmcv.yaml
@@ -1,0 +1,26 @@
+name: MMCV
+description: |
+  MMCV is an open-source foundational Python library from OpenMMLab that provides computer vision utilities, data transforms, training frameworks, and I/O operations shared across all OpenMMLab projects. It offers highly optimized CUDA operators for common CV tasks, a modular training registry system, configurable data pipelines, and performance profiling tools.
+tagline: Foundational computer vision library powering the OpenMMLab ecosystem
+
+github_url: https://github.com/open-mmlab/mmcv
+website_url: https://mmcv.readthedocs.io
+docs_url: https://mmcv.readthedocs.io
+
+install_command: pip install mmcv
+
+category: Data
+tags: [computer-vision, cuda-operators, data-transforms, training-framework, openmmlab, deep-learning]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Computer vision research and development requires a vast set of shared utilities — data transforms, CUDA operators, training loops, and file I/O — that each project reimplements independently, leading to fragmentation and duplicated effort. MMCV solves this by providing a unified foundational library with optimized CUDA kernels, standardized data pipelines, a modular training registry, and consistent evaluation tools used across all OpenMMLab projects.
+
+use_cases:
+  - Access optimized CUDA operators for NMS, RoI pooling, deformable convolution, and other CV primitives without reimplementation
+  - Build custom data processing pipelines with configurable transforms for image loading, augmentation, and normalization
+  - Leverage the modular training framework with configurable optimizers, schedulers, and evaluation hooks
+  - Implement new computer vision models using MMCV's registry system for modular model components and backbones
+  - Profile and visualize training runs with built-in logging, checkpoint management, and performance analysis tools

--- a/tools/dev-tools/t5x.yaml
+++ b/tools/dev-tools/t5x.yaml
@@ -1,0 +1,24 @@
+name: T5X
+description: |
+  T5X is Google Research's open-source, modular framework for training, evaluating, and serving large language models using JAX. It powers state-of-the-art models like PaLM and T5 with scalable training across TPU pods, support for mixture-of-experts architectures, chain-of-thought prompting, few-shot evaluation, and production-grade model serving.
+tagline: Modular JAX framework for training and serving large language models
+
+github_url: https://github.com/google-research/t5x
+website_url: https://github.com/google-research/t5x
+docs_url: https://github.com/google-research/t5x
+
+category: Dev Tools
+tags: [llm-training, jax, tpu, large-language-models, google-research, distributed-training]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Training large language models at scale requires complex distributed infrastructure — sharding model parameters across TPU pods, managing training checkpoints, implementing mixture-of-experts routing, and supporting diverse evaluation protocols. T5X solves this by providing a modular, production-tested JAX framework that handles TPU-parallel training, checkpointing, few-shot evaluation, and mixture-of-experts architectures with standardized configuration.
+
+use_cases:
+  - Pre-train large language models at scale across hundreds of TPU accelerators with data and model parallelism
+  - Fine-tune pre-trained LLMs on downstream tasks with few-shot evaluation and chain-of-thought prompting support
+  - Train mixture-of-experts models with sparse routing for efficient capacity scaling
+  - Evaluate model performance on standard benchmarks with configurable in-context learning and prompting strategies
+  - Serve trained models for production inference with optimized TPU-compatible serving pipelines

--- a/tools/other/chainer.yaml
+++ b/tools/other/chainer.yaml
@@ -1,0 +1,26 @@
+name: Chainer
+description: |
+  Chainer is an open-source deep learning framework that pioneered the define-by-run (dynamic computational graph) paradigm, enabling intuitive neural network construction with native Python control flow. It provides a NumPy-compatible array library (CuPy), built-in training utilities, and support for convolutional networks, recurrent networks, and reinforcement learning across CPU and GPU backends.
+tagline: Pioneering define-by-run deep learning framework with dynamic computational graphs
+
+github_url: https://github.com/chainer/chainer
+website_url: https://chainer.org
+docs_url: https://docs.chainer.org
+
+install_command: pip install chainer
+
+category: Other
+tags: [deep-learning, neural-networks, define-by-run, cuda, python, reinforcement-learning]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Early deep learning frameworks used static computational graphs that required building the entire network before execution, making it difficult to implement dynamic architectures with variable-length inputs or conditional branching. Chainer solved this by introducing define-by-run computation where the graph is constructed on-the-fly during forward propagation, enabling intuitive neural network implementation with native Python control flow and loop structures.
+
+use_cases:
+  - Train deep neural networks with dynamic architectures that change shape based on input data characteristics
+  - Implement recurrent networks with variable-length sequences and conditional branching using native Python control flow
+  - Build reinforcement learning agents with policy gradients and Q-learning using Chainer's RL-oriented utilities
+  - Experiment with novel network architectures where static graph definitions would require complex workarounds
+  - Leverage CuPy for GPU-accelerated NumPy-compatible array operations in scientific computing workflows


### PR DESCRIPTION
Add FlatBuffers, Cap'n Proto, Chainer, MMCV, and T5X to the catalog.

- **FlatBuffers**: Google's cross-platform serialization library with zero-copy data access, ideal for performance-critical ML inference pipelines (26,273★, Apache-2.0)
- **Cap'n Proto**: High-performance data interchange format with zero-copy deserialization and capabilities-based RPC for distributed systems (13,140★, MIT)
- **Chainer**: Pioneering define-by-run deep learning framework with dynamic computational graphs and CuPy GPU array library (5,923★, MIT)
- **MMCV**: Foundational OpenMMLab computer vision library with optimized CUDA operators, data transforms, and training framework (6,461★, Apache-2.0)
- **T5X**: Google Research's modular JAX framework for training, evaluating, and serving large language models at TPU scale (2,978★, Apache-2.0)