### PR TITLE
Add rclone, ripgrep, tmux, Yarn to catalog

### DIFF
--- a/tools/data/rclone.yaml
+++ b/tools/data/rclone.yaml
@@ -1,0 +1,26 @@
+name: rclone
+description: Command-line program to sync, copy, and manage files across 70+ cloud storage providers including S3, Google Drive, Dropbox, and Azure Blob. Widely used to move AI training data, model artifacts, and dataset backups between local storage and object stores with checksum-verified transfers.
+tagline: rsync for cloud storage
+
+github_url: https://github.com/rclone/rclone
+website_url: https://rclone.org
+docs_url: https://rclone.org/docs/
+install_command: brew install rclone
+
+category: Data
+tags: [cloud-storage, file-sync, backup, s3, object-storage, data-transfer, storage]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Moving AI datasets between local disks, cloud object storage, and remote servers often involves
+  vendor-specific CLIs with different flags and no checksum verification. rclone unifies 70+ storage
+  backends behind one rsync-like interface, so data engineers can sync, verify, and automate dataset
+  transfers with consistent commands, encryption, and incremental copy support.
+
+use_cases:
+  - Sync AI training datasets from local workstations to S3, GCS, or Azure Blob Storage with checksum verification
+  - Schedule automated backups of model checkpoints and experiment artifacts to cloud object storage
+  - Migrate large data corpora between cloud providers such as Google Drive to S3 without downloading locally
+  - Mount cloud storage as a virtual filesystem for data science workflows using rclone mount

--- a/tools/dev-tools/ripgrep.yaml
+++ b/tools/dev-tools/ripgrep.yaml
@@ -1,0 +1,25 @@
+name: ripgrep
+description: Ultra-fast recursive regex search tool that respects .gitignore rules, built in Rust. Searches codebases, log files, and large directories at line-oriented speed, making it the default grep replacement for developers working with large ML repositories and datasets.
+tagline: Blazing-fast recursive regex search
+
+github_url: https://github.com/BurntSushi/ripgrep
+website_url: https://github.com/BurntSushi/ripgrep
+docs_url: https://github.com/BurntSushi/ripgrep/blob/master/README.md
+install_command: brew install ripgrep
+
+category: Dev Tools
+tags: [search, grep, regex, code-search, cli, developer-tools, productivity]
+pricing: free
+is_open_source: true
+license: Unlicense
+
+problem_solved: |
+  Searching large codebases, log files, or training-data directories with grep is slow and floods
+  results with binary files and vendor directories. ripgrep delivers line-oriented regex search at
+  near-memory speed, automatically respects .gitignore, and skips hidden and binary files — finding
+  needles in huge repositories in milliseconds.
+
+use_cases:
+  - Search across massive ML codebases for function definitions, config keys, or error strings in milliseconds
+  - Grep through training-data directories and log files while automatically ignoring binary and vendor files
+  - Pipe regex-matched lines into other tools for log analysis, dataset auditing, and code quality checks

--- a/tools/dev-tools/tmux.yaml
+++ b/tools/dev-tools/tmux.yaml
@@ -1,0 +1,25 @@
+name: tmux
+description: Terminal multiplexer that lets users run multiple shell sessions, split panes, and detach or re-attach sessions over SSH. Essential for long-running AI training jobs, remote development, and managing multiple processes in a single terminal window.
+tagline: Terminal multiplexer for persistent sessions
+
+github_url: https://github.com/tmux/tmux
+website_url: https://github.com/tmux/tmux
+docs_url: https://github.com/tmux/tmux/blob/master/README.md
+install_command: brew install tmux
+
+category: Dev Tools
+tags: [terminal, multiplexer, cli, tmux, session-management, developer-tools, remote-development]
+pricing: free
+is_open_source: true
+license: ISC
+
+problem_solved: |
+  Running long AI training jobs or multi-process workflows in a single terminal loses state when the
+  SSH connection drops, and juggling multiple terminal windows is unwieldy. tmux provides persistent
+  sessions with detachable panes and windows, so training runs, dev servers, and shell tasks survive
+  disconnects and can be re-attached from anywhere.
+
+use_cases:
+  - Run long-running model training jobs in a persistent session that survives SSH disconnects
+  - Split a terminal into multiple panes to monitor training logs, GPU usage, and dev servers side by side
+  - Attach to shared sessions for pair debugging on remote GPU machines

--- a/tools/dev-tools/yarn.yaml
+++ b/tools/dev-tools/yarn.yaml
@@ -1,0 +1,25 @@
+name: Yarn
+description: Fast, reliable JavaScript package manager that caches every package and parallelizes installs for speed. Yarn Berry adds Plug'n'Play resolution, workspaces for monorepos, and constraints — streamlining dependency management for AI web applications and model-serving front-ends.
+tagline: Fast and reliable JavaScript package manager
+
+github_url: https://github.com/yarnpkg/berry
+website_url: https://yarnpkg.com
+docs_url: https://yarnpkg.com/docs
+install_command: npm install -g yarn
+
+category: Dev Tools
+tags: [javascript, package-manager, npm, nodejs, dependencies, web-development, monorepo]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+problem_solved: |
+  Slow, non-deterministic npm installs and fragile node_modules layouts slow down AI web application
+  development and CI pipelines. Yarn speeds up dependency resolution with caching and parallelism, and
+  its Berry release adds Plug'n'Play to eliminate node_modules entirely — making installs deterministic
+  and workspace management for monorepos far simpler.
+
+use_cases:
+  - Install and manage JavaScript dependencies for AI web front-ends and model-serving dashboards faster than npm
+  - Use workspaces to manage monorepos containing shared UI components, SDKs, and app code
+  - Enable Plug'n'Play or offline caching to make CI installs deterministic and reproducible


### PR DESCRIPTION
## Summary

Adds 4 tools to the catalog:

| Tool | Category | Repo | Stars | License |
|---|---|---|---|---|
| rclone | Data | [rclone/rclone](https://github.com/rclone/rclone) | 58.8k | MIT |
| ripgrep | Dev Tools | [BurntSushi/ripgrep](https://github.com/BurntSushi/ripgrep) | 66.7k | Unlicense |
| tmux | Dev Tools | [tmux/tmux](https://github.com/tmux/tmux) | 48.2k | ISC |
| Yarn | Dev Tools | [yarnpkg/berry](https://github.com/yarnpkg/berry) | 8.1k | BSD-2-Clause |

All entries validated locally with `npx tsx scripts/validate-tool.ts` — all pass.

- rclone: rsync-for-cloud-storage CLI for syncing AI datasets/model artifacts across 70+ storage backends (Data)
- ripgrep: ultra-fast recursive regex search that respects .gitignore — the default grep replacement for large ML codebases (Dev Tools)
- tmux: terminal multiplexer with persistent sessions — essential for long-running training jobs over SSH (Dev Tools)
- Yarn: fast JavaScript package manager with workspaces and Plug'n'Play for AI web front-ends (Dev Tools)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rclone to the tools catalog, including cloud-storage synchronization details, installation guidance, links, licensing, pricing, and use cases.
  * Added ripgrep with developer-tool metadata, installation instructions, project links, licensing, pricing, and use cases.
  * Added tmux with persistent-session capabilities, installation guidance, links, licensing, and use cases.
  * Added Yarn Berry with package-management details, documentation links, installation instructions, licensing, and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->