### PR TITLE
Add pdfplumber, Camelot, Tabula, OpenParse, AudioLDM to catalog

### DIFF
--- a/tools/data/camelot.yaml
+++ b/tools/data/camelot.yaml
@@ -1,0 +1,26 @@
+name: Camelot
+description: Python library for extracting tabular data from PDF files with two parsing methods — lattice (ruled tables) and stream (whitespace-delimited tables). Exports extracted tables to CSV, JSON, Excel, and HTML, making it a staple for turning PDF reports into structured data for AI pipelines.
+tagline: Extract tables from PDFs
+
+github_url: https://github.com/camelot-dev/camelot
+website_url: https://camelot-py.readthedocs.io/
+docs_url: https://camelot-py.readthedocs.io/
+install_command: pip install camelot-py
+
+category: Data
+tags: [pdf, table-extraction, document-processing, data-extraction, python, csv, data-pipeline]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Tables buried inside PDF reports are notoriously hard to extract — text-based parsers lose row and
+  column structure, and manual copy-paste does not scale. Camelot detects ruled and unruled tables using
+  lattice and stream algorithms, preserves cell structure, and exports clean CSV, JSON, and Excel files —
+  so teams can feed PDF-derived tabular data into analytics and machine learning pipelines automatically.
+
+use_cases:
+  - Convert tables from financial filings, government reports, and research PDFs into CSV for analysis
+  - Extract structured tables from scanned or print-generated documents for RAG and data warehousing
+  - Automate recurring report ingestion by batch-processing PDF tables into a database
+  - Export extracted tables as Excel or JSON for downstream BI dashboards and ML feature stores

--- a/tools/data/openparse.yaml
+++ b/tools/data/openparse.yaml
@@ -1,0 +1,26 @@
+name: OpenParse
+description: Open-source document parsing library that converts complex PDFs, PPTX, and DOCX files into structured, LLM-friendly markdown. Uses vision-language models to identify tables, headings, and reading order, producing clean chunks that plug directly into RAG pipelines and agent knowledge bases.
+tagline: LLM-ready document parsing
+
+github_url: https://github.com/Filimoa/open-parse
+website_url: https://filimoa.github.io/open-parse/
+docs_url: https://filimoa.github.io/open-parse/
+install_command: pip install openparse
+
+category: Data
+tags: [document-processing, rag, pdf, markdown, llm, parsing, knowledge-base]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Feeding raw PDFs, slides, or Office files into LLM pipelines produces noisy chunks that break tables,
+  split headings, and lose reading order — degrading retrieval quality in RAG systems. OpenParse parses
+  documents into semantically coherent markdown blocks with vision-model assistance, preserving tables
+  and structure so embeddings and retrieval see clean, meaningful units instead of mangled text.
+
+use_cases:
+  - Convert PDFs, PPTX, and DOCX files into clean markdown for RAG retrieval pipelines
+  - Preserve tables and headings as structured blocks for higher-quality embedding and chunking
+  - Ingest presentation decks and reports into agent knowledge bases without manual preprocessing
+  - Use vision-language parsing to handle complex layouts and scanned documents accurately

--- a/tools/data/pdfplumber.yaml
+++ b/tools/data/pdfplumber.yaml
@@ -1,0 +1,26 @@
+name: pdfplumber
+description: Python library for precise PDF text extraction, table detection, and character-level inspection. Unlike naive text dumpers, pdfplumber exposes each character, line, and rectangle with coordinates — enabling reliable parsing of forms, reports, and scientific papers for AI data pipelines.
+tagline: Precise PDF text and table extraction
+
+github_url: https://github.com/jsvine/pdfplumber
+website_url: https://github.com/jsvine/pdfplumber
+docs_url: https://jsvine.github.io/pdfplumber/
+install_command: pip install pdfplumber
+
+category: Data
+tags: [pdf, document-processing, text-extraction, table-extraction, ocr, data-pipeline, python]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Extracting structured content from PDFs for RAG and document-processing pipelines usually produces
+  garbled text with no layout awareness — tables get scrambled, columns merge, and coordinates are lost.
+  pdfplumber gives developers character-, line-, and table-level access with bounding boxes, so they can
+  reliably parse forms, invoices, and research papers into clean structured data for downstream AI use.
+
+use_cases:
+  - Extract text and tables from research papers, financial reports, and invoices for RAG ingestion
+  - Reconstruct tables from scanned or digitally generated PDFs using pdfplumber's table-finding algorithm
+  - Pull character-level coordinates and styling to rebuild document layouts for document AI models
+  - Batch-process thousands of PDFs into structured JSON for training or analytics pipelines

