### PR TITLE
Add RVC, FunASR, Spleeter, Ultimate Vocal Remover, WeNet to catalog

### DIFF
--- a/tools/other/funasr.yaml
+++ b/tools/other/funasr.yaml
@@ -1,0 +1,27 @@
+name: FunASR
+description: Open-source speech recognition toolkit from Alibaba's ModelScope team for training and inference of end-to-end ASR, voice activity detection, punctuation restoration, and speaker verification models. Includes pretrained models for multiple languages and real-time streaming recognition.
+tagline: End-to-end speech recognition toolkit
+
+github_url: https://github.com/modelscope/FunASR
+website_url: https://funasr.readthedocs.io/
+docs_url: https://funasr.readthedocs.io/
+install_command: pip install funasr
+
+category: Other
+tags: [speech-recognition, asr, voice-activity-detection, audio, deep-learning, streaming, model-scope]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Building production speech recognition — transcribing meetings, voice commands, or media — usually
+  means stitching together separate models for VAD, ASR, punctuation, and speaker IDs, plus handling
+  streaming inference. FunASR bundles end-to-end ASR with voice activity detection, punctuation
+  restoration, and speaker verification in one toolkit, with pretrained multilingual models and
+  streaming support, so teams can ship robust transcription pipelines without training from scratch.
+
+use_cases:
+  - Transcribe meetings, calls, and media in real time with streaming end-to-end ASR models
+  - Detect speech segments and restore punctuation automatically in transcription pipelines
+  - Recognize speech in multiple languages using pretrained ModelScope checkpoints
+  - Verify speakers and diarize audio for security and analytics applications

--- a/tools/other/rvc.yaml
+++ b/tools/other/rvc.yaml
@@ -1,0 +1,27 @@
+name: RVC
+description: Retrieval-based Voice Conversion WebUI for training high-quality voice conversion models with as little as 10 minutes of voice data. Uses retrieval-based feature matching and a small vocoder to convert any source audio into a target voice with low latency and high fidelity.
+tagline: Train voice conversion models with minutes of data
+
+github_url: https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI
+website_url: https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI
+docs_url: https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI
+install_command: pip install rvc-python
+
+category: Other
+tags: [voice-conversion, tts, audio, speech, deep-learning, real-time, webui]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Building a custom voice conversion system traditionally requires hours of studio-quality voice data
+  and complex speaker-encoder pipelines. RVC makes it possible to train a production-grade voice
+  conversion model from 10 minutes of target-voice audio, using retrieval-based feature matching and a
+  lightweight vocoder — enabling creators, game studios, and accessibility teams to convert speech into
+  custom voices quickly and run it in real time.
+
+use_cases:
+  - Train a personal or character voice model from short voice samples for content creation
+  - Convert singing or speech into a target voice in real time for streaming and games
+  - Build multilingual dubbing pipelines by converting source audio into localized voices
+  - Prototype voice cloning research with a complete training and inference WebUI

--- a/tools/other/spleeter.yaml
+++ b/tools/other/spleeter.yaml
@@ -1,0 +1,26 @@
+name: Spleeter
+description: Deezer's open-source source separation library with pretrained models that split audio into stems such as vocals, drums, bass, and other instruments. Runs on TensorFlow with CPU or GPU support and processes thousands of tracks quickly for music and audio production workflows.
+tagline: Split music into stems with AI
+
+github_url: https://github.com/deezer/spleeter
+website_url: https://github.com/deezer/spleeter
+docs_url: https://github.com/deezer/spleeter
+install_command: pip install spleeter
+
+category: Other
+tags: [audio, source-separation, music, vocals, deep-learning, tensorflow, stem-splitting]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Separating music into vocal, drum, bass, and instrumental stems normally requires expensive studio
+  tools or manual editing. Spleeter applies a U-Net-style source separation model with pretrained
+  weights to split any audio track into clean stems in seconds — powering karaoke apps, remixing tools,
+  and dataset preparation where isolated vocal or instrumental tracks are needed for AI pipelines.
+
+use_cases:
+  - Isolate vocals, drums, bass, and other stems for karaoke, remixing, and DJ tools
+  - Prepare clean vocal or instrumental training data for music and speech ML models
+  - Batch-process large music libraries into stems for content and analytics applications
+  - Extract acapella tracks for mashups and creative audio production workflows

