### PR TITLE
Add DiffusionBee, Valkey, KeyDB to catalog

### DIFF
--- a/tools/data/keydb.yaml
+++ b/tools/data/keydb.yaml
@@ -1,0 +1,13 @@
+name: KeyDB
+description: |
+  KeyDB is a high-performance fork of Redis with a focus on multithreading, memory efficiency, and high throughput. Now part of Snap Inc., it offers Active Replication, FLASH Storage support, and Subkey Expires. KeyDB maintains full Redis protocol compatibility while delivering significantly higher throughput through its MVCC architecture that prevents blocking on KEYS and SCAN operations.
+problem_solved: |
+  Traditional Redis deployments face throughput bottlenecks due to single-threaded architecture, requiring complex sharding setups for high-load scenarios. KeyDB solves this with native multithreading support that can achieve significantly higher throughput on the same hardware, while maintaining full Redis protocol compatibility for drop-in replacement without application changes or code modifications.
+use_cases:
+  - "High-throughput caching layer for AI inference at production scale"
+  - "Real-time feature store serving ML model predictions with low latency"
+  - "Session management and rate limiting for AI application backends"
+category: Data
+github_url: https://github.com/Snapchat/KeyDB
+website_url: https://docs.keydb.dev/
+is_open_source: true

--- a/tools/data/valkey.yaml
+++ b/tools/data/valkey.yaml
@@ -1,0 +1,13 @@
+name: Valkey
+description: |
+  Valkey is a high-performance data structure server forked from Redis that primarily serves key/value workloads. It supports a wide range of native structures and an extensible plugin system for adding new data structures and access patterns. Maintained under the Linux Foundation as a community-driven open-source project with broad operating system support across Linux, macOS, and BSD systems.
+problem_solved: |
+  After Redis changed to a source-available license, the open-source community needed a truly open fork maintained under a permissive BSD-3-Clause license. Valkey provides a drop-in replacement with full compatibility, an extensible plugin architecture, and continued community-driven development supported by major cloud providers and the Linux Foundation, ensuring long-term open-source governance and innovation.
+use_cases:
+  - "High-performance caching and session storage for AI inference pipelines"
+  - "Real-time feature store and rate limiting for LLM application backends"
+  - "Message broker and job queue for distributed ML training workflows"
+category: Data
+github_url: https://github.com/valkey-io/valkey
+website_url: https://valkey.io/
+is_open_source: true

--- a/tools/other/diffusionbee.yaml
+++ b/tools/other/diffusionbee.yaml
@@ -1,0 +1,14 @@
+name: DiffusionBee
+description: |
+  DiffusionBee is the easiest way to run Stable Diffusion locally on Intel and Apple Silicon Macs. It provides a clean, intuitive GUI with one-click installer and full data privacy — no data is sent to the cloud. Supports SD 1.x, SD 2.x, SD XL, inpainting, outpainting, ControlNet, LoRA, upscaling, and image-to-image generation. Optimized for Apple Silicon with a native macOS experience.
+problem_solved: |
+  Running Stable Diffusion on macOS traditionally requires complex command-line setup, dependency management, and GPU driver configuration. DiffusionBee solves this by providing a native macOS application with a one-click installer that handles all dependencies automatically, making AI image generation accessible to non-technical users on both Intel and Apple Silicon Macs without any cloud dependency.
+use_cases:
+  - "Generate AI images from text prompts locally on macOS"
+  - "Edit photos with inpainting, outpainting, and image-to-image tools"
+  - "Apply style transfer and ControlNet guidance to generated images"
+category: Other
+github_url: https://github.com/divamgupta/diffusionbee-stable-diffusion-ui
+website_url: https://diffusionbee.com/
+is_open_source: true
+install_command: brew install --cask diffusionbee


### PR DESCRIPTION
This PR adds 3 tools to the catalog:

- **DiffusionBee** — Easiest way to run Stable Diffusion locally on macOS (divamgupta/diffusionbee-stable-diffusion-ui, 13.6k★)
- **Valkey** — High-performance data structure server forked from Redis, BSD-3-Clause, Linux Foundation (valkey-io/valkey, 26.7k★)
- **KeyDB** — Multithreaded high-performance fork of Redis, Snap Inc. (Snapchat/KeyDB, 12.5k★)

All files validated with `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added KeyDB to the tools directory with details about its capabilities, use cases, links, and open-source status.
  - Added Valkey with information about its AI/ML applications, repository, website, and licensing.
  - Added DiffusionBee, including its local image-generation features, project links, open-source status, and Homebrew installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->