### PR TITLE
Add K6, Node.js, Visual Studio Code, Webpack to catalog

### DIFF
--- a/tools/dev-tools/nodejs.yaml
+++ b/tools/dev-tools/nodejs.yaml
@@ -1,0 +1,24 @@
+name: Node.js
+description: Open-source, cross-platform JavaScript runtime built on Chrome's V8 engine, designed for building fast and scalable server-side and network applications. The foundation of the modern JavaScript ecosystem, from web servers and CLIs to AI tooling and agent frameworks.
+tagline: JavaScript runtime built on Chrome's V8 engine
+
+github_url: https://github.com/nodejs/node
+website_url: https://nodejs.org
+docs_url: https://nodejs.org/docs/latest/api/
+
+install_command: brew install node
+
+category: Dev Tools
+tags: [javascript, runtime, nodejs, backend, server, npm, web, devtools, typescript, event-driven]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  JavaScript was confined to the browser until developers needed a unified language for servers, CLIs, and build tools. Node.js solves this with an event-driven, non-blocking runtime built on V8 that handles thousands of concurrent connections with minimal overhead. It powers the entire modern web toolchain — bundlers, package managers, dev servers, and an ecosystem of AI and agent frameworks — with one language across the stack.
+use_cases:
+  - Build high-throughput web APIs and real-time applications with an event-driven, non-blocking model
+  - Run frontend build tooling, bundlers, and dev servers from a single JavaScript toolchain
+  - Develop command-line tools and automation scripts that share code with web frontends
+  - Power serverless functions and edge runtimes for AI applications and API backends
+  - Serve as the runtime for agent frameworks, MCP servers, and LLM orchestration tooling

--- a/tools/dev-tools/visual-studio-code.yaml
+++ b/tools/dev-tools/visual-studio-code.yaml
@@ -1,0 +1,24 @@
+name: Visual Studio Code
+description: Free, open-source code editor from Microsoft with built-in Git, debugging, IntelliSense, and a massive extension marketplace. The most widely used editor for AI development, with first-class support for Python, JavaScript, notebooks, and AI coding assistants.
+tagline: Open-source code editor with rich extension ecosystem
+
+github_url: https://github.com/microsoft/vscode
+website_url: https://code.visualstudio.com
+docs_url: https://code.visualstudio.com/docs
+
+install_command: brew install --cask visual-studio-code
+
+category: Dev Tools
+tags: [editor, ide, code, extensions, debugging, typescript, python, devtools, lsp, notebooks]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Developers juggle editors, debuggers, terminals, and Git clients that don't integrate, wasting time on context switching. Visual Studio Code solves this with a single, fast editor that unifies editing, IntelliSense, debugging, source control, and terminal access, extended by tens of thousands of extensions. Its Language Server Protocol support and AI-assistant integrations make it the default workspace for ML and web development.
+use_cases:
+  - Write and debug Python, JavaScript, and TypeScript with rich IntelliSense and breakpoint debugging
+  - Run Jupyter notebooks and data science workflows inline with variable inspection and plotting
+  - Extend the editor with marketplace extensions for frameworks, linters, and AI coding assistants
+  - Manage Git operations, pull requests, and remote development from one integrated interface
+  - Pair with language servers and dev containers for consistent, reproducible coding environments

--- a/tools/dev-tools/webpack.yaml
+++ b/tools/dev-tools/webpack.yaml
@@ -1,0 +1,24 @@
+name: Webpack
+description: Static module bundler for modern JavaScript applications that bundles assets, scripts, images, and styles into optimized deployable files. Its plugin and loader ecosystem, code splitting, and dev-server made it the standard build tool for the React and broader frontend ecosystem.
+tagline: Static module bundler for modern JavaScript applications
+
+github_url: https://github.com/webpack/webpack
+website_url: https://webpack.js.org
+docs_url: https://webpack.js.org/concepts/
+
+install_command: npm install --save-dev webpack
+
+category: Dev Tools
+tags: [bundler, javascript, modules, assets, react, build-tools, webpack, devtools, code-splitting, dev-server]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Browser applications grew beyond what plain script tags could handle — hundreds of modules, assets, and dependencies with no coherent build story. Webpack solves this by treating every asset as a module and bundling them into optimized output, with loaders for almost any file type, code splitting for performance, and a rich plugin system. It became the backbone of React tooling and modern frontend builds.
+use_cases:
+  - Bundle JavaScript, styles, images, and fonts into optimized, cache-friendly production assets
+  - Split application code into lazy-loaded chunks to reduce initial page load time
+  - Transform modern syntax, JSX, and TypeScript with loaders and the Babel integration
+  - Serve a development experience with hot module replacement via the built-in dev server
+  - Extend builds with plugins for minification, tree-shaking, environment injection, and more

--- a/tools/monitoring/k6.yaml
+++ b/tools/monitoring/k6.yaml
@@ -1,0 +1,24 @@
+name: K6
+description: Open-source load testing tool from Grafana Labs for testing the performance and reliability of APIs, microservices, and websites. Scripts load tests in JavaScript, runs them locally or in the cloud, and produces rich performance metrics and thresholds.
+tagline: Developer-focused load testing tool for APIs and services
+
+github_url: https://github.com/grafana/k6
+website_url: https://k6.io
+docs_url: https://k6.io/docs/
+
+install_command: brew install k6
+
+category: Monitoring
+tags: [load-testing, performance, api, benchmarking, javascript, grafana, testing, devtools, reliability, observability]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Performance testing is often bolted on with heavyweight enterprise tools that are hard to script and integrate. K6 solves this with a developer-friendly approach: load tests are plain JavaScript, run from the CLI or CI with minimal setup, and emit precise metrics, thresholds, and failure reports. Teams catch latency and reliability regressions in AI services and APIs before users do.
+use_cases:
+  - Load test REST, GraphQL, and gRPC APIs with configurable virtual users and ramp-up scenarios
+  - Run performance checks in CI pipelines with pass/fail thresholds on latency and error rate
+  - Simulate realistic traffic patterns for inference endpoints and model-serving infrastructure
+  - Compare response-time distributions and throughput across service versions and configs
+  - Generate detailed performance reports with custom metrics, tags, and Grafana dashboards


### PR DESCRIPTION
Adds four foundational developer tools to the catalog:

- **K6** — open-source load testing tool from Grafana Labs for APIs, microservices, and websites
- **Node.js** — JavaScript runtime built on Chrome's V8 engine, foundation of the modern JS ecosystem
- **Visual Studio Code** — open-source code editor with a massive extension ecosystem and first-class AI support
- **Webpack** — static module bundler for modern JavaScript applications, standard for frontend builds

All four are verified open source, actively maintained, with install commands.
