### PR TITLE
Add PurpleLlama, Presidio, ZincSearch, Cayley, pgvecto.rs to catalog

### DIFF
--- a/tools/data/cayley.yaml
+++ b/tools/data/cayley.yaml
@@ -1,0 +1,21 @@
+name: Cayley
+description: "An open-source graph database written in Go that provides a graph query interface with support for Gremlin, GraphQL, and MQL query languages, designed for storing and querying highly connected data with a simple HTTP API."
+tagline: "Open-source graph database in Go"
+github_url: https://github.com/cayleygraph/cayley
+website_url: https://cayley.io
+docs_url: https://cayley.io/docs
+category: Data
+tags:
+  - graph-database
+  - go
+  - gremlin
+  - graphql
+  - knowledge-graph
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Teams building knowledge graphs for RAG and entity relationship modeling need a graph database that is simple to deploy and query, but popular graph databases like Neo4j require Java, have significant operational complexity, or lock users into proprietary query languages. Cayley provides a lightweight, embedded graph database written in Go with support for multiple graph query languages (Gremlin, GraphQL, MQL), multiple storage backends (LevelDB, Bolt, PostgreSQL, MongoDB), and a simple HTTP API — enabling graph-based data modeling for knowledge bases, recommendation systems, and entity resolution without dedicated infrastructure or proprietary licensing."
+use_cases:
+  - "Build knowledge graphs for RAG pipelines by storing entity relationships, document connections, and concept hierarchies in Cayley's graph model with Gremlin traversal queries for context retrieval"
+  - "Model recommendation and relationship discovery systems using Cayley's graph queries to find connected entities, shortest paths, and graph-based similarity for content and product recommendations"
+  - "Deploy graph databases for entity resolution and identity linking by storing entity attributes and relationship edges, querying across connected records to identify duplicates and associations"

--- a/tools/data/presidio.yaml
+++ b/tools/data/presidio.yaml
@@ -1,0 +1,22 @@
+name: Presidio
+description: "An open-source data protection and anonymization framework from Microsoft that identifies and redacts personally identifiable information (PII) in text and images through customizable entity recognition and anonymization pipelines."
+tagline: "Data protection and PII anonymization"
+github_url: https://github.com/microsoft/presidio
+website_url: https://microsoft.github.io/presidio
+docs_url: https://microsoft.github.io/presidio
+install_command: "pip install presidio-analyzer"
+category: Data
+tags:
+  - pii
+  - data-privacy
+  - anonymization
+  - microsoft
+  - nlp
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Organizations processing user-generated content and logs for ML training need to remove personally identifiable information (PII) before storage and analysis, but building custom PII detection with regex patterns for each data source is fragile, misses non-standard formats, and requires ongoing maintenance as privacy regulations evolve. Presidio provides a modular PII detection pipeline with pre-built recognizers for names, emails, phone numbers, credit cards, and medical identifiers — supporting regex, NLP-based, and ML-based entity recognition with configurable anonymization strategies (redaction, replacement, encryption) that integrate into existing data preprocessing workflows."
+use_cases:
+  - "Anonymize customer support chat logs and user-generated content before using them as LLM training data, redacting names, emails, and phone numbers while preserving linguistic structure"
+  - "Implement automated PII detection in data ingestion pipelines for compliance with GDPR, CCPA, and HIPAA regulations, flagging and redacting sensitive information at scale"
+  - "Integrate Presidio with NLP pipelines to identify and pseudonymize personal entities in unstructured text, replacing names and identifiers with consistent placeholders for privacy-preserving analytics"

--- a/tools/data/zincsearch.yaml
+++ b/tools/data/zincsearch.yaml
@@ -1,0 +1,21 @@
+name: ZincSearch
+description: "A lightweight, modern search engine written in Go that provides full-text search, indexing, and analytics with a simple API, minimal resource footprint, and no external dependencies — designed as a simpler alternative to Elasticsearch."
+tagline: "Lightweight search engine in Go"
+github_url: https://github.com/zincsearch/zincsearch
+website_url: https://zincsearch.com
+docs_url: https://docs.zincsearch.com
+category: Data
+tags:
+  - search-engine
+  - full-text-search
+  - go
+  - elasticsearch-alternative
+  - indexing
+pricing: freemium
+is_open_source: true
+license: NOASSERTION
+problem_solved: "Teams deploying search functionality in ML applications often turn to Elasticsearch for its full-text search and analytics capabilities, but Elasticsearch's JVM-based architecture requires significant memory allocation, complex cluster configuration, and dedicated infrastructure that is overkill for smaller deployments and development environments. ZincSearch provides a single-binary, embedded search engine written in Go with a RESTful API compatible with Elasticsearch's indexing and query patterns — enabling full-text search, facet aggregation, and log analytics with MBs of memory rather than GBs, without requiring Java, separate indexing pipelines, or cluster management."
+use_cases:
+  - "Deploy lightweight full-text search for knowledge bases, documentation, and retrieval-augmented generation (RAG) pipelines without the operational overhead of Elasticsearch clusters"
+  - "Index and search application logs, metrics, and structured data with ZincSearch's simple indexing API, supporting faceted search and aggregation for operations dashboards"
+  - "Embed search functionality into development and testing environments that mirror production Elasticsearch APIs at a fraction of the resource cost for CI and local development"

