### PR TITLE
Add Garnet, Riffusion to catalog

### DIFF
--- a/tools/data/garnet.yaml
+++ b/tools/data/garnet.yaml
@@ -1,0 +1,14 @@
+name: Garnet
+description: |
+  Garnet is a remote cache-store from Microsoft Research that offers high performance, low latency, and scalable data caching. It supports a rich cache API including raw string (GET/SET) operations, Redis-compatible commands, pub/sub, and geo-distributed replication. Garnet is built on .NET and provides a drop-in Redis-compatible replacement with significantly higher throughput and lower client latency.
+problem_solved: |
+  Traditional Redis deployments can struggle with throughput scaling due to single-threaded architecture limitations. Garnet solves this with a modern multithreaded architecture on .NET that achieves higher throughput and lower latency, while maintaining wire-compatibility with Redis clients for seamless migration without application-level changes.
+use_cases:
+  - "High-performance caching layer for AI inference serving at scale"
+  - "Low-latency session store and rate limiting for LLM application backends"
+  - "Pub/sub message broker for real-time AI application event streaming"
+category: Data
+github_url: https://github.com/microsoft/garnet
+website_url: https://microsoft.github.io/garnet/
+is_open_source: true
+install_command: dotnet tool install --global garnet-server

--- a/tools/other/riffusion.yaml
+++ b/tools/other/riffusion.yaml
@@ -1,0 +1,14 @@
+name: Riffusion
+description: |
+  Riffusion is an open-source library for real-time music and audio generation using latent diffusion models. Based on the Stable Diffusion architecture fine-tuned on spectrograms, it enables text-to-music generation, audio-to-audio style transfer, and real-time audio synthesis. The hobbyist fork provides a web UI and Python API for experimenting with AI music generation.
+problem_solved: |
+  Generating music and audio with AI traditionally requires large models, complex pipelines, and significant computational resources. Riffusion solves this by adapting Stable Diffusion's spectrogram-based approach to produce coherent audio from text descriptions, making AI music generation accessible through a simple web interface and lightweight Python API.
+use_cases:
+  - "Generate music and audio clips from text descriptions in real time"
+  - "Apply audio-to-audio style transfer and audio inpainting"
+  - "Create sound effects and musical loops for content creation"
+category: Other
+github_url: https://github.com/riffusion/riffusion-hobby
+website_url: https://riffusion.com/
+is_open_source: true
+install_command: pip install riffusion


### PR DESCRIPTION
This PR adds 2 tools to the catalog:

- **Garnet** — Remote cache-store from Microsoft Research, Redis-compatible, .NET-based (microsoft/garnet, 11.9k★)
- **Riffusion** — Real-time music and audio generation using latent diffusion models (riffusion/riffusion-hobby, 3.9k★)

All files validated with `npx tsx scripts/validate-tool.ts`.
