### PR TITLE
Add Babel, curl, FFmpeg, Homebrew, jq to catalog

### DIFF
--- a/tools/dev-tools/babel.yaml
+++ b/tools/dev-tools/babel.yaml
@@ -1,0 +1,24 @@
+name: Babel
+description: JavaScript compiler that transforms modern ES2015+ syntax, JSX, and TypeScript into backward-compatible versions for older browsers and environments. Powers the build pipelines of React, Vue, and countless bundlers through a plugin and preset ecosystem.
+tagline: JavaScript compiler for modern syntax and JSX transformation
+
+github_url: https://github.com/babel/babel
+website_url: https://babeljs.io
+docs_url: https://babeljs.io/docs
+
+install_command: npm install --save-dev @babel/core @babel/cli
+
+category: Dev Tools
+tags: [javascript, compiler, transpiler, jsx, typescript, build-tools, nodejs, devtools, polyfills, react]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Modern JavaScript syntax and JSX run only in the newest browsers, forcing teams to choose between cutting-edge code and broad compatibility. Babel solves this by compiling ES2015+ features, JSX, and TypeScript into widely supported JavaScript, with configurable presets and plugins for every environment. Its transform pipeline powers React, Vue, and most major bundlers, letting developers write modern code that still runs anywhere.
+use_cases:
+  - Transpile modern JavaScript and JSX into syntax compatible with older browsers and runtimes
+  - Add TypeScript and Flow type-stripping to build pipelines without a full type checker
+  - Inject polyfills for missing standard library features based on target browser support
+  - Create custom code transforms with the plugin API for framework-specific syntax extensions
+  - Power the compilation layer inside bundlers like webpack, Rollup, and Vite

--- a/tools/dev-tools/curl.yaml
+++ b/tools/dev-tools/curl.yaml
@@ -1,0 +1,24 @@
+name: curl
+description: Command-line tool and library for transferring data with URLs, supporting HTTP, HTTPS, FTP, and dozens of other protocols. The de facto standard for API testing, scripting, and automation across every operating system.
+tagline: Command-line data transfer tool for URLs and APIs
+
+github_url: https://github.com/curl/curl
+website_url: https://curl.se
+docs_url: https://curl.se/docs/
+
+install_command: brew install curl
+
+category: Dev Tools
+tags: [http, api, command-line, networking, automation, testing, scripting, devtools, cli, rest]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Testing APIs and transferring data over HTTP from the command line is awkward without a dedicated tool — browsers hide request details and scripting languages require verbose setup. curl solves this with a single, ubiquitous command that supports any protocol, headers, authentication, and file uploads. It is the standard building block for CI pipelines, API debugging, model serving checks, and automation scripts on every platform.
+use_cases:
+  - Test REST and GraphQL APIs from the terminal with full control over headers, methods, and bodies
+  - Download models, datasets, and artifacts in scripts and CI pipelines with resume and retry options
+  - Upload files and data to endpoints using multipart forms and raw request bodies
+  - Automate health checks against inference servers and web services with exit-code based assertions
+  - Debug TLS, proxy, and DNS behavior with verbose output and protocol-level inspection flags

--- a/tools/dev-tools/homebrew.yaml
+++ b/tools/dev-tools/homebrew.yaml
@@ -1,0 +1,24 @@
+name: Homebrew
+description: Package manager for macOS and Linux that installs software Apple and other vendors don't provide. Maintains a massive catalog of formulae and casks, handling dependencies, upgrades, and cleanup with simple commands like brew install and brew services.
+tagline: The missing package manager for macOS and Linux
+
+github_url: https://github.com/Homebrew/brew
+website_url: https://brew.sh
+docs_url: https://docs.brew.sh
+
+install_command: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+category: Dev Tools
+tags: [package-manager, macos, linux, cli, devtools, dependencies, brew, open-source, sysadmin, automation]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+problem_solved: |
+  Installing and updating development tools on macOS is fragmented — installers, manual PATH edits, and missing dependencies waste hours. Homebrew solves this with a single package manager that installs, upgrades, and manages dependencies for thousands of open-source tools and desktop apps from the command line. Teams bootstrap entire development environments reproducibly, and CI setups stay consistent with a shared set of formulae.
+use_cases:
+  - Install and upgrade developer tools, compilers, and runtimes with a single brew install command
+  - Manage background services like databases and message queues with brew services
+  - Install GUI applications alongside CLI tools using casks with automatic updates
+  - Bootstrap reproducible development environments on fresh machines with a Brewfile
+  - Run Linuxbrew on Linux servers to keep toolchains consistent across platforms

