### PR TITLE
Add Playwright, Storybook, esbuild, Rollup, Turborepo to catalog

### DIFF
--- a/tools/dev-tools/esbuild.yaml
+++ b/tools/dev-tools/esbuild.yaml
@@ -1,0 +1,24 @@
+name: esbuild
+description: Extremely fast JavaScript and TypeScript bundler written in Go, offering 10-100x faster builds than traditional bundlers. Handles bundling, minification, transpilation, and dev-server serving through a simple API used by Vite, Snowpack, and many build pipelines.
+tagline: Ultra-fast JavaScript and TypeScript bundler written in Go
+
+github_url: https://github.com/evanw/esbuild
+website_url: https://esbuild.github.io
+docs_url: https://esbuild.github.io/api/
+
+install_command: npm install esbuild
+
+category: Dev Tools
+tags: [bundler, javascript, typescript, build-tools, minification, go, nodejs, devtools, performance, transpiler]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Traditional JavaScript bundlers are slow, making large codebases painful to build and iterate on. esbuild solves this by using Go's parallel execution and a highly optimized architecture to deliver 10-100x faster bundling, transpilation, and minification. Its speed makes it the default bundler powering Vite, and its zero-config CLI and JS API let teams build and serve modern web applications with minimal setup.
+use_cases:
+  - Bundle JavaScript and TypeScript applications 10-100x faster than Webpack or Rollup
+  - Transpile modern syntax and JSX for older browsers during build and development
+  - Minify production assets with best-in-class output size and speed
+  - Serve as the build engine inside larger tools like Vite and Snowpack
+  - Run a zero-config local dev server with hot reload for prototyping

--- a/tools/dev-tools/playwright.yaml
+++ b/tools/dev-tools/playwright.yaml
@@ -1,0 +1,24 @@
+name: Playwright
+description: Microsoft's browser automation framework for reliable end-to-end testing across Chromium, Firefox, and WebKit. Provides auto-waiting, trace viewer, codegen, and a unified test runner that makes cross-browser tests fast and dependable for modern web applications.
+tagline: Cross-browser automation and end-to-end testing framework
+
+github_url: https://github.com/microsoft/playwright
+website_url: https://playwright.dev
+docs_url: https://playwright.dev/docs/intro
+
+install_command: npm install playwright
+
+category: Dev Tools
+tags: [testing, browser-automation, e2e, web, chromium, firefox, webkit, nodejs, devtools, automation]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Traditional browser automation tools are flaky — they race against page loads and depend on fragile selectors and sleep timers. Playwright solves this with auto-waiting that retries actions until elements are ready, a single API across Chromium, Firefox, and WebKit, and rich debugging tools like trace viewers and inspector codegen. Teams get deterministic end-to-end tests plus the same engine used for web scraping, visual regression, and AI agent browser control.
+use_cases:
+  - Write end-to-end tests that run reliably across Chromium, Firefox, and WebKit with auto-waiting and retries
+  - Record browser interactions with codegen and replay them as maintainable test or scraping scripts
+  - Debug flaky tests with trace viewer, video recording, and per-action network and DOM snapshots
+  - Scrape data and automate workflows against modern single-page applications using a high-level API
+  - Drive headless browsers for visual regression testing and performance measurement in CI pipelines

--- a/tools/dev-tools/rollup.yaml
+++ b/tools/dev-tools/rollup.yaml
@@ -1,0 +1,24 @@
+name: Rollup
+description: JavaScript module bundler that compiles small code fragments into larger, optimized libraries using native ES modules. Its tree-shaking and code-splitting capabilities make it the standard choice for publishing JavaScript libraries and the foundation of Vite's production builds.
+tagline: ES module bundler with powerful tree-shaking for libraries
+
+github_url: https://github.com/rollup/rollup
+website_url: https://rollupjs.org
+docs_url: https://rollupjs.org/guide/en/
+
+install_command: npm install rollup
+
+category: Dev Tools
+tags: [bundler, javascript, esmodules, tree-shaking, libraries, npm, nodejs, devtools, build-tools, packaging]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Publishing modern JavaScript libraries requires bundling many source files into a few optimized outputs, but naive bundling bloats packages and breaks tree-shaking. Rollup solves this by consuming native ES modules and eliminating unused exports, producing smaller, faster libraries that consumers can further optimize. Its rich plugin ecosystem and support for multiple output formats make it the default for library authors and the production bundler inside Vite.
+use_cases:
+  - Publish JavaScript libraries in multiple formats (ESM, CommonJS, IIFE) from one source tree
+  - Eliminate dead code automatically through static analysis and tree-shaking
+  - Split code into lazy-loaded chunks for faster application startup
+  - Generate type-safe, optimized builds for npm packages with the plugin ecosystem
+  - Power production builds for Vite-based frontend frameworks

