### PR TITLE
Add HoloViews, Datashader, RLax, Sonnet, Apache Mahout to catalog

### DIFF
--- a/tools/data/apache-mahout.yaml
+++ b/tools/data/apache-mahout.yaml
@@ -1,0 +1,21 @@
+name: Apache Mahout
+description: "Apache Mahout is a distributed linear algebra framework and machine learning library built on Apache Spark. It provides scalable implementations of classification, clustering, recommendation, and dimensionality reduction algorithms that run on large datasets across clusters, with a Scala-based math DSL for custom ML development."
+tagline: "Distributed machine learning library built on Apache Spark"
+github_url: https://github.com/apache/mahout
+docs_url: https://mahout.apache.org/
+category: Data
+tags:
+  - machine-learning
+  - spark
+  - distributed-computing
+  - scala
+  - big-data
+  - recommendation
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Training machine learning models on datasets too large for single-machine frameworks requires distributed computation. Apache Mahout provides scalable, tested implementations of ML algorithms that run on Spark clusters, enabling classification, clustering, and recommendation on petabyte-scale data without custom distributed programming."
+use_cases:
+  - "Build collaborative filtering recommendation systems that scale to millions of users and items"
+  - "Train clustering and classification models on petabyte-scale datasets using Spark's distributed engine"
+  - "Implement custom matrix factorization and linear algebra operations for large-scale ML pipelines"

--- a/tools/data/datashader.yaml
+++ b/tools/data/datashader.yaml
@@ -1,0 +1,22 @@
+name: Datashader
+description: "Datashader is a Python library for rendering large datasets — millions to billions of points — as images in real time. It uses rasterization and aggregation pipelines to turn massive, high-dimensional data into meaningful visualizations without downsampling or data loss, making it practical to explore big data interactively."
+tagline: "Render massive datasets as images without downsampling"
+github_url: https://github.com/holoviz/datashader
+docs_url: https://datashader.org/
+install_command: pip install datashader
+category: Data
+tags:
+  - visualization
+  - big-data
+  - python
+  - rasterization
+  - data-science
+  - interactive
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Standard plotting libraries fail with large datasets — they either crash, freeze, or require destructive downsampling that hides patterns. Datashader renders millions to billions of data points as pixel-perfect rasterized images without subsampling, preserving outliers, clusters, and density patterns that scatter plots would miss."
+use_cases:
+  - "Visualize billion-point geospatial datasets like GPS traces, climate data, or cellular coverage maps"
+  - "Explore large ML training datasets to identify distribution shifts, outliers, and label errors"
+  - "Build interactive dashboards for real-time monitoring of high-volume system metrics and logs"

--- a/tools/data/holoviews.yaml
+++ b/tools/data/holoviews.yaml
@@ -1,0 +1,22 @@
+name: HoloViews
+description: "HoloViews is a Python library that makes data visualization simple and reproducible. It provides a declarative, compositional API for building interactive visualizations that work across plotting backends (Bokeh, Matplotlib, Plotly). Complex multi-panel dashboards and statistical plots can be expressed in a few lines of Python."
+tagline: "Declarative data visualization that works across plotting backends"
+github_url: https://github.com/holoviz/holoviews
+docs_url: https://holoviews.org/
+install_command: pip install holoviews
+category: Data
+tags:
+  - visualization
+  - python
+  - data-science
+  - plotting
+  - interactive
+  - dashboard
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Building interactive data visualizations often requires backend-specific APIs and tedious boilerplate for multi-panel layouts. HoloViews provides a declarative, backend-agnostic interface that lets users express what to visualize, not how, with automatic interactivity and seamless transitions between static and web-based rendering."
+use_cases:
+  - "Build interactive multi-panel dashboards for exploring ML model outputs and training metrics"
+  - "Create reproducible scientific visualizations for research papers and data analysis reports"
+  - "Quickly prototype data exploration workflows with automatic backend switching from static to interactive plots"

--- a/tools/other/rlax.yaml
+++ b/tools/other/rlax.yaml
@@ -1,0 +1,21 @@
+name: RLax
+description: "RLax is a JAX-based library of reinforcement learning building blocks and utility functions from DeepMind. It provides modular implementations of RL algorithms and components — value functions, policy gradients, TD learning, eligibility traces, and distributional RL — designed to work seamlessly with JAX's automatic differentiation and vectorization."
+tagline: "JAX library of RL building blocks by DeepMind"
+github_url: https://github.com/google-deepmind/rlax
+install_command: pip install rlax
+category: Other
+tags:
+  - reinforcement-learning
+  - jax
+  - deepmind
+  - machine-learning
+  - python
+  - research
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Implementing reinforcement learning algorithms from scratch is error-prone and hard to compose, and most RL libraries are designed for single frameworks. RLax provides modular, composable building blocks that work with JAX's functional programming model, enabling researchers and engineers to prototype and experiment with RL algorithms without reimplementing core components."
+use_cases:
+  - "Build custom reinforcement learning agents with composable value and policy components"
+  - "Implement and benchmark distributional RL algorithms for game-playing and robotics"
+  - "Create RL training pipelines that leverage JAX's automatic differentiation and hardware acceleration"

--- a/tools/other/sonnet.yaml
+++ b/tools/other/sonnet.yaml
@@ -1,0 +1,22 @@
+name: Sonnet
+description: "Sonnet is a JAX-based neural network library from DeepMind built on top of Haiku and Optax. It provides well-tested, modular neural network components — including convolutions, recurrent blocks, normalization, and attention — designed for research flexibility with clean separation of parameter management and compute."
+tagline: "DeepMind's neural network library for JAX research"
+github_url: https://github.com/google-deepmind/sonnet
+docs_url: https://dm-sonnet.readthedocs.io/
+install_command: pip install dm-sonnet
+category: Other
+tags:
+  - neural-networks
+  - jax
+  - deep-learning
+  - deepmind
+  - python
+  - research
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Building neural networks in JAX requires managing parameter initialization, module state, and architectural composition across separate libraries. Sonnet provides a familiar, object-oriented module interface for JAX that handles parameter ownership, offers pre-built components for common architectures, and integrates with Haiku and Optax for training."
+use_cases:
+  - "Rapidly prototype neural architectures for computer vision, NLP, and reinforcement learning research"
+  - "Build modular deep learning models with reusable components for convolutional and attention-based networks"
+  - "Combine with Haiku and Optax for end-to-end JAX training pipelines with gradient computation and optimization"


### PR DESCRIPTION
Adds 5 tools to the Agentic AI For Good catalog:

- **HoloViews** (2,898★) — Declarative data visualization that works across plotting backends
- **Datashader** (3,558★) — Render massive datasets as images without downsampling
- **RLax** (1,434★) — JAX library of reinforcement learning building blocks from DeepMind
- **Sonnet** (9,944★) — DeepMind's neural network library for JAX research
- **Apache Mahout** (2,300★) — Distributed machine learning library built on Apache Spark
