### PR TITLE
Add BERTopic, KeyBERT, Moshi, Stable Audio to catalog

### DIFF
--- a/tools/data/bertopic.yaml
+++ b/tools/data/bertopic.yaml
@@ -1,0 +1,22 @@
+name: BERTopic
+description: "A topic modeling technique that leverages BERT embeddings and c-TF-IDF to create dense topic representations, providing modular components for clustering, topic reduction, and dynamic topic visualization."
+tagline: "BERT-based topic modeling"
+github_url: https://github.com/MaartenGr/BERTopic
+website_url: https://maartengr.github.io/BERTopic
+docs_url: https://maartengr.github.io/BERTopic
+install_command: "pip install bertopic"
+category: Data
+tags:
+  - topic-modeling
+  - nlp
+  - bert
+  - clustering
+  - embeddings
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Traditional topic modeling methods like LDA and NMF rely on bag-of-words representations that ignore word order, semantics, and context — producing topics with overlapping, redundant keywords that are hard to interpret. BERTopic combines transformer-based sentence embeddings with class-based TF-IDF (c-TF-IDF) to generate dense, semantic topic representations where each topic is described by distinctive n-gram phrases rather than individual words — enabling intuitive topic hierarchies, dynamic topic evolution over time, and interoperable visualization without requiring manual topic labeling."
+use_cases:
+  - "Discover latent themes and topics in large text corpora (customer reviews, support tickets, research papers) by clustering sentence embeddings and extracting c-TF-IDF topic representations"
+  - "Track how topic prevalence changes over time across document collections using BERTopic's dynamic topic modeling, identifying emerging trends in chat logs, news archives, and product feedback"
+  - "Reduce and merge semantically similar topics into a coherent hierarchy with BERTopic's hierarchical topic reduction, producing interpretable topic taxonomies for business stakeholders"

--- a/tools/data/keybert.yaml
+++ b/tools/data/keybert.yaml
@@ -1,0 +1,22 @@
+name: KeyBERT
+description: "A lightweight keyword extraction library that leverages BERT sentence embeddings and cosine similarity to identify the most representative keywords and keyphrases in text documents."
+tagline: "BERT-based keyword extraction"
+github_url: https://github.com/MaartenGr/KeyBERT
+website_url: https://maartengr.github.io/KeyBERT
+docs_url: https://maartengr.github.io/KeyBERT
+install_command: "pip install keybert"
+category: Data
+tags:
+  - keyword-extraction
+  - nlp
+  - bert
+  - embeddings
+  - text-analysis
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Extracting meaningful keywords from documents traditionally required rule-based approaches (TF-IDF, RAKE) that capture statistical frequency but miss semantic relevance, or supervised methods that need labeled training data. KeyBERT uses pre-trained BERT sentence embeddings to compare document-level embeddings with candidate keyword embeddings, selecting keywords whose semantic representation is most similar to the document — producing contextually relevant keywords without training data, language-specific rules, or external knowledge bases, while supporting multiple embedding models and keyphrase extraction via MMR diversity."
+use_cases:
+  - "Extract semantically relevant keywords from research papers, product descriptions, and support articles for metadata tagging, search indexing, and content categorization"
+  - "Generate keyphrases for SEO optimization and content summarization by selecting diverse keyword candidates using MMR (Maximal Marginal Relevance) to reduce redundancy"
+  - "Identify trending terms and emerging topics in chat logs, forum posts, and social media content by comparing document embeddings against a dynamic vocabulary of candidate keywords"

--- a/tools/other/moshi.yaml
+++ b/tools/other/moshi.yaml
@@ -1,0 +1,21 @@
+name: Moshi
+description: "A real-time speech-to-speech AI model from Kyutai that enables low-latency voice conversations with natural prosody, backchanneling, and turn-taking — processing audio input and generating speech output in a streaming fashion without a separate ASR-TTS pipeline."
+tagline: "Real-time speech-to-speech AI model"
+github_url: https://github.com/kyutai-labs/moshi
+website_url: https://kyutai.org/moshi
+docs_url: https://github.com/kyutai-labs/moshi
+category: Other
+tags:
+  - speech
+  - real-time
+  - ai-assistant
+  - audio
+  - kyutai
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Voice AI assistants traditionally require a cascaded pipeline of separate ASR (speech-to-text), LLM (text generation), and TTS (text-to-speech) components, creating 2-5 second end-to-end latency that makes natural conversation impossible — the AI can't interrupt, backchannel (uh-huh, mhm), or adjust tone in real-time. Moshi is a single neural network that directly processes audio input and generates audio output in a streaming low-latency loop, supporting natural prosody, emotional tone, conversational turn-taking, and text-free operation — enabling voice interfaces that feel as responsive as human conversation without complex multi-model orchestration."
+use_cases:
+  - "Build real-time voice assistants that hold natural conversational exchanges with users, including backchanneling, turn-taking, and emotional tone variation without perceptible delay"
+  - "Create multilingual speech interfaces that process audio input directly without requiring separate ASR and TTS components for each supported language"
+  - "Develop accessibility tools for hands-free interaction with AI systems in environments where text input is impractical (driving, industrial settings, physical disabilities)"

--- a/tools/other/stable-audio.yaml
+++ b/tools/other/stable-audio.yaml
@@ -1,0 +1,21 @@
+name: Stable Audio
+description: "A generative audio model from Stability AI that produces music, sound effects, and vocal tracks from text descriptions, genre tags, and reference audio using latent diffusion."
+tagline: "Text-to-audio and music generation"
+github_url: https://github.com/Stability-AI/stable-audio-tools
+website_url: https://stability.ai/stable-audio
+install_command: "pip install stable-audio-tools"
+category: Other
+tags:
+  - audio-generation
+  - music
+  - diffusion
+  - stability-ai
+  - generative-ai
+pricing: freemium
+is_open_source: true
+license: Stability-AI Non-Commercial
+problem_solved: "Producing custom music and sound effects for applications, games, and videos traditionally requires professional composers, licensing fees, or royalty-free libraries that rarely match the specific creative brief — making audio content generation expensive and slow. Stable Audio uses latent diffusion on compressed audio representations to generate full-length stereo tracks (up to 90 seconds) from text descriptions with control over genre, tempo, instrumentation, and sound quality — enabling creators to generate production-ready audio assets in seconds from a text prompt without audio engineering expertise."
+use_cases:
+  - "Generate background music tracks for video content, podcasts, and games from text descriptions specifying genre, mood, tempo, and instrumentation"
+  - "Create sound effects and ambient audio for applications and virtual environments by describing the desired sound in natural language with style controls"
+  - "Generate vocal samples and a cappella tracks from lyric prompts with Stable Audio's extended generation capabilities, producing radio-quality vocal performances"


### PR DESCRIPTION
This PR adds 4 tools to the catalog:

- **BERTopic** — BERT-based topic modeling (MaartenGr/BERTopic, 7.8k★)
- **KeyBERT** — BERT-based keyword extraction (MaartenGr/KeyBERT, 4.2k★)
- **Moshi** — Real-time speech-to-speech AI model (kyutai-labs/moshi, 10.8k★)
- **Stable Audio** — Text-to-audio and music generation (Stability-AI/stable-audio-tools, 3.8k★)

All files validated successfully with `npx tsx scripts/validate-tool.ts`.