--- a/tools/other/ultimate-vocal-remover.yaml
+++ b/tools/other/ultimate-vocal-remover.yaml
@@ -1,0 +1,26 @@
+name: Ultimate Vocal Remover
+description: GUI application for vocal removal and source separation using deep neural networks. Bundles multiple state-of-the-art models, batch processing, and stem extraction for vocals, drums, bass, and other instruments — popular among creators and researchers for clean acapella and instrumental extraction.
+tagline: Deep-learning vocal remover GUI
+
+github_url: https://github.com/Anjok07/ultimatevocalremovergui
+website_url: https://github.com/Anjok07/ultimatevocalremovergui
+docs_url: https://github.com/Anjok07/ultimatevocalremovergui
+
+category: Other
+tags: [audio, vocal-removal, source-separation, music, gui, stem-splitting, deep-learning]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Removing vocals from songs or isolating individual stems typically requires commercial software with
+  subscriptions and cloud uploads. Ultimate Vocal Remover provides a free, local GUI that applies
+  ensemble deep-learning models to split tracks into vocals, drums, bass, and other instruments — with
+  batch processing and model selection — so creators, researchers, and hobbyists can extract clean
+  stems offline without licensing fees or privacy concerns.
+
+use_cases:
+  - Remove vocals from songs for karaoke, covers, and remix production locally
+  - Extract instrumental or acapella stems in batch for media and content workflows
+  - Compare multiple separation models to get the cleanest stems for a given track
+  - Prepare isolated audio components for music research and ML dataset creation

--- a/tools/other/wenet.yaml
+++ b/tools/other/wenet.yaml
@@ -1,0 +1,27 @@
+name: WeNet
+description: Production-first and production-ready end-to-end speech recognition toolkit supporting streaming and non-streaming ASR with a unified two-pass approach. Built on PyTorch and TorchAudio, with pretrained models, a lightweight runtime, and tools for training, deployment, and benchmarking.
+tagline: Production-ready end-to-end ASR
+
+github_url: https://github.com/wenet-e2e/wenet
+website_url: https://github.com/wenet-e2e/wenet
+docs_url: https://wenet-e2e.github.io/wenet/
+install_command: pip install git+https://github.com/wenet-e2e/wenet.git
+
+category: Other
+tags: [speech-recognition, asr, streaming, pytorch, audio, deep-learning, production]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Deploying speech recognition in production — especially with streaming requirements for live
+  transcription and voice interfaces — often means juggling separate non-streaming accuracy and
+  streaming latency models. WeNet unifies streaming and non-streaming ASR in a single two-pass
+  architecture trained end-to-end with PyTorch, offering pretrained checkpoints and a lightweight
+  runtime so teams can go from data to deployed transcription without complex model ensembles.
+
+use_cases:
+  - Deploy real-time streaming speech recognition for voice assistants and live captioning
+  - Train end-to-end ASR models on custom domains with the PyTorch training pipeline
+  - Run on-device or server-side inference with WeNet's lightweight runtime
+  - Benchmark streaming versus non-streaming accuracy for production trade-off decisions


### PR DESCRIPTION
## Summary

Adds 5 tools to the catalog:

| Tool | Category | Repo | Stars | License |
|---|---|---|---|---|
| RVC | Other | [RVC-Project/Retrieval-based-Voice-Conversion-WebUI](https://github.com/RVC-Project/Retrieval-based-Voice-Conversion-WebUI) | 36.8k | MIT |
| FunASR | Other | [modelscope/FunASR](https://github.com/modelscope/FunASR) | 19.6k | MIT |
| Spleeter | Other | [deezer/spleeter](https://github.com/deezer/spleeter) | 28.3k | MIT |
| Ultimate Vocal Remover | Other | [Anjok07/ultimatevocalremovergui](https://github.com/Anjok07/ultimatevocalremovergui) | 25.6k | MIT |
| WeNet | Other | [wenet-e2e/wenet](https://github.com/wenet-e2e/wenet) | 5.2k | Apache-2.0 |

All entries validated locally with `npx tsx scripts/validate-tool.ts` — all pass.

- RVC: retrieval-based voice conversion — train voice models from ~10 min of audio (Other)
- FunASR: Alibaba end-to-end ASR toolkit — VAD, punctuation, streaming (Other)
- Spleeter: Deezer source separation — split music into vocals/drums/bass stems (Other)
- Ultimate Vocal Remover: deep-learning vocal removal GUI with batch processing (Other)
- WeNet: production-first streaming + non-streaming end-to-end ASR on PyTorch (Other)
