### PR TITLE
Add NCCL, ROCm to catalog

### DIFF
--- a/tools/dev-tools/nccl.yaml
+++ b/tools/dev-tools/nccl.yaml
@@ -1,0 +1,24 @@
+name: NCCL
+description: |
+  NVIDIA Collective Communications Library (NCCL) is an open-source library providing multi-GPU and multi-node communication primitives optimized for NVIDIA GPUs. It implements collective operations including all-gather, all-reduce, broadcast, reduce, and reduce-scatter with topology-aware communication across PCIe, NVLink, and InfiniBand interconnects, serving as the backbone for distributed deep learning training.
+tagline: Multi-GPU and multi-node collective communication library for distributed training
+
+github_url: https://github.com/NVIDIA/nccl
+website_url: https://developer.nvidia.com/nccl
+docs_url: https://docs.nvidia.com/deeplearning/nccl
+
+category: Dev Tools
+tags: [multi-gpu, distributed-training, nvidia, cuda, communication, high-performance-computing]
+pricing: free
+is_open_source: true
+license: NOASSERTION
+
+problem_solved: |
+  Distributed deep learning training across multiple GPUs requires efficient communication primitives to synchronize gradients and model parameters, but implementing topology-aware collective operations across diverse interconnects (PCIe, NVLink, InfiniBand) is complex and error-prone. NCCL solves this by providing highly optimized, topology-aware implementations of standard collective operations that automatically detect and utilize the fastest available interconnects between GPUs and nodes.
+
+use_cases:
+  - Synchronize gradients across multiple GPUs during distributed model training using all-reduce with NVLink-aware communication
+  - Scale training across multiple nodes with InfiniBand or TCP interconnects using NCCL's topology detection and optimization
+  - Reduce model parameter broadcasting overhead with NCCL's broadcast primitive in distributed inference pipelines
+  - Implement all-gather operations for distributed data-parallel training where each GPU holds a subset of the data
+  - Leverage NCCL's fused operations to combine gradient computation, reduction, and weight update in a single communication step

--- a/tools/dev-tools/rocm.yaml
+++ b/tools/dev-tools/rocm.yaml
@@ -1,0 +1,24 @@
+name: ROCm
+description: |
+  ROCm is an open-source GPU compute platform from AMD providing a complete ecosystem for high-performance computing and machine learning on AMD GPUs. It includes HIP for CUDA-to-AMD code portability, ROCm libraries for BLAS, FFT, and sparse operations, an LLVM-based compiler stack, and support for popular ML frameworks including PyTorch and TensorFlow with near-drop-in CUDA compatibility.
+tagline: AMD's open-source GPU compute platform for HPC and machine learning
+
+github_url: https://github.com/ROCm/ROCm
+website_url: https://rocm.docs.amd.com
+docs_url: https://rocm.docs.amd.com
+
+category: Dev Tools
+tags: [gpu-compute, amd, hpc, cuda-compatibility, machine-learning, rocm, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Running ML and HPC workloads on AMD GPUs traditionally required writing separate, non-portable code paths versus NVIDIA CUDA, creating fragmentation and limiting GPU compute options. ROCm solves this by providing a complete open-source GPU compute platform with HIP, a CUDA-compatible programming model that enables running code written for CUDA on AMD GPUs with minimal changes — including full support for PyTorch, TensorFlow, and popular ML frameworks.
+
+use_cases:
+  - Run PyTorch training and inference workloads on AMD GPUs with ROCm-optimized PyTorch builds using native HIP kernels
+  - Port existing CUDA-based HPC and ML applications to AMD GPUs using the HIP programming model with minimal code changes
+  - Accelerate scientific computing with ROCm-optimized BLAS, FFT, and sparse linear algebra libraries for AMD GPUs
+  - Leverage ROCm's LLVM-based compiler stack for custom GPU kernel development with advanced optimization passes
+  - Enable multi-GPU distributed training across AMD GPUs using ROCm's RCCL communication library (NCCL-compatible)


### PR DESCRIPTION
Add NCCL and ROCm to the catalog.

- **NCCL**: NVIDIA Collective Communications Library providing topology-aware multi-GPU and multi-node communication primitives for distributed deep learning training (4,921★, NOASSERTION)
- **ROCm**: AMD's open-source GPU compute platform with HIP CUDA-compatible programming model, optimized libraries, and ML framework support (6,730★, MIT)