### PR TITLE
Add Mocha, Vitest, isort, flake8, pylint to catalog

### DIFF
--- a/tools/dev-tools/flake8.yaml
+++ b/tools/dev-tools/flake8.yaml
@@ -1,0 +1,22 @@
+name: flake8
+description: "A Python linting tool that wraps Pyflakes, pycodestyle, and McCabe to check code against style guides, flag logic errors, unused imports, and complexity issues, with a plugin system for custom checks."
+tagline: "Python code linter"
+github_url: https://github.com/PyCQA/flake8
+website_url: https://flake8.pycqa.org
+docs_url: https://flake8.pycqa.org
+install_command: "pip install flake8"
+category: Dev Tools
+tags:
+  - python
+  - linting
+  - code-quality
+  - pep8
+  - static-analysis
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "AI research code often ships with unused imports, undefined names, and style inconsistencies that are caught only at runtime or in review. flake8 combines Pyflakes logic checks (unused imports, undefined names), pycodestyle formatting rules, and McCabe complexity limits into one fast, extensible linter, so teams can catch bugs and enforce style in CI before code reaches training jobs or production."
+use_cases:
+  - "Lint Python modules and training scripts for unused imports and undefined names before merging"
+  - "Enforce PEP 8 style and cyclomatic complexity limits across a shared ML library with a flake8 config"
+  - "Add custom plugins for team-specific rules (for example banned imports or required docstrings) and run in pre-commit"

--- a/tools/dev-tools/isort.yaml
+++ b/tools/dev-tools/isort.yaml
@@ -1,0 +1,22 @@
+name: isort
+description: "A Python utility and library for sorting imports alphabetically and automatically separating them into sections, keeping import blocks clean, consistent, and free of merge conflicts."
+tagline: "Python import sorter"
+github_url: https://github.com/PyCQA/isort
+website_url: https://pycqa.github.io/isort
+docs_url: https://pycqa.github.io/isort
+install_command: "pip install isort"
+category: Dev Tools
+tags:
+  - python
+  - imports
+  - code-quality
+  - formatting
+  - linter
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Python ML codebases accumulate unsorted, duplicated imports as features are added — making diffs noisy and imports easy to merge incorrectly. isort automatically sorts imports alphabetically, groups them by section (stdlib, third-party, local), and fixes missing imports in a single pass, so teams can enforce clean import hygiene in CI just like formatting."
+use_cases:
+  - "Auto-sort and group imports in training scripts and library code with a single command or pre-commit hook"
+  - "Enforce import style in CI so pull requests stay focused on logic changes instead of import churn"
+  - "Check import ordering across a monorepo of ML services to prevent merge conflicts on shared dependency files"

--- a/tools/dev-tools/mocha.yaml
+++ b/tools/dev-tools/mocha.yaml
@@ -1,0 +1,22 @@
+name: Mocha
+description: "A feature-rich JavaScript test framework that runs on Node.js and in the browser, with support for BDD/TDD interfaces, async testing, hooks, and a huge ecosystem of reporters and integrations."
+tagline: "JavaScript test framework"
+github_url: https://github.com/mochajs/mocha
+website_url: https://mochajs.org
+docs_url: https://mochajs.org
+install_command: "npm install mocha"
+category: Dev Tools
+tags:
+  - javascript
+  - testing
+  - nodejs
+  - bdd
+  - tdd
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Node.js services powering AI backends need reliable test frameworks that handle asynchronous code, promises, and event streams without flaky timeouts. Mocha provides a simple, flexible test runner with BDD and TDD styles, deep async support (async/await, promises, callbacks), lifecycle hooks, and broad reporter and plugin integration — letting teams structure expressive test suites for APIs, agents, and data pipelines."
+use_cases:
+  - "Write BDD-style describe/it suites for model-serving APIs and test async LLM client calls with promises and retries"
+  - "Use beforeEach/afterEach hooks to set up and tear down database or vector-store fixtures for integration tests"
+  - "Run the same suite in Node and in the browser to verify SDK behavior across environments with Mocha's built-in browser support"

--- a/tools/dev-tools/pylint.yaml
+++ b/tools/dev-tools/pylint.yaml
@@ -1,0 +1,22 @@
+name: pylint
+description: "A powerful Python static code analyzer that checks for errors, enforces coding standards, detects code smells and refactoring opportunities, and can even catch subtle bugs through inference."
+tagline: "Python static code analyzer"
+github_url: https://github.com/pylint-dev/pylint
+website_url: https://pylint.readthedocs.io
+docs_url: https://pylint.readthedocs.io
+install_command: "pip install pylint"
+category: Dev Tools
+tags:
+  - python
+  - static-analysis
+  - linting
+  - code-quality
+  - refactoring
+pricing: free
+is_open_source: true
+license: GPL-2.0
+problem_solved: "Python codebases grow technical debt — dead code, overly complex functions, missing docstrings, and subtle bugs that simple linters miss. pylint performs deep static analysis with type inference, flagging errors, style violations, design issues (high complexity, too many branches), and refactoring opportunities with configurable severity, so teams can enforce quality gates on ML libraries and services."
+use_cases:
+  - "Run pylint as a CI quality gate that fails builds on error-level issues in shared ML code"
+  - "Detect code smells like duplicated branches, overly long functions, and unused arguments across a data pipeline"
+  - "Score refactoring candidates by pylint's design and refactor messages to prioritize technical-debt paydown"

--- a/tools/dev-tools/vitest.yaml
+++ b/tools/dev-tools/vitest.yaml
@@ -1,0 +1,22 @@
+name: Vitest
+description: "A blazing-fast Vite-native testing framework for JavaScript and TypeScript with out-of-the-box ESM, TypeScript, and JSX support, plus watch mode, snapshot testing, mocking, and coverage built in."
+tagline: "Vite-native JavaScript testing framework"
+github_url: https://github.com/vitest-dev/vitest
+website_url: https://vitest.dev
+docs_url: https://vitest.dev
+install_command: "npm install vitest"
+category: Dev Tools
+tags:
+  - javascript
+  - typescript
+  - testing
+  - vite
+  - unit-testing
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Modern TypeScript frontends and AI web apps need test setups that understand ESM, TSX, and Vite configs without slow build steps or complex Jest transforms. Vitest runs on the Vite dev server with near-instant startup, native ESM and TypeScript support, watch-mode re-runs, and built-in mocking, snapshots, and coverage — making unit tests for agent UIs and LLM components fast enough to run continuously during development."
+use_cases:
+  - "Unit-test React components and agent chat UIs with instant watch-mode re-runs as code changes"
+  - "Mock fetch and WebSocket layers to test streaming LLM responses deterministically in isolation"
+  - "Generate coverage reports for SDK and hook libraries in CI with Vitest's built-in coverage provider"


### PR DESCRIPTION
## Summary

Adds 5 tools to the catalog (all Dev Tools):

| Tool | Stars | License | Install |
|---|---|---|---|
| Mocha | 22.9k | MIT | npm install mocha |
| Vitest | 16.9k | MIT | npm install vitest |
| isort | 6.9k | MIT | pip install isort |
| flake8 | 3.8k | MIT | pip install flake8 |
| pylint | 5.7k | GPL-2.0 | pip install pylint |

All validated locally with `npx tsx scripts/validate-tool.ts`.
