### PR TITLE
Add starlette, OmniParser, Alpaca-LoRA, Gorilla, Kohya SS to catalog

### DIFF
--- a/tools/agent-frameworks/omniparser.yaml
+++ b/tools/agent-frameworks/omniparser.yaml
@@ -1,0 +1,20 @@
+name: OmniParser
+description: "A screen parsing tool from Microsoft that converts UI screenshots into structured representations — identifying interactable UI elements, their types, bounding boxes, and text content — for building vision-based GUI automation agents."
+tagline: "Screen parsing for GUI agents"
+github_url: https://github.com/microsoft/OmniParser
+website_url: https://github.com/microsoft/OmniParser
+category: Agents
+tags:
+  - screen-parsing
+  - gui-automation
+  - computer-vision
+  - microsoft
+  - agent
+pricing: free
+is_open_source: true
+license: CC-BY-4.0
+problem_solved: "AI agents that automate desktop and web applications need to understand on-screen UI elements — buttons, text fields, dropdowns, links — from raw screenshots, but traditional approaches require brittle coordinate-based scripts or accessibility-tree scraping that misses visually-rendered content. OmniParser uses a fine-tuned vision model to parse screenshots into structured element descriptions with bounding boxes, types, and text labels — enabling agents to reason about UI state, plan click/type actions, and execute multi-step workflows based on what they see rather than hard-coded selectors."
+use_cases:
+  - "Enable vision-based AI agents to understand desktop application UIs by parsing screenshots into structured element lists with types, text content, and spatial coordinates"
+  - "Build automated web testing and form-filling agents that navigate pages by visually identifying buttons, inputs, and links rather than relying on fragile DOM selectors"
+  - "Create accessibility-aware automation pipelines that work across native desktop apps, browser-based tools, and legacy interfaces without requiring source-level integration"

--- a/tools/dev-tools/starlette.yaml
+++ b/tools/dev-tools/starlette.yaml
@@ -1,0 +1,22 @@
+name: starlette
+description: "A lightweight ASGI framework for building high-performance async web services in Python, with a low-complexity API that supports WebSocket, GraphQL, SSE streaming, and background tasks while serving as the foundation for FastAPI."
+tagline: "Lightweight ASGI framework for Python"
+github_url: https://github.com/encode/starlette
+website_url: https://www.starlette.io
+docs_url: https://www.starlette.io
+install_command: "pip install starlette"
+category: Dev Tools
+tags:
+  - python
+  - asgi
+  - web-framework
+  - async
+  - api
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Python developers building async web services and APIs need a framework that is fast, lightweight, and compatible with the ASGI standard, but existing frameworks either carry synchronous baggage (Flask, Django) or impose heavy abstractions (aiohttp.web). Starlette provides a minimal, composable ASGI framework with WebSocket support, background tasks, streaming responses, middleware, and test client — serving as the foundation for FastAPI while remaining usable standalone for lightweight async services and microservices."
+use_cases:
+  - "Build lightweight async API endpoints for model inference and embedding services using Starlette's ASGI-based routing, request parsing, and streaming response support"
+  - "Serve real-time WebSocket connections for LLM token streaming and chat applications with Starlette's built-in WebSocket endpoint handling and background task management"
+  - "Create middleware pipelines for authentication, rate limiting, and request logging across async Python services, with Starlette's composable middleware interface"

--- a/tools/fine-tuning/alpaca-lora.yaml
+++ b/tools/fine-tuning/alpaca-lora.yaml
@@ -1,0 +1,20 @@
+name: Alpaca-LoRA
+description: "A research project and fine-tuning recipe that applied Low-Rank Adaptation to instruction-tune LLaMA models on the Stanford Alpaca dataset, demonstrating that consumer-grade GPUs can produce instruction-following LLMs via parameter-efficient fine-tuning."
+tagline: "LoRA fine-tuning recipe for LLaMA instruction tuning"
+github_url: https://github.com/tloen/alpaca-lora
+website_url: https://github.com/tloen/alpaca-lora
+category: Fine-tuning
+tags:
+  - lora
+  - llama
+  - instruction-tuning
+  - peft
+  - fine-tuning
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Fine-tuning LLMs required expensive multi-GPU setups and full-model training, creating a barrier for researchers and practitioners who wanted to create instruction-following variants on limited hardware. Alpaca-LoRA demonstrated that parameter-efficient fine-tuning with LoRA can reproduce instruction-following behavior (matching Stanford Alpaca quality) on a single consumer GPU — training adapter weights representing less than 0.1% of full parameters — proving that low-cost fine-tuning is accessible to individual developers and academic labs without cloud GPU clusters."
+use_cases:
+  - "Fine-tune LLaMA models for instruction following on consumer-class GPUs (RTX 3090/4090) using LoRA adapters, achieving Alpaca-level performance with minimal VRAM requirements"
+  - "Adapt pre-trained LLMs to domain-specific tasks (code generation, medical QA, legal analysis) by training lightweight LoRA adapters on curated instruction datasets without full model retraining"
+  - "Experiment with hyperparameter tuning and dataset composition for instruction fine-tuning at low cost, iterating on adapter configurations in hours rather than days"

