### PR TITLE
Add Dev Tools to catalog (Gunicorn, Hydra)

### DIFF
--- a/tools/dev-tools/gunicorn.yaml
+++ b/tools/dev-tools/gunicorn.yaml
@@ -1,0 +1,24 @@
+name: Gunicorn
+description: "Production-grade WSGI HTTP server for Python web applications, featuring pre-fork worker model with multiple worker types (sync, async, gevent, tornado) for handling concurrent requests. Gunicorn is the standard deployment server for Python web frameworks including Django and Flask."
+tagline: "Production WSGI server for Python web applications"
+github_url: https://github.com/benoitc/gunicorn
+website_url: https://gunicorn.org
+docs_url: https://docs.gunicorn.org
+install_command: pip install gunicorn
+category: Dev Tools
+tags:
+  - python
+  - web-server
+  - wsgi
+  - deployment
+  - model-serving
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "AI/ML engineers need to serve model inference APIs and web applications reliably in production, but Python's built-in development servers are single-threaded, lack concurrency control, and crash under real-world traffic loads. Gunicorn provides a production-hardened WSGI HTTP server with a pre-fork worker model that automatically manages worker processes, handles graceful shutdowns, supports multiple concurrency strategies (sync, async, gevent), and integrates seamlessly with reverse proxies and process supervisors for scalable model serving."
+use_cases:
+  - "Serve Flask-based ML model inference endpoints in production with configurable worker counts and graceful restarts"
+  - "Deploy Django AI dashboards and web applications behind NGINX with Gunicorn as the application server"
+  - "Run multiple concurrent model inference workers behind a single server port with automatic load distribution"
+  - "Serve async Python web applications using gevent or tornado worker types for improved throughput"
+  - "Integrate with systemd, Supervisor, or container orchestration platforms for production process management"

--- a/tools/dev-tools/hydra.yaml
+++ b/tools/dev-tools/hydra.yaml
@@ -1,0 +1,24 @@
+name: Hydra
+description: "Framework for elegantly configuring complex applications in Python with hierarchical configuration, command-line overrides, multi-run experiments, and instant configurable launching. Hydra composes configurations from YAML files and command-line arguments, enabling reproducible experiment management for ML research."
+tagline: "Framework for elegantly configuring complex Python applications"
+github_url: https://github.com/facebookresearch/hydra
+website_url: https://hydra.cc
+docs_url: https://hydra.cc/docs
+install_command: pip install hydra-core
+category: Dev Tools
+tags:
+  - python
+  - configuration
+  - experiment-management
+  - yaml
+  - mlops
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "ML experiments involve numerous configuration parameters — model architectures, hyperparameters, dataset paths, training schedules — that are hard to manage with hardcoded values, brittle argument parsers, or ad-hoc YAML loading. Changing one parameter requires editing source code or remembering complex command-line flags, and running sweeps across configurations requires custom scripting. Hydra provides a hierarchical configuration system that composes YAML configs, supports command-line overrides for any parameter, enables multi-run experiments sweeping across config combinations, and integrates with launching tools for distributed training."
+use_cases:
+  - "Manage ML training configurations with hierarchical YAML files for datasets, model architectures, and hyperparameters"
+  - "Run hyperparameter sweeps across multiple configuration combinations with automatic logging of results"
+  - "Override individual configuration parameters from the command line without editing YAML files between runs"
+  - "Compose complex experiment configurations from reusable config groups for datasets, models, and training regimes"
+  - "Integrate with distributed training launchers and experiment trackers for reproducible research workflows"


### PR DESCRIPTION
## Tools Added

### Dev Tools
- **Gunicorn** (10.6k★) — Production-grade WSGI HTTP server for Python web applications with pre-fork worker model, supporting multiple worker types for concurrent model serving. `pip install gunicorn`
- **Hydra** (10.6k★) — Framework for elegantly configuring complex Python applications with hierarchical YAML configuration, command-line overrides, multi-run experiments, and instant configurable launching. `pip install hydra-core`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gunicorn to the Dev Tools catalog, with installation details, licensing, links, and guidance for serving Python web applications in production.
  * Added Hydra to the Dev Tools catalog, including descriptions, setup information, project links, licensing, pricing, and common use cases.
  * Expanded tool discovery with practical scenarios covering WSGI deployments, model inference, Flask and Django applications, configuration management, and process orchestration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->