### PR TITLE
Add Linkerd, pyinstrument, bandit to catalog

### DIFF
--- a/tools/dev-tools/bandit.yaml
+++ b/tools/dev-tools/bandit.yaml
@@ -1,0 +1,22 @@
+name: bandit
+description: "A Python security linter that analyzes code for common vulnerabilities and dangerous constructs using the AST, with a plugin system for custom checks."
+tagline: "Python security linter"
+github_url: https://github.com/PyCQA/bandit
+website_url: https://bandit.readthedocs.io
+docs_url: https://bandit.readthedocs.io
+install_command: "pip install bandit"
+category: Dev Tools
+tags:
+  - python
+  - security
+  - linting
+  - static-analysis
+  - vulnerability
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "ML pipelines handle sensitive data and credentials, but security issues — hardcoded secrets, unsafe deserialization, SQL injection via generated queries — are rarely caught in code review. bandit statically analyzes Python code against a database of dangerous patterns (assert usage, pickle, eval, subprocess shell usage, weak crypto), reporting severity and confidence, so teams can catch vulnerabilities in data pipelines and model-serving code before deployment."
+use_cases:
+  - "Scan training and inference code in CI for hardcoded secrets, unsafe deserialization, and shell injection patterns"
+  - "Audit agent tool-calling code for eval, pickle, or subprocess usage that could enable prompt-injection escalation"
+  - "Run bandit with custom plugins to enforce security rules specific to an ML platform's data access layer"

--- a/tools/dev-tools/linkerd.yaml
+++ b/tools/dev-tools/linkerd.yaml
@@ -1,0 +1,22 @@
+name: Linkerd
+description: "An ultralight, security-first service mesh for Kubernetes that adds observability, reliability, and mTLS encryption to cloud-native workloads with a simple CLI and minimal performance overhead."
+tagline: "Lightweight Kubernetes service mesh"
+github_url: https://github.com/linkerd/linkerd2
+website_url: https://linkerd.io
+docs_url: https://linkerd.io/2.15/overview/
+install_command: curl -sL https://run.linkerd.io/install | sh
+category: Dev Tools
+tags:
+  - kubernetes
+  - service-mesh
+  - mtls
+  - observability
+  - infrastructure
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Running AI services on Kubernetes introduces traffic management, encryption, and observability challenges — services need mTLS between pods, retries and timeouts for flaky model calls, and golden metrics per workload. Linkerd adds a transparent service mesh with automatic mTLS, load balancing, retries, and per-service metrics (success rate, latency, throughput) with a tiny footprint and no application changes, making inference pipelines observable and resilient."
+use_cases:
+  - "Add automatic mTLS encryption between model-serving pods and feature-store services without changing application code"
+  - "Get golden metrics (success rate, latency, throughput) per deployment to monitor inference pipeline health"
+  - "Configure retries and timeouts for flaky LLM API calls at the mesh layer for resilient multi-service agents"

--- a/tools/dev-tools/pyinstrument.yaml
+++ b/tools/dev-tools/pyinstrument.yaml
@@ -1,0 +1,22 @@
+name: pyinstrument
+description: "A Python profiler that samples the call stack at high frequency to produce rich, low-overhead performance reports with a beautiful interactive HTML output."
+tagline: "Python call-stack profiler"
+github_url: https://github.com/joerick/pyinstrument
+website_url: https://pyinstrument.readthedocs.io
+docs_url: https://pyinstrument.readthedocs.io
+install_command: "pip install pyinstrument"
+category: Dev Tools
+tags:
+  - python
+  - profiling
+  - performance
+  - debugging
+  - optimization
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Profiling Python training loops and inference code with cProfile produces noisy, hard-to-read output that obscures which function actually dominates runtime. pyinstrument samples the call stack at high frequency with minimal overhead, attributing time accurately and rendering an interactive flame-tree HTML report — so engineers can immediately see the real bottleneck in data loading, preprocessing, or model calls and fix it fast."
+use_cases:
+  - "Profile a training loop to find whether data loading, augmentation, or forward passes dominate wall-clock time"
+  - "Generate an interactive HTML report to share profiling results for an inference service's hot path"
+  - "Compare profiling runs before and after optimization to verify latency improvements on request handlers"


### PR DESCRIPTION
## Summary

Adds 3 tools to the catalog (all Dev Tools):

| Tool | Stars | License | Install |
|---|---|---|---|
| Linkerd | 11.5k | Apache-2.0 | curl -sL run.linkerd.io/install |
| pyinstrument | 8.0k | BSD-3-Clause | pip install pyinstrument |
| bandit | 8.2k | Apache-2.0 | pip install bandit |

All validated locally with `npx tsx scripts/validate-tool.ts`.
