### PR TITLE
Add Typer, Alembic, Psutil, Caddy, Jest to catalog

### DIFF
--- a/tools/dev-tools/alembic.yaml
+++ b/tools/dev-tools/alembic.yaml
@@ -1,0 +1,22 @@
+name: Alembic
+description: "A lightweight database migration tool for SQLAlchemy that lets teams version their database schema, auto-generate migration scripts from model changes, and apply or roll back schema changes across environments."
+tagline: "SQLAlchemy database migrations"
+github_url: https://github.com/sqlalchemy/alembic
+website_url: https://alembic.sqlalchemy.org
+docs_url: https://alembic.sqlalchemy.org
+install_command: "pip install alembic"
+category: Dev Tools
+tags:
+  - python
+  - sqlalchemy
+  - database
+  - migrations
+  - schema
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "AI applications that persist data face schema drift — models change as features evolve, but databases silently fall out of sync, causing runtime errors and data corruption. Alembic versions every schema change as a migration script, auto-generates migrations by diffing SQLAlchemy models against the live database, and provides upgrade and downgrade paths so teams can evolve schemas safely across dev, staging, and production."
+use_cases:
+  - "Auto-generate migration scripts after adding a new column or table to SQLAlchemy models and review the diff before applying"
+  - "Apply schema changes across development, staging, and production environments with a single upgrade command"
+  - "Roll back a failed migration with downgrade scripts to keep vector stores and metadata tables consistent"

--- a/tools/dev-tools/caddy.yaml
+++ b/tools/dev-tools/caddy.yaml
@@ -1,0 +1,21 @@
+name: Caddy
+description: "A production-ready open-source web server with automatic HTTPS, HTTP/2/3, and a simple declarative configuration, widely used to serve AI applications, model APIs, and static sites with zero manual certificate management."
+tagline: "Web server with automatic HTTPS"
+github_url: https://github.com/caddyserver/caddy
+website_url: https://caddyserver.com
+docs_url: https://caddyserver.com/docs
+category: Dev Tools
+tags:
+  - web-server
+  - https
+  - reverse-proxy
+  - go
+  - infrastructure
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Serving AI web apps and model APIs over HTTPS normally requires configuring nginx or Apache plus manually renewing TLS certificates, which is error-prone and time-consuming. Caddy automatically obtains and renews Let's Encrypt certificates for every configured domain, ships with sane defaults, and uses a readable Caddyfile — so a single binary replaces the web server, reverse proxy, and TLS management stack for deploying inference endpoints and frontend applications."
+use_cases:
+  - "Serve a fine-tuned model's REST API behind automatic HTTPS with a three-line Caddyfile and zero certificate management"
+  - "Reverse-proxy multiple agent services or Jupyter instances to subdomains with automatic TLS and load balancing"
+  - "Host an AI tool's marketing site or docs with static file serving, compression, and HTTP/3 built in"

--- a/tools/dev-tools/jest.yaml
+++ b/tools/dev-tools/jest.yaml
@@ -1,0 +1,22 @@
+name: Jest
+description: "A delightful JavaScript testing framework with zero-config setup, built-in mocking, snapshot testing, code coverage, and parallel test execution, used to test AI web apps, agent UIs, and LLM-powered frontends."
+tagline: "JavaScript testing framework"
+github_url: https://github.com/jestjs/jest
+website_url: https://jestjs.io
+docs_url: https://jestjs.io/docs
+install_command: "npm install jest"
+category: Dev Tools
+tags:
+  - javascript
+  - testing
+  - mocking
+  - snapshots
+  - nodejs
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "AI-powered web applications are hard to test because they mix asynchronous data fetching, streaming responses, and complex UI state — and hand-rolled test setups are slow and flaky. Jest provides zero-config test running with built-in mocking, fake timers, snapshot testing, and parallel execution, so frontend and Node.js teams can test agent UIs, API integrations, and LLM response rendering deterministically and quickly."
+use_cases:
+  - "Test an agent chat interface with mocked LLM responses and fake timers for deterministic streaming behavior"
+  - "Snapshot-test tool result cards and JSON-LD output so UI regressions surface on every pull request"
+  - "Run unit and integration tests for the MCP server or API routes with built-in coverage reports in CI"

