### PR TITLE
Add Prettier, ESLint, Vite, TypeScript, pnpm to catalog

### DIFF
--- a/tools/dev-tools/eslint.yaml
+++ b/tools/dev-tools/eslint.yaml
@@ -1,0 +1,22 @@
+name: ESLint
+description: "A pluggable JavaScript and TypeScript linter that statically analyzes code to find problems and enforce style rules, with an extensive rule set and ecosystem of shareable configs."
+tagline: "JavaScript and TypeScript linter"
+github_url: https://github.com/eslint/eslint
+website_url: https://eslint.org
+docs_url: https://eslint.org/docs
+install_command: "npm install eslint"
+category: Dev Tools
+tags:
+  - javascript
+  - typescript
+  - linting
+  - code-quality
+  - static-analysis
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "JavaScript codebases — including AI agent frontends and Node backends — accumulate bugs, unused variables, and inconsistent patterns that are easy to miss in review. ESLint statically analyzes code against hundreds of configurable rules, supports TypeScript via plugins, auto-fixes many issues, and integrates with editors and CI, so teams can catch real bugs and enforce conventions without a compiler."
+use_cases:
+  - "Lint React components and agent chat UIs for common bugs, unused imports, and accessibility issues in CI"
+  - "Enforce team conventions with shareable configs (airbnb, typescript-eslint) across frontend and Node services"
+  - "Auto-fix style violations and dangerous patterns on save with ESLint's editor and CLI fix modes"

--- a/tools/dev-tools/pnpm.yaml
+++ b/tools/dev-tools/pnpm.yaml
@@ -1,0 +1,22 @@
+name: pnpm
+description: "A fast, disk-space-efficient package manager for JavaScript that installs dependencies in a content-addressable store, enabling monorepo workspaces and near-instant installs."
+tagline: "Fast, disk-efficient JavaScript package manager"
+github_url: https://github.com/pnpm/pnpm
+website_url: https://pnpm.io
+docs_url: https://pnpm.io/motivation
+install_command: "npm install -g pnpm"
+category: Dev Tools
+tags:
+  - javascript
+  - package-manager
+  - monorepo
+  - nodejs
+  - developer-tools
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "npm installs duplicate copies of every dependency into each project, wasting disk space and slowing CI pipelines for teams maintaining multiple AI services and SDKs. pnpm stores packages in a content-addressable store and hard-links them into projects, so installs are faster, disk usage drops dramatically, and monorepo workspaces manage shared dependencies cleanly — while strict node_modules rules prevent phantom dependencies."
+use_cases:
+  - "Install dependencies across a monorepo of AI services in seconds with pnpm workspaces and a shared store"
+  - "Cut CI install times and disk usage for frontend and backend packages by up to 70 percent versus npm"
+  - "Enforce strict dependency declarations with pnpm's isolated node_modules layout for cleaner packages"

--- a/tools/dev-tools/prettier.yaml
+++ b/tools/dev-tools/prettier.yaml
@@ -1,0 +1,22 @@
+name: Prettier
+description: "An opinionated code formatter that supports JavaScript, TypeScript, HTML, CSS, Markdown, JSON, and YAML, enforcing consistent style across a codebase with a single unified format."
+tagline: "Opinionated code formatter"
+github_url: https://github.com/prettier/prettier
+website_url: https://prettier.io
+docs_url: https://prettier.io/docs
+install_command: "npm install prettier"
+category: Dev Tools
+tags:
+  - javascript
+  - typescript
+  - formatting
+  - code-quality
+  - developer-tools
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "AI web applications are often built by teams with different editors and formatting preferences, producing inconsistent code that generates noisy diffs and merge conflicts. Prettier parses code into an AST and reprints it with a single, opinionated style across JavaScript, TypeScript, HTML, CSS, Markdown, and YAML — ending style debates and letting teams focus pull requests on logic changes."
+use_cases:
+  - "Format JavaScript and TypeScript code across an AI frontend repo with a single command or on save in every editor"
+  - "Enforce consistent formatting in CI so every pull request is style-clean before review"
+  - "Normalize YAML tool configs and Markdown docs with the same formatter for a uniform repository"

--- a/tools/dev-tools/typescript.yaml
+++ b/tools/dev-tools/typescript.yaml
@@ -1,0 +1,22 @@
+name: TypeScript
+description: "A typed superset of JavaScript that adds static types, interfaces, and modern tooling to the language, compiling to plain JavaScript for browsers, Node.js, and edge runtimes."
+tagline: "Typed superset of JavaScript"
+github_url: https://github.com/microsoft/TypeScript
+website_url: https://www.typescriptlang.org
+docs_url: https://www.typescriptlang.org/docs
+install_command: "npm install typescript"
+category: Dev Tools
+tags:
+  - javascript
+  - typescript
+  - compiler
+  - static-typing
+  - developer-tools
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Large AI web applications written in plain JavaScript suffer from runtime type errors — undefined properties, wrong argument shapes, and silent API mismatches that surface in production. TypeScript adds static types, interfaces, and generics with editor support and compile-time checking, letting teams model LLM responses, tool schemas, and API contracts explicitly and catch entire classes of bugs before runtime."
+use_cases:
+  - "Type LLM response schemas and tool-calling interfaces so malformed model output is caught at compile time"
+  - "Model MCP server tool definitions and API contracts with interfaces shared between frontend and backend"
+  - "Refactor large codebases safely with type-guided rename and go-to-definition across a monorepo"

--- a/tools/dev-tools/vite.yaml
+++ b/tools/dev-tools/vite.yaml
@@ -1,0 +1,22 @@
+name: Vite
+description: "A next-generation frontend build tool that serves code via native ES modules for instant startup in development and produces optimized production bundles with pre-configured defaults."
+tagline: "Next-generation frontend build tool"
+github_url: https://github.com/vitejs/vite
+website_url: https://vite.dev
+docs_url: https://vite.dev/guide
+install_command: "npm install vite"
+category: Dev Tools
+tags:
+  - javascript
+  - typescript
+  - build-tool
+  - bundler
+  - frontend
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Traditional bundlers slow AI web app development down — every edit triggers a full rebuild that can take seconds or minutes. Vite serves source files as native ES modules with on-demand compilation, so browser refreshes are near-instant, and it pre-bundles dependencies with esbuild for fast cold starts. Production builds use Rollup for optimized, tree-shaken bundles, giving teams both speed and quality without complex config."
+use_cases:
+  - "Develop an agent chat frontend with instant hot module replacement, eliminating rebuild waits on every edit"
+  - "Build optimized production bundles for an AI web app with code splitting and asset handling out of the box"
+  - "Scaffold a React, Vue, or Svelte project with TypeScript in seconds using Vite's create templates"


### PR DESCRIPTION
## Summary

Adds 5 frontend/JS tooling entries to the catalog (all Dev Tools):

| Tool | Stars | License | Install |
|---|---|---|---|
| Prettier | 52.2k | MIT | npm install prettier |
| ESLint | 27.4k | MIT | npm install eslint |
| Vite | 82.1k | MIT | npm install vite |
| TypeScript | 110k | Apache-2.0 | npm install typescript |
| pnpm | 35.9k | MIT | npm install -g pnpm |

All validated locally with `npx tsx scripts/validate-tool.ts`.
