### PR TITLE
Add mypy, Pyright, pytest, Requests, aiohttp to catalog

### DIFF
--- a/tools/dev-tools/aiohttp.yaml
+++ b/tools/dev-tools/aiohttp.yaml
@@ -1,0 +1,23 @@
+name: aiohttp
+description: "An asynchronous HTTP client and server library for Python built on asyncio, providing non-blocking HTTP/1.1, WebSocket support, and a client session API optimized for high-concurrency workloads like web scraping, API clients, and microservices."
+tagline: "Async HTTP client and server for Python"
+github_url: https://github.com/aio-libs/aiohttp
+website_url: https://docs.aiohttp.org
+docs_url: https://docs.aiohttp.org/en/stable
+install_command: "pip install aiohttp"
+category: Dev Tools
+tags:
+  - python
+  - http
+  - async
+  - asyncio
+  - websocket
+  - networking
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Python developers building concurrent I/O-bound applications (web scrapers, API clients, streaming data pipelines) hit throughput limits with synchronous HTTP libraries that block on every request — forcing thread-per-request patterns that waste memory and context-switch overhead. Aiohttp provides a native asyncio-based HTTP client that multiplexes hundreds of concurrent requests on a single thread, with automatic connection pooling, keep-alive, and redirect handling — enabling web crawlers, LLM API batching, and microservice backends to saturate network bandwidth without thread-per-request overhead."
+use_cases:
+  - "Send hundreds of concurrent HTTP requests to LLM providers, embedding APIs, and search endpoints from a single process using aiohttp.ClientSession for batch inference and retrieval"
+  - "Build asynchronous web crawlers and document scrapers that fetch, parse, and extract content from thousands of URLs simultaneously without thread-per-request overhead"
+  - "Serve AI model inference endpoints and WebSocket streaming responses with aiohttp.web, handling concurrent client connections with asyncio-native request lifecycle management"

--- a/tools/dev-tools/mypy.yaml
+++ b/tools/dev-tools/mypy.yaml
@@ -1,0 +1,22 @@
+name: mypy
+description: "A static type checker for Python that infers and validates type annotations at analysis time, catching type-related bugs before runtime while supporting gradual typing, stub files, and the full Python type system (generics, protocols, overloads, and type narrowing)."
+tagline: "Optional static type checker for Python"
+github_url: https://github.com/python/mypy
+website_url: https://mypy-lang.org
+docs_url: https://mypy.readthedocs.io
+install_command: "pip install mypy"
+category: Dev Tools
+tags:
+  - python
+  - type-checking
+  - static-analysis
+  - linting
+  - code-quality
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Python's dynamic typing leads to runtime type errors that are only discovered during execution, causing production failures that could have been caught at development time. Without static type checking, teams rely on runtime tests to catch type mismatches, leaving gaps in coverage for rarely-executed code paths. Mypy analyzes Python programs without running them, inferring types from annotations and validating them against the type system — catching None-type errors, argument mismatches, and return-type violations during CI rather than in production, while supporting gradual adoption through per-file opt-in and stub files for third-party libraries."
+use_cases:
+  - "Add type annotations to existing Python codebases incrementally and validate them with mypy in CI, catching None-related AttributeError and argument type mismatches before deployment"
+  - "Define and enforce strict type contracts for library APIs using mypy's strict mode, ensuring that all function signatures, generic types, and protocol implementations are correctly typed"
+  - "Use stub files (.pyi) and third-party type stubs (typeshed) to type-check interactions with untyped libraries, extending coverage beyond the project's own code"

--- a/tools/dev-tools/pyright.yaml
+++ b/tools/dev-tools/pyright.yaml
@@ -1,0 +1,22 @@
+name: Pyright
+description: "A fast Python static type checker written in TypeScript, powering the Pylance VS Code extension and providing TypeScript-style type checking, incremental analysis, and language server protocol integration for large codebases."
+tagline: "Fast Python type checker in TypeScript"
+github_url: https://github.com/microsoft/pyright
+website_url: https://github.com/microsoft/pyright
+docs_url: https://microsoft.github.io/pyright
+install_command: "pip install pyright"
+category: Dev Tools
+tags:
+  - python
+  - type-checking
+  - static-analysis
+  - microsoft
+  - lsp
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Developers working on large Python codebases need fast, scalable type checking that integrates with their editor and CI pipeline, but existing type checkers can be slow on multi-million-line projects and lack first-class language server protocol (LSP) support. Pyright is written in TypeScript with a high-performance incremental analysis engine that provides sub-second type checking and auto-completion in VS Code via the Pylance extension, while also offering a CLI for CI integration — giving teams both IDE-speed type feedback and pre-commit type safety without switching tools."
+use_cases:
+  - "Run pyright in CI pipelines to enforce type correctness across large Python monorepos, leveraging its incremental analysis for fast diff-level type validation on each commit"
+  - "Provide real-time type checking, auto-completion, and inline error reporting in VS Code via the Pylance extension, giving developers immediate type feedback while editing"
+  - "Configure pyright with strict mode, per-directory severity overrides, and type stub paths to enforce graduated typing policies across microservices and library packages"