--- a/tools/fine-tuning/kohya-ss.yaml
+++ b/tools/fine-tuning/kohya-ss.yaml
@@ -1,0 +1,20 @@
+name: Kohya SS
+description: "A GUI tool for training Stable Diffusion LoRA, DreamBooth, and textual inversion models, providing a comprehensive interface for dataset preparation, hyperparameter configuration, and model merging for fine-tuning diffusion models on custom image datasets."
+tagline: "LoRA training GUI for Stable Diffusion"
+github_url: https://github.com/bmaltais/kohya_ss
+website_url: https://github.com/bmaltais/kohya_ss
+category: Fine-tuning
+tags:
+  - stable-diffusion
+  - lora
+  - dreambooth
+  - gui
+  - image-generation
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Training custom Stable Diffusion models and LoRAs traditionally requires writing Python training scripts, managing dataset formats, tuning hyperparameters through trial and error via command-line flags, and keeping track of model checkpoints — creating a steep learning curve for artists and creators without ML engineering backgrounds. Kohya SS provides a GUI-driven interface for dataset preparation (tagging, captioning, bucketing), training configuration (LoRA, DreamBooth, textual inversion), and model merging — making custom diffusion model training accessible to non-engineers while providing power users with fine-grained control over every training parameter."
+use_cases:
+  - "Train custom Stable Diffusion LoRA models on personal image datasets through a GUI interface, configuring batch size, learning rate, and network rank without writing training scripts"
+  - "Prepare training data with built-in captioning, tagging, and aspect-ratio bucketing tools that automatically resize and organize image datasets for optimal training results"
+  - "Merge multiple trained LoRAs and checkpoint models using Kohya SS's model merging interface, combining style concepts and character representations into unified generation pipelines"

--- a/tools/llm/gorilla.yaml
+++ b/tools/llm/gorilla.yaml
@@ -1,0 +1,21 @@
+name: Gorilla
+description: "An LLM fine-tuned for accurately generating API function calls from natural language descriptions, enabling LLMs to invoke thousands of APIs reliably through a document-retrieval-aware training approach that reduces hallucination."
+tagline: "LLM for accurate API function calling"
+github_url: https://github.com/gorilla-llm/gorilla-cli
+website_url: https://gorilla.cs.berkeley.edu
+install_command: "pip install gorilla-cli"
+category: LLM
+tags:
+  - function-calling
+  - api
+  - llm
+  - berkeley
+  - tool-use
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Standard LLMs struggle with accurate API function calling — they hallucinate endpoint URLs, invent parameter names, or fail to match API documentation for less popular services — making reliable tool-use automation difficult. Gorilla trains on a large corpus of API documentation with a retrieval-aware mechanism that associates each API call with its source document, enabling the model to generate correct function signatures, required parameters, and endpoint URLs even for APIs with changing or sparse documentation — achieving significantly higher call accuracy than general-purpose models on the APIBench benchmark."
+use_cases:
+  - "Enable LLM agents to make reliable function calls to cloud service APIs (AWS, GCP, Azure) and ML platform APIs (Hugging Face, Replicate) by generating correct JSON signatures from natural language tool descriptions"
+  - "Build autonomous AI agents that discover, understand, and invoke APIs from documentation, reducing the need for hard-coded tool definitions in agent frameworks"
+  - "Augment chatbot and copilot applications with function-calling accuracy for retrieving live data from external services through natural language commands"


### PR DESCRIPTION
This PR adds 5 tools to the catalog:

- **starlette** — Lightweight ASGI framework for Python (encode/starlette, 12.5k★)
- **OmniParser** — Screen parsing for GUI agents (microsoft/OmniParser, 25.2k★)
- **Alpaca-LoRA** — LoRA fine-tuning recipe for LLaMA instruction tuning (tloen/alpaca-lora, 18.9k★)
- **Gorilla** — LLM for accurate API function calling (gorilla-llm/gorilla-cli, 1.4k★)
- **Kohya SS** — LoRA training GUI for Stable Diffusion (bmaltais/kohya_ss, 12.5k★)

All files validated successfully with `npx tsx scripts/validate-tool.ts`.
