### PR TITLE
Add Librosa, Pydub, MeloTTS, Kokoro to catalog

### DIFF
--- a/tools/other/kokoro.yaml
+++ b/tools/other/kokoro.yaml
@@ -1,0 +1,27 @@
+name: Kokoro
+description: State-of-the-art 82M-parameter text-to-speech model that produces high-quality, expressive audio with minimal compute, distributed under Apache-2.0. Supports multiple voices and languages, runs on CPU or GPU, and integrates easily into Python applications for local speech synthesis.
+tagline: Lightweight high-quality text-to-speech
+
+github_url: https://github.com/hexgrad/kokoro
+website_url: https://hf.co/hexgrad/Kokoro-82M
+docs_url: https://github.com/hexgrad/kokoro
+install_command: pip install kokoro
+
+category: Other
+tags: [text-to-speech, tts, speech-synthesis, lightweight, edge, audio, python]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  High-quality text-to-speech usually demands large models or commercial APIs, making local deployment
+  slow, costly, or restricted by licensing. Kokoro achieves near-state-of-the-art speech quality with an
+  82M-parameter model under a permissive Apache-2.0 license, running comfortably on CPU — giving
+  developers a practical path to expressive, private, on-device TTS for assistants, accessibility, and
+  content generation without recurring API fees.
+
+use_cases:
+  - Generate expressive speech locally for voice assistants and agent applications on CPU hardware
+  - Synthesize voiceovers for videos, e-learning, and marketing content without cloud TTS costs
+  - Add multilingual accessibility voice features to apps with permissive commercial licensing
+  - Batch-produce audio prompts and training data for speech and audio ML pipelines

--- a/tools/other/librosa.yaml
+++ b/tools/other/librosa.yaml
@@ -1,0 +1,27 @@
+name: Librosa
+description: Python package for music and audio analysis, providing building blocks for feature extraction, beat tracking, spectrogram computation, and audio resampling. The de facto standard library for loading audio and extracting mel-spectrograms and MFCCs for machine learning and speech research.
+tagline: Python audio and music analysis
+
+github_url: https://github.com/librosa/librosa
+website_url: https://librosa.org/
+docs_url: https://librosa.org/doc/
+install_command: pip install librosa
+
+category: Other
+tags: [audio-analysis, music, feature-extraction, spectrogram, mfcc, python, signal-processing]
+pricing: free
+is_open_source: true
+license: ISC
+
+problem_solved: |
+  Working with audio data for ML — speech recognition, music information retrieval, or sound
+  classification — requires converting raw waveforms into usable features, which involves resampling,
+  spectrograms, and filtering that are easy to get wrong. Librosa provides a consistent, well-tested API
+  for loading audio and computing mel-spectrograms, MFCCs, chroma, and beat features, letting researchers
+  focus on models instead of DSP plumbing.
+
+use_cases:
+  - Extract mel-spectrograms and MFCC features from audio for speech and sound classification models
+  - Analyze music for tempo, beats, and harmony in music information retrieval applications
+  - Load and preprocess audio datasets with consistent resampling and normalization for training pipelines
+  - Visualize waveforms, spectrograms, and harmonic content for audio debugging and research

--- a/tools/other/melotts.yaml
+++ b/tools/other/melotts.yaml
@@ -1,0 +1,27 @@
+name: MeloTTS
+description: High-quality multilingual text-to-speech library supporting English, Spanish, French, Chinese, Japanese, and Korean, with a lightweight and fast inference engine. Built for real-time and edge TTS applications with per-language optimization from the MyShell team.
+tagline: Multilingual text-to-speech library
+
+github_url: https://github.com/myshell-ai/MeloTTS
+website_url: https://github.com/myshell-ai/MeloTTS
+docs_url: https://github.com/myshell-ai/MeloTTS
+install_command: pip install melotts
+
+category: Other
+tags: [text-to-speech, tts, multilingual, speech-synthesis, edge, real-time, audio]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Adding natural-sounding speech to applications across multiple languages typically means paying for
+  commercial TTS APIs or wrestling with heavyweight models that are slow and hard to deploy. MeloTTS
+  delivers high-quality multilingual synthesis — English, Spanish, French, Chinese, Japanese, and Korean
+  — in a lightweight package that runs fast enough for real-time and edge deployment, so developers can
+  add local TTS to agents, assistants, and content tools without cloud dependencies.
+
+use_cases:
+  - Generate natural multilingual speech for voice assistants, agents, and interactive applications
+  - Run text-to-speech locally on edge devices with fast, lightweight inference
+  - Produce audio training data and voice prompts in six languages for content pipelines
+  - Add screen-reader and accessibility voice features to web and mobile products

--- a/tools/other/pydub.yaml
+++ b/tools/other/pydub.yaml
@@ -1,0 +1,26 @@
+name: Pydub
+description: Simple and easy high-level audio manipulation library for Python. Supports slicing, concatenating, overlaying, volume adjustment, format conversion, and playback across MP3, WAV, FLAC, and OGG via FFmpeg — ideal for preprocessing audio datasets for ML and TTS pipelines.
+tagline: Simple audio manipulation in Python
+
+github_url: https://github.com/jiaaro/pydub
+website_url: https://github.com/jiaaro/pydub
+docs_url: https://github.com/jiaaro/pydub
+install_command: pip install pydub
+
+category: Other
+tags: [audio, audio-processing, ffmpeg, python, tts, data-pipeline, sound]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Preparing audio for ML training and TTS pipelines usually means writing fiddly FFmpeg command lines to
+  trim, concatenate, convert, or adjust audio files. Pydub wraps FFmpeg in a clean Python API where
+  slicing is as simple as `audio[10:20]`, enabling rapid batch manipulation — trimming silence, splicing
+  clips, converting formats, and normalizing loudness — without shell scripting or low-level DSP code.
+
+use_cases:
+  - Trim, concatenate, and split audio clips programmatically when building speech and music datasets
+  - Convert between MP3, WAV, FLAC, and OGG formats at scale for ML ingestion pipelines
+  - Normalize loudness and apply fades or overlays for TTS training and podcast processing
+  - Extract and manipulate audio segments in QA tools that verify synthesized speech output


### PR DESCRIPTION
## Summary

Adds 4 tools to the catalog:

| Tool | Category | Repo | Stars | License |
|---|---|---|---|---|
| Librosa | Other | [librosa/librosa](https://github.com/librosa/librosa) | 8.5k | ISC |
| Pydub | Other | [jiaaro/pydub](https://github.com/jiaaro/pydub) | 9.8k | MIT |
| MeloTTS | Other | [myshell-ai/MeloTTS](https://github.com/myshell-ai/MeloTTS) | 7.6k | MIT |
| Kokoro | Other | [hexgrad/kokoro](https://github.com/hexgrad/kokoro) | 8.2k | Apache-2.0 |

All entries validated locally with `npx tsx scripts/validate-tool.ts` — all pass.

- Librosa: Python audio/music analysis — mel-spectrograms, MFCCs, beat tracking (Other)
- Pydub: simple high-level audio manipulation — trim, concat, convert via FFmpeg (Other)
- MeloTTS: multilingual TTS (EN/ES/FR/ZH/JA/KO), lightweight real-time inference (Other)
- Kokoro: 82M-param Apache-2.0 TTS model, CPU-friendly high-quality speech (Other)