--- a/tools/dev-tools/pytest.yaml
+++ b/tools/dev-tools/pytest.yaml
@@ -1,0 +1,22 @@
+name: pytest
+description: "A mature, full-featured Python testing framework that makes it easy to write simple and scalable tests, with fixture-based dependency injection, parameterized testing, assertion introspection, and a rich plugin ecosystem."
+tagline: "Python testing framework"
+github_url: https://github.com/pytest-dev/pytest
+website_url: https://pytest.org
+docs_url: https://docs.pytest.org
+install_command: "pip install pytest"
+category: Dev Tools
+tags:
+  - python
+  - testing
+  - fixtures
+  - ci
+  - code-quality
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Python projects need a testing framework that is simple to start with yet powerful enough for complex test suites, but Python's built-in unittest framework requires verbose boilerplate (TestCase classes, self.assert* methods, setUp/tearDown) that discourages comprehensive testing. Pytest replaces unittest with plain assert statements, automatic test discovery, fixture-based dependency injection that eliminates shared setup boilerplate, and a plugin system supporting coverage, parallelism (pytest-xdist), parametrized tests, and async testing — enabling teams to write more tests with less code and run them faster across CI and local development."
+use_cases:
+  - "Write test functions with plain Python assert statements and automatic discovery, eliminating unittest boilerplate and making tests readable for non-specialist contributors"
+  - "Use pytest fixtures for test dependency injection — database connections, API clients, and ML model instances — with automatic setup, teardown, and scope management"
+  - "Run tests in parallel across multiple CPUs (pytest-xdist), generate coverage reports (pytest-cov), and integrate with CI pipelines for pre-merge validation"

--- a/tools/dev-tools/requests.yaml
+++ b/tools/dev-tools/requests.yaml
@@ -1,0 +1,22 @@
+name: Requests
+description: "A simple, elegant HTTP library for Python with a human-friendly API for sending HTTP/1.1 requests, handling sessions, cookies, authentication, file uploads, and SSL verification — described as HTTP for Humans."
+tagline: "Elegant HTTP library for Python"
+github_url: https://github.com/psf/requests
+website_url: https://requests.readthedocs.io
+docs_url: https://requests.readthedocs.io/en/latest
+install_command: "pip install requests"
+category: Dev Tools
+tags:
+  - python
+  - http
+  - api-client
+  - networking
+  - web
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Python's standard library urllib provides basic HTTP capabilities but requires verbose, non-intuitive code for common operations like session management, cookie handling, JSON POST requests, and file uploads — making it frustrating for developers to interact with REST APIs, web services, and authentication flows. Requests provides a clean, well-documented API where common HTTP operations are expressible in a single line — get, post with JSON, stream downloads, session persistence across requests, and automatic connection pooling — reducing boilerplate by 60-80% compared to urllib while handling edge cases like keep-alive, encoding detection, and SSL verification transparently."
+use_cases:
+  - "Send authenticated HTTP requests to REST APIs for LLM inference endpoints, embedding services, and vector database operations with structured JSON request/response handling"
+  - "Manage session state across multiple requests (cookies, headers, connection pooling) using requests.Session for long-running interactions with web applications and API gateways"
+  - "Download large model weights and datasets with streaming requests, progress tracking, and automatic decompression to avoid memory overflow during ML model acquisition"


### PR DESCRIPTION
This PR adds 5 Python development tools to the catalog:

- **mypy** — Static type checker for Python (python/mypy, 20.6k★)
- **Pyright** — Fast Python type checker by Microsoft (microsoft/pyright, 15.6k★)
- **pytest** — Full-featured Python testing framework (pytest-dev/pytest, 14.4k★)
- **Requests** — Elegant HTTP library for Python (psf/requests, 54.2k★)
- **aiohttp** — Async HTTP client/server for Python (aio-libs/aiohttp, 16.5k★)

All files validated successfully with `npx tsx scripts/validate-tool.ts`.
