### PR TITLE
Add Deno, fzf, GitHub CLI, lazygit, oh-my-zsh to catalog

### DIFF
--- a/tools/dev-tools/deno.yaml
+++ b/tools/dev-tools/deno.yaml
@@ -1,0 +1,24 @@
+name: Deno
+description: Secure JavaScript and TypeScript runtime from the creator of Node.js, with built-in TypeScript support, dependency URL imports, and modern web APIs. Offers first-class permissions, a standard library, and tools for formatting, linting, and bundling out of the box.
+tagline: Secure JavaScript and TypeScript runtime with built-in tooling
+
+github_url: https://github.com/denoland/deno
+website_url: https://deno.com
+docs_url: https://docs.deno.com
+
+install_command: curl -fsSL https://deno.land/install.sh | sh
+
+category: Dev Tools
+tags: [javascript, typescript, runtime, deno, security, web, nodejs, devtools, permissions, cli]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Node.js left security and modern tooling as afterthoughts — scripts run with full system access, and bundling, linting, and formatting require separate tools. Deno solves this with a secure-by-default runtime that requires explicit permissions, native TypeScript execution, and built-in formatter, linter, and bundler. Its URL-based imports and web-standard APIs make modern JavaScript development simpler and safer.
+use_cases:
+  - Run TypeScript and JavaScript directly without transpilation or dependency configuration
+  - Execute untrusted scripts safely with granular filesystem, network, and environment permissions
+  - Build web servers and APIs using standard Request, Response, and fetch APIs
+  - Bundle, lint, format, and test code with built-in tools instead of separate packages
+  - Deploy serverless functions and edge workloads using the same runtime across environments

--- a/tools/dev-tools/fzf.yaml
+++ b/tools/dev-tools/fzf.yaml
@@ -1,0 +1,24 @@
+name: fzf
+description: General-purpose command-line fuzzy finder that lets users interactively search files, history, processes, and any streaming input with a fast, responsive interface. Composable with any command, it has become an essential productivity tool for terminal workflows.
+tagline: Command-line fuzzy finder for interactive search
+
+github_url: https://github.com/junegunn/fzf
+website_url: https://github.com/junegunn/fzf#readme
+docs_url: https://github.com/junegunn/fzf#readme
+
+install_command: brew install fzf
+
+category: Dev Tools
+tags: [fuzzy-finder, command-line, productivity, terminal, search, vim, shell, devtools, cli, interactive]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Searching through files, shell history, and command output on the terminal is slow when everything requires exact names or multiple commands. fzf solves this with an interactive fuzzy matcher that instantly filters any input stream as you type, then hands the selection to the next command. It supercharges shell workflows — file navigation, history search, and process killing — with minimal setup.
+use_cases:
+  - Navigate files and directories interactively with fuzzy matching integrated into the shell
+  - Search through command history and run previous commands with a few keystrokes
+  - Filter and select from arbitrary command output with custom preview panes
+  - Kill processes, switch Git branches, and manage tmux sessions from fuzzy pickers
+  - Build custom interactive workflows by piping any data source into fzf

--- a/tools/dev-tools/github-cli.yaml
+++ b/tools/dev-tools/github-cli.yaml
@@ -1,0 +1,24 @@
+name: GitHub CLI
+description: Official command-line tool for GitHub that brings pull requests, issues, releases, actions, and more into the terminal. Enables scripting and automation of the entire GitHub workflow without leaving the shell.
+tagline: GitHub from your command line
+
+github_url: https://github.com/cli/cli
+website_url: https://cli.github.com
+docs_url: https://cli.github.com/manual/
+
+install_command: brew install gh
+
+category: Dev Tools
+tags: [github, cli, git, automation, pull-requests, issues, devtools, ci, terminal, api]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Managing GitHub workflows — creating PRs, triaging issues, running actions, and reviewing code — normally means switching between the browser and the terminal, breaking automation and focus. GitHub CLI solves this by bringing the full GitHub workflow to the command line, with commands that are scriptable and CI-friendly. Teams automate releases, PR management, and repository operations with the same tool developers use daily.
+use_cases:
+  - Create, review, and merge pull requests entirely from the terminal
+  - Triage issues, labels, and milestones with scriptable command-line workflows
+  - Trigger and monitor GitHub Actions workflows and check run status
+  - Automate releases, gists, and repository management in CI pipelines
+  - Query the GitHub API with authenticated gh api commands for custom automation

