### PR TITLE
Add Ruff, pipenv, pipx, pre-commit, Black to catalog

### DIFF
--- a/tools/dev-tools/black.yaml
+++ b/tools/dev-tools/black.yaml
@@ -1,0 +1,22 @@
+name: Black
+description: "The uncompromising Python code formatter that automatically formats code with minimal configuration, producing consistently styled code by enforcing a deterministic style with the smallest possible diffs."
+tagline: "Uncompromising Python code formatter"
+github_url: https://github.com/psf/black
+website_url: https://black.readthedocs.io
+docs_url: https://black.readthedocs.io/en/stable
+install_command: "pip install black"
+category: Dev Tools
+tags:
+  - python
+  - formatter
+  - code-style
+  - automation
+  - pep-8
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Python teams traditionally debate code formatting conventions in code reviews, wasting time on stylistic preferences (single vs double quotes, trailing commas, line wrapping) that add no functional value. Black eliminates formatting discussions by providing a deterministic, opinionated formatter that produces the same output regardless of who runs it — with an occasional opt-out (# fmt: off) for special cases. This guarantees PEP 8 compliance, reduces code review noise from formatting nits, and integrates with pre-commit hooks or CI to enforce a consistent style across the entire codebase without configuration or debate."
+use_cases:
+  - "Format entire Python codebases consistently with black . in CI pipelines, producing the same output on every run and eliminating code review debates about formatting conventions"
+  - "Integrate Black with pre-commit hooks and editor auto-save-on-format configurations so that every developer produces identically styled code without manual formatting effort"
+  - "Use Black with Jupyter notebook support (black[jupyter]) to format code cells in .ipynb files, maintaining consistent style across both Python scripts and notebooks"

--- a/tools/dev-tools/pipenv.yaml
+++ b/tools/dev-tools/pipenv.yaml
@@ -1,0 +1,22 @@
+name: pipenv
+description: "A Python dependency management tool that combines Pipfile-based dependency specification, virtual environment management, and deterministic lockfiles into a single workflow — aiming to bring the best of npm/yarn and Bundler conventions to Python project dependency management."
+tagline: "Python dependency management with Pipfile and lockfiles"
+github_url: https://github.com/pypa/pipenv
+website_url: https://pipenv.pypa.io
+docs_url: https://pipenv.pypa.io/en/latest
+install_command: "pip install pipenv"
+category: Dev Tools
+tags:
+  - python
+  - dependency-management
+  - virtual-environments
+  - packaging
+  - pipfile
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Python projects lack a built-in standard for declarative dependency specification with deterministic lockfiles, forcing teams to choose between fragile requirements.txt files (no lock semantics, no dev/production separation) and more opinionated tools like Poetry or Conda. Pipenv provides a Pipfile-based manifest format with separate dev and runtime dependencies, Pipfile.lock for reproducible installs, automatic virtual environment creation, and dependency graph visualization — standardizing Python dependency management across teams without migrating away from PyPI."
+use_cases:
+  - "Initialize Python projects with a standard Pipfile that separates development dependencies (testing, linting) from runtime dependencies (library packages) and generates a deterministic Pipfile.lock"
+  - "Install project dependencies into an automatically created virtual environment with pipenv install, ensuring consistent environments across developer machines and CI runners"
+  - "Audit the dependency graph for sub-dependencies and security vulnerabilities using pipenv graph and pipenv check, maintaining visibility into transitive dependency resolution"

--- a/tools/dev-tools/pipx.yaml
+++ b/tools/dev-tools/pipx.yaml
@@ -1,0 +1,22 @@
+name: pipx
+description: "A tool for installing and running Python applications in isolated virtual environments, enabling side-effect-free installation of CLI tools like black, ruff, mypy, and poetry without polluting the global Python environment or requiring per-project venvs."
+tagline: "Install and run Python applications in isolated environments"
+github_url: https://github.com/pypa/pipx
+website_url: https://pipx.pypa.io
+docs_url: https://pipx.pypa.io/stable
+install_command: "pip install pipx"
+category: Dev Tools
+tags:
+  - python
+  - cli-tools
+  - virtual-environments
+  - packaging
+  - application-management
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Python CLI tools like black, ruff, mypy, poetry, and httpie traditionally require either system-wide pip installs that cause dependency conflicts between tools, or per-project installs that require activating virtual environments just to run a linter or formatter. pipx installs each Python CLI application in its own isolated virtual environment, symlinks the binary to a shared PATH location, and handles upgrades and removals — keeping global site-packages clean and eliminating environment conflicts between tools that depend on different library versions."
+use_cases:
+  - "Install and run Python-based development tools (black, ruff, mypy, poetry) in isolated environments with pipx install, keeping global site-packages free of tool-specific dependencies"
+  - "Run a Python CLI tool temporarily without installing it using pipx run, streaming the package and executing it in a transient ephemeral environment"
+  - "List, upgrade, and remove globally installed Python tools with pipx list, pipx upgrade-all, and pipx uninstall-all for simple tool lifecycle management"

--- a/tools/dev-tools/pre-commit.yaml
+++ b/tools/dev-tools/pre-commit.yaml
@@ -1,0 +1,22 @@
+name: pre-commit
+description: "A framework for managing and maintaining multi-language pre-commit hooks in Git repositories, with automatic hook installation, configurable execution, and a curated registry of ready-to-use hooks from the open-source community."
+tagline: "Multi-language pre-commit hook framework"
+github_url: https://github.com/pre-commit/pre-commit
+website_url: https://pre-commit.com
+docs_url: https://pre-commit.com/index.html
+install_command: "pip install pre-commit"
+category: Dev Tools
+tags:
+  - git-hooks
+  - code-quality
+  - python
+  - automation
+  - ci
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Teams using Git repositories for collaborative development need automated code quality checks (linting, formatting, type checking, secret scanning) before each commit, but writing and maintaining shell scripts for pre-commit hooks is error-prone, language-specific, and hard to share across team members. Pre-commit provides a declarative .pre-commit-config.yaml format where developers list the hooks they want from a registry of 2000+ pre-built hooks, installs them automatically, and runs each hook against staged files — catching issues before they reach CI without requiring every developer to install tools manually."
+use_cases:
+  - "Configure automated linting, formatting, and type checking hooks (ruff, black, mypy) in a .pre-commit-config.yaml file that runs before every commit, ensuring all contributors pass the same quality gates"
+  - "Run pre-commit hooks in CI pipelines with pre-commit run --all-files to catch issues in pull requests that bypassed local git hooks"
+  - "Use hooks from the pre-commit hook registry for trailing whitespace removal, YAML validation, JSON formatting, secret detection, and large-file prevention without writing custom hook scripts"

--- a/tools/dev-tools/ruff.yaml
+++ b/tools/dev-tools/ruff.yaml
@@ -1,0 +1,21 @@
+name: Ruff
+description: "An extremely fast Python linter and code formatter written in Rust, providing linting for over 800 rules (including pyflakes, pylint, isort, and flake8) with zero-config setup, automatic fix support, and drop-in compatibility with existing formatters like Black."
+tagline: "Extremely fast Python linter and formatter"
+github_url: https://github.com/astral-sh/ruff
+website_url: https://docs.astral.sh/ruff
+install_command: "pip install ruff"
+category: Dev Tools
+tags:
+  - python
+  - linter
+  - formatter
+  - rust
+  - code-quality
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Python projects historically required multiple linting tools (flake8, pyflakes, isort, pylint) and formatters (Black, autopep8) running as separate pre-commit hooks, each with its own configuration, performance profile, and output format — leading to slow CI pipelines, configuration drift, and inconsistent rule application. Ruff combines hundreds of lint rules and auto-fixes in a single Rust-built binary that runs 10-100x faster than existing tools, with zero-config defaults and automatic formatter compatibility that lets teams replace a multi-tool pre-commit setup with a single dependency."
+use_cases:
+  - "Lint and auto-fix Python codebases of any size in CI pipelines, catching PEP 8 violations, unused imports, logic errors, and security issues across 800+ built-in rules with sub-second execution"
+  - "Replace separate flake8, isort, and pylint configurations with a single Ruff config file while maintaining the same rule sets for team consistency"
+  - "Format Python code with drop-in Black compatibility, reordering imports and sorting dependencies in the same pass without an extra isort step"


### PR DESCRIPTION
This PR adds 5 Python development tools to the catalog:

- **Ruff** — Extremely fast Python linter and formatter (astral-sh/ruff, 48.9k★)
- **pipenv** — Python dependency management with Pipfile and lockfiles (pypa/pipenv, 25k★)
- **pipx** — Install and run Python applications in isolated environments (pypa/pipx, 12.9k★)
- **pre-commit** — Multi-language pre-commit hook framework (pre-commit/pre-commit, 15.5k★)
- **Black** — Uncompromising Python code formatter (psf/black, 41.8k★)

All files validated successfully with `npx tsx scripts/validate-tool.ts`.