--- a/tools/dev-tools/typer.yaml
+++ b/tools/dev-tools/typer.yaml
@@ -1,0 +1,22 @@
+name: Typer
+description: "A Python library for building command-line interfaces (CLIs) from type-annotated functions, with automatic help text, argument parsing, and shell completion built on Click and type hints."
+tagline: "Python CLI library built on type hints"
+github_url: https://github.com/tiangolo/typer
+website_url: https://typer.tiangolo.com
+docs_url: https://typer.tiangolo.com
+install_command: "pip install typer"
+category: Dev Tools
+tags:
+  - python
+  - cli
+  - command-line
+  - type-hints
+  - developer-tools
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Building command-line tools for AI workflows with argparse is verbose and error-prone — no auto-generated help, weak validation, and poor tab-completion support. Typer lets you write a Python function, annotate parameters with types and defaults, and get a production-ready CLI with automatic help text, validation, and shell completion for free. AI engineers use it to build model training scripts, data pipeline CLIs, and agent control interfaces without writing argument-parsing code."
+use_cases:
+  - "Build a CLI for fine-tuning scripts where arguments (model, dataset, epochs, lr) are typed function parameters with auto-generated help"
+  - "Ship data pipeline commands with subcommands for extract, transform, and load stages, each with validated typed options"
+  - "Create internal developer tools for agents — invocation, model selection, and output format flags with autocompletion"

--- a/tools/monitoring/psutil.yaml
+++ b/tools/monitoring/psutil.yaml
@@ -1,0 +1,23 @@
+name: Psutil
+description: "A cross-platform Python library for retrieving system information — CPU, memory, disks, network, sensors, and running processes — and for process management, used by monitoring tools and ML infrastructure to track resource utilization."
+tagline: "Cross-platform system and process monitoring for Python"
+github_url: https://github.com/giampaolo/psutil
+website_url: https://psutil.readthedocs.io
+docs_url: https://psutil.readthedocs.io
+install_command: "pip install psutil"
+category: Monitoring
+tags:
+  - python
+  - system-monitoring
+  - cpu
+  - memory
+  - processes
+  - observability
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "ML engineers need to know whether their training jobs are CPU-bound, leaking memory, or exhausting disk — but reading /proc, ps, and system stats portably across operating systems is fragile and platform-specific. Psutil provides a single cross-platform API for CPU, memory, disk, network, and process metrics, so monitoring agents, training supervisors, and observability dashboards can track resource usage consistently on Linux, macOS, and Windows."
+use_cases:
+  - "Track CPU and memory usage of a training process to detect leaks and right-size instance types"
+  - "Build a lightweight resource dashboard that samples disk, network, and per-process stats across worker nodes"
+  - "Watch for process crashes or zombies in a multi-agent deployment and restart unhealthy workers programmatically"


### PR DESCRIPTION
## Summary

Adds 5 tools to the catalog:

| Tool | Category | Stars | License |
|---|---|---|---|
| Typer | Dev Tools | 19.8k | MIT |
| Alembic | Dev Tools | 4.3k | MIT |
| Psutil | Monitoring | 11.3k | BSD-3-Clause |
| Caddy | Dev Tools | 74.5k | Apache-2.0 |
| Jest | Dev Tools | 45.5k | MIT |

All entries validated locally with `npx tsx scripts/validate-tool.ts`. Caddy is a Go binary server — no `install_command` (no pip/npm package for the server itself).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Alembic, Caddy, Jest, Typer, and Psutil.
  * Included descriptions, installation details, documentation links, licensing, categories, and supported use cases.
  * Expanded developer-tool coverage for database migrations, web serving, testing, CLI development, and system monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->