--- a/tools/dev-tools/lazygit.yaml
+++ b/tools/dev-tools/lazygit.yaml
@@ -1,0 +1,24 @@
+name: lazygit
+description: Simple terminal UI for Git commands, providing a visual interface for staging, committing, branching, merging, and rebasing. Packs the power of complex Git workflows into an intuitive TUI that runs in any terminal.
+tagline: Simple terminal UI for Git commands
+
+github_url: https://github.com/jesseduffield/lazygit
+website_url: https://github.com/jesseduffield/lazygit#readme
+docs_url: https://github.com/jesseduffield/lazygit#readme
+
+install_command: brew install lazygit
+
+category: Dev Tools
+tags: [git, terminal, tui, productivity, version-control, devtools, cli, interactive, merge, rebase]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Git's power hides behind obscure command-line flags, making staging hunks, resolving conflicts, and managing branches slow and error-prone. lazygit solves this with a keyboard-driven terminal UI that visualizes the repository state — diffs, branches, and commit graphs — so complex operations become single keystrokes. Developers get the speed of the terminal with the clarity of a GUI.
+use_cases:
+  - Stage and unstage files, hunks, and lines visually with instant diff previews
+  - Manage branches, tags, and stashes with interactive menus and search
+  - Perform interactive rebases and cherry-picks from a visual commit graph
+  - Resolve merge conflicts with side-by-side diff navigation and selection
+  - Run custom Git commands from a customizable keybinding palette

--- a/tools/dev-tools/oh-my-zsh.yaml
+++ b/tools/dev-tools/oh-my-zsh.yaml
@@ -1,0 +1,24 @@
+name: oh-my-zsh
+description: Community-driven framework for managing Zsh configuration, bundling hundreds of plugins, themes, and helpful functions. Makes the terminal friendlier and more productive with sensible defaults, autosuggestions, and syntax highlighting.
+tagline: Community-driven framework for managing Zsh configuration
+
+github_url: https://github.com/ohmyzsh/ohmyzsh
+website_url: https://ohmyz.sh
+docs_url: https://github.com/ohmyzsh/ohmyzsh#readme
+
+install_command: sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+category: Dev Tools
+tags: [zsh, shell, terminal, productivity, plugins, themes, devtools, cli, configuration, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Stock shells lack conveniences like alias discovery, plugin management, and smart completions, so developers waste time retyping long commands and hunting through history. oh-my-zsh solves this with a curated framework of hundreds of plugins and themes that upgrade the Zsh experience — Git shortcuts, autojump-style navigation, syntax highlighting, and prompt themes — configured in minutes instead of weeks.
+use_cases:
+  - Supercharge the terminal with Git, Docker, and language-specific plugin shortcuts
+  - Get sensible defaults for completions, history, and prompt customization out of the box
+  - Switch between productivity themes and prompt styles with a single config line
+  - Add autosuggestions and syntax highlighting through bundled plugin frameworks
+  - Standardize shell environments across teams by sharing a managed Zsh config


### PR DESCRIPTION
Adds five essential terminal and developer tools to the catalog:

- **Deno** — secure JavaScript and TypeScript runtime with built-in tooling from the creator of Node.js
- **fzf** — general-purpose command-line fuzzy finder for interactive search
- **GitHub CLI** — official GitHub command-line tool for PRs, issues, actions, and automation
- **lazygit** — simple terminal UI for Git commands
- **oh-my-zsh** — community-driven framework for managing Zsh configuration

All five are verified open source, actively maintained, with install commands.