--- a/tools/dev-tools/jq.yaml
+++ b/tools/dev-tools/jq.yaml
@@ -1,0 +1,24 @@
+name: jq
+description: Lightweight and flexible command-line JSON processor that slices, filters, maps, and transforms structured data with a concise query language. The standard tool for parsing API responses, config files, and logs in shell scripts and CI pipelines.
+tagline: Command-line JSON processor for parsing and transformation
+
+github_url: https://github.com/jqlang/jq
+website_url: https://jqlang.github.io/jq/
+docs_url: https://jqlang.github.io/jq/manual/
+
+install_command: brew install jq
+
+category: Dev Tools
+tags: [json, command-line, jq, parsing, data-processing, scripting, cli, devtools, automation, api]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Extracting values from JSON in shell scripts is painful — grep and sed break on nested structures, and writing full programs for simple queries is overkill. jq solves this with a compact query language for filtering, mapping, and transforming JSON, built for pipelines and one-liners. It turns API responses and config files into exactly the data a script needs, with no dependencies and instant startup.
+use_cases:
+  - Extract fields from API responses in shell pipelines with dot notation and filters
+  - Transform and reshape JSON documents with mapping, grouping, and array operations
+  - Slice and project large JSON logs and configuration files down to relevant subsets
+  - Validate and pretty-print JSON output for debugging and documentation
+  - Build data-processing steps in CI scripts that consume machine-readable tool output

--- a/tools/other/ffmpeg.yaml
+++ b/tools/other/ffmpeg.yaml
@@ -1,0 +1,24 @@
+name: FFmpeg
+description: Leading open-source multimedia framework for decoding, encoding, transcoding, muxing, filtering, and streaming audio and video. Powers media processing in YouTube, VLC, OBS, and countless AI pipelines that prepare training data and generate outputs.
+tagline: Cross-platform multimedia framework for audio and video
+
+github_url: https://github.com/FFmpeg/FFmpeg
+website_url: https://ffmpeg.org
+docs_url: https://ffmpeg.org/documentation.html
+
+install_command: brew install ffmpeg
+
+category: Other
+tags: [video, audio, multimedia, transcoding, streaming, codecs, command-line, media, ffmpeg, processing]
+pricing: free
+is_open_source: true
+license: LGPL-2.1
+
+problem_solved: |
+  Processing audio and video programmatically usually means juggling proprietary codecs, containers, and platform-specific tools. FFmpeg solves this with one framework that decodes, encodes, transcodes, filters, and streams virtually any media format, with a powerful filter graph for transformations. It is the backbone of media pipelines everywhere, from dataset preparation for video models to rendering and streaming AI-generated content.
+use_cases:
+  - Transcode and convert video and audio between formats for datasets, deliverables, and streaming
+  - Extract frames, audio tracks, and metadata from video for computer vision and speech pipelines
+  - Apply filters like scaling, cropping, denoising, and overlays in a single pass
+  - Generate previews, thumbnails, and clips for content pipelines and model evaluation
+  - Stream live media and encode high-quality output for broadcasting and real-time applications


### PR DESCRIPTION
Adds five foundational command-line and build tools to the catalog:

- **Babel** — JavaScript compiler transforming modern syntax, JSX, and TypeScript for broad browser compatibility
- **curl** — ubiquitous command-line data transfer tool for URLs and APIs
- **FFmpeg** — leading multimedia framework for encoding, transcoding, filtering, and streaming audio/video
- **Homebrew** — the missing package manager for macOS and Linux
- **jq** — lightweight command-line JSON processor for parsing and transforming structured data

All five are verified open source, actively maintained, with install commands.