--- a/tools/monitoring/purple-llama.yaml
+++ b/tools/monitoring/purple-llama.yaml
@@ -1,0 +1,20 @@
+name: PurpleLlama
+description: "A collection of trust and safety tools from Meta for evaluating and improving LLM security — including cyber attack simulation, input/output guardrails, and prompt injection detection for responsible generative AI deployment."
+tagline: "LLM safety and security tools from Meta"
+github_url: https://github.com/meta-llama/PurpleLlama
+website_url: https://ai.meta.com/research/publications/purple-llama-cyberseceval
+category: Monitoring
+tags:
+  - llm-security
+  - red-teaming
+  - meta
+  - safety
+  - guardrails
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Organizations deploying LLMs in production lack standardized tooling for evaluating and improving model security — relying on ad-hoc prompt injection testing, manual red-teaming, and inconsistent input/output filtering that can miss critical vulnerabilities. PurpleLlama provides a modular suite of security benchmarks and tools including CybersecEval for automated red-teaming, input/output guardrails for content filtering, and prompt injection detectors — enabling teams to systematically evaluate LLM attack surfaces and deploy defenses without building security infrastructure from scratch."
+use_cases:
+  - "Run automated cyber attack simulations against LLM deployments using CybersecEval benchmarks to identify prompt injection, jailbreak, and data extraction vulnerabilities"
+  - "Deploy input and output guardrails from PurpleLlama to filter toxic content, block prompt injection attempts, and enforce safety policies in production LLM serving pipelines"
+  - "Generate systematic red-teaming datasets for evaluating model robustness across attack categories, including encode-based attacks, multi-turn jailbreaks, and payload smuggling techniques"

--- a/tools/vector-databases/pgvecto-rs.yaml
+++ b/tools/vector-databases/pgvecto-rs.yaml
@@ -1,0 +1,21 @@
+name: pgvecto.rs
+description: "A vector similarity search extension for PostgreSQL written in Rust, providing high-performance approximate nearest neighbor (ANN) search with disk-based indexes, filtering, and full SQL integration for production vector databases."
+tagline: "Vector search extension for PostgreSQL"
+github_url: https://github.com/tensorchord/pgvecto.rs
+website_url: https://pgvecto.rs
+docs_url: https://pgvecto.rs
+category: Vector DB
+tags:
+  - postgresql
+  - vector-search
+  - rust
+  - ann
+  - extension
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Teams using PostgreSQL for their application database need to add vector similarity search for RAG and embedding-based retrieval without running a separate vector database service — but existing PostgreSQL vector extensions either lack ANN indexing (pgvector) or are written in C with limited filter support. pgvecto.rs is a Rust-based PostgreSQL extension that implements high-performance HNSW and IVF-PQ indexes with full SQL integration, pre-filtering on scalar columns, disk-based index storage that doesn't require indexes to fit in RAM, and distance functions (cosine, Euclidean, dot product, Hamming) — enabling hybrid structured + vector queries within PostgreSQL without additional infrastructure."
+use_cases:
+  - "Add vector similarity search to existing PostgreSQL databases for RAG retrieval, enabling semantic search over document embeddings with pre-filtering on metadata fields like date, author, and category"
+  - "Build hybrid search applications that combine full-text PostgreSQL queries with vector ANN search, ranking results by combined BM25 and semantic similarity scores in a single SQL query"
+  - "Deploy production vector search with disk-based HNSW indexes that scale to billions of vectors without requiring all indexes to fit in RAM, reducing infrastructure costs for large-scale embedding retrieval"


### PR DESCRIPTION
This PR adds 5 tools to the catalog:

- **PurpleLlama** — LLM safety and security tools from Meta (meta-llama/PurpleLlama, 4.3k★)
- **Presidio** — Data protection and PII anonymization (microsoft/presidio, 10.3k★)
- **ZincSearch** — Lightweight search engine in Go (zincsearch/zincsearch, 17.9k★)
- **Cayley** — Open-source graph database in Go (cayleygraph/cayley, 15k★)
- **pgvecto.rs** — Vector search extension for PostgreSQL (tensorchord/pgvecto.rs, 2.2k★)

All files validated successfully with `npx tsx scripts/validate-tool.ts`.