--- a/tools/dev-tools/storybook.yaml
+++ b/tools/dev-tools/storybook.yaml
@@ -1,0 +1,24 @@
+name: Storybook
+description: Frontend workshop for building UI components and pages in isolation. Provides a sandboxed development environment with hot reload, visual testing, accessibility checks, and documentation generation across React, Vue, Angular, Svelte, and Web Components.
+tagline: Frontend component workshop and UI development environment
+
+github_url: https://github.com/storybookjs/storybook
+website_url: https://storybook.js.org
+docs_url: https://storybook.js.org/docs
+
+install_command: npm install storybook
+
+category: Dev Tools
+tags: [ui, components, frontend, react, vue, angular, svelte, testing, design-system, devtools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  UI development inside full applications is slow: every change requires navigation through app state, and components are hard to test, review, and document in isolation. Storybook solves this by rendering each component in its own sandbox with mock data and all its states, so developers build faster with hot reload, testers run visual and interaction tests, and teams generate living documentation that stays in sync with the code.
+use_cases:
+  - Develop UI components in isolation with instant hot reload and mock data for every state
+  - Run visual regression and interaction tests on components before they ship to production
+  - Generate living style guides and design-system documentation that sync with the source code
+  - Review UI work in pull requests with screenshot comparisons and accessibility reports
+  - Build component libraries across React, Vue, Angular, Svelte, and Web Components with one workflow

--- a/tools/dev-tools/turborepo.yaml
+++ b/tools/dev-tools/turborepo.yaml
@@ -1,0 +1,24 @@
+name: Turborepo
+description: High-performance build system for JavaScript and TypeScript monorepos from Vercel. Uses content-based caching, parallel task execution, and remote caching to make builds, tests, and deployments dramatically faster as repositories grow.
+tagline: High-performance monorepo build system with caching
+
+github_url: https://github.com/vercel/turborepo
+website_url: https://turborepo.com
+docs_url: https://turborepo.com/docs
+
+install_command: npm install turbo
+
+category: Dev Tools
+tags: [monorepo, build-system, caching, typescript, javascript, vercel, devtools, ci, task-runner, performance]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Monorepos grow slow: every build, lint, and test run re-executes unchanged work, and coordinating tasks across packages is manual and error-prone. Turborepo solves this with content-aware caching that skips tasks whose inputs haven't changed, parallel execution across packages, and remote caches shared across machines and CI. Teams get the coordination of a single repo without the slowdowns that usually come with scale.
+use_cases:
+  - Cache build and test outputs so unchanged packages skip re-execution entirely
+  - Run tasks across many packages in parallel with dependency-aware scheduling
+  - Share remote caches across local machines and CI to speed up every developer's workflow
+  - Incrementally adopt monorepo conventions in an existing repository with minimal config
+  - Prune monorepo applications for Docker deployments with first-class tooling support


### PR DESCRIPTION
Adds five foundational frontend/JavaScript build and testing tools to the catalog:

- **Playwright** — cross-browser automation and end-to-end testing framework (Chromium, Firefox, WebKit) with auto-waiting, trace viewer, and codegen
- **Storybook** — frontend workshop for building and testing UI components in isolation across React, Vue, Angular, Svelte
- **esbuild** — ultra-fast JavaScript/TypeScript bundler written in Go, powering Vite and modern build pipelines
- **Rollup** — ES module bundler with powerful tree-shaking, the standard for publishing JS libraries
- **Turborepo** — high-performance monorepo build system from Vercel with content-based caching and parallel task execution

All five are verified open source (Apache-2.0/MIT), active, with npm install commands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Esbuild, Playwright, Rollup, Storybook, and Turborepo.
  * Included installation instructions, documentation links, licensing and pricing details, categories, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->