--- a/tools/data/tabula.yaml
+++ b/tools/data/tabula.yaml
@@ -1,0 +1,26 @@
+name: Tabula
+description: Tool for liberating data tables trapped inside PDF files, with a desktop application and a Python wrapper (tabula-py). Extracts tables by detecting ruling lines and cell boundaries, then exports them to CSV, TSV, and JSON for use in data analysis and AI pipelines.
+tagline: Liberate data tables from PDFs
+
+github_url: https://github.com/tabulapdf/tabula
+website_url: https://tabula.technology/
+docs_url: https://tabula-py.readthedocs.io/
+install_command: pip install tabula-py
+
+category: Data
+tags: [pdf, table-extraction, document-processing, data-extraction, java, python, csv]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Valuable data is often locked inside tables in PDF documents that resist standard text extraction —
+  rows and columns collapse into unstructured text streams. Tabula identifies table boundaries from
+  ruling lines and cell geometry, reconstructs the grid, and exports clean CSV or JSON, so analysts and
+  ML pipelines can consume report data without manual transcription or paid extraction services.
+
+use_cases:
+  - Extract tables from SEC filings, academic papers, and government PDFs into structured CSV files
+  - Automate table harvesting from batch PDF reports using tabula-py in Python data pipelines
+  - Recover tabular data from legacy documents for database migration and data warehousing
+  - Convert PDF tables to JSON for feeding document-AI and RAG applications

--- a/tools/other/audioldm.yaml
+++ b/tools/other/audioldm.yaml
@@ -1,0 +1,26 @@
+name: AudioLDM
+description: Latent diffusion model framework that generates speech, sound effects, and music from text prompts. Built on a latent audio diffusion architecture trained on CLAP embeddings, AudioLDM produces high-fidelity audio from natural language descriptions for creative and AI-driven audio pipelines.
+tagline: Text-to-audio latent diffusion
+
+github_url: https://github.com/haoheliu/audioldm
+website_url: https://audioldm.github.io/
+docs_url: https://github.com/haoheliu/audioldm
+install_command: pip install audioldm
+
+category: Other
+tags: [audio-generation, diffusion, text-to-audio, music, sound-effects, generative-ai, deep-learning]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Generating custom audio — voice clips, sound effects, or music — for applications typically requires
+  recording studios, licensed stock libraries, or complex synthesis code. AudioLDM applies latent
+  diffusion to audio, letting developers generate speech, sound effects, and music straight from text
+  prompts with a single Python library, unlocking synthetic audio for demos, games, and AI training data.
+
+use_cases:
+  - Generate sound effects and ambient audio from text prompts for games and interactive demos
+  - Create synthetic voice and speech clips for TTS training data and application prototyping
+  - Produce royalty-free music beds and loops for videos, podcasts, and marketing content
+  - Fine-tune the diffusion model on custom audio datasets for domain-specific sound generation


### PR DESCRIPTION
## Summary

Adds 5 tools to the catalog:

| Tool | Category | Repo | Stars | License |
|---|---|---|---|---|
| pdfplumber | Data | [jsvine/pdfplumber](https://github.com/jsvine/pdfplumber) | 10.6k | MIT |
| Camelot | Data | [camelot-dev/camelot](https://github.com/camelot-dev/camelot) | 3.8k | MIT |
| Tabula | Data | [tabulapdf/tabula](https://github.com/tabulapdf/tabula) | 7.5k | MIT |
| OpenParse | Data | [Filimoa/open-parse](https://github.com/Filimoa/open-parse) | 3.2k | MIT |
| AudioLDM | Other | [haoheliu/audioldm](https://github.com/haoheliu/audioldm) | 2.9k | MIT |

All entries validated locally with `npx tsx scripts/validate-tool.ts` — all pass.

- pdfplumber: precise PDF text/table extraction with character-level coordinates (Data)
- Camelot: lattice/stream table extraction from PDFs → CSV/JSON/Excel (Data)
- Tabula: table liberation from PDFs with desktop app + tabula-py wrapper (Data)
- OpenParse: vision-model-assisted PDF/PPTX/DOCX → LLM-ready markdown for RAG (Data)
- AudioLDM: text-to-audio latent diffusion for speech, SFX, and music (Other)
