### PR TITLE
Add Tone.js, howler.js, wavesurfer.js to catalog

### DIFF
--- a/tools/other/howler-js.yaml
+++ b/tools/other/howler-js.yaml
@@ -1,0 +1,26 @@
+name: howler.js
+description: JavaScript audio library for the modern web that makes working with audio in HTML5 and Web Audio easy. Supports multiple codecs, sprite playback, spatial audio, and a consistent API across browsers — widely used for game audio, media players, and web applications.
+tagline: Audio library for the modern web
+
+github_url: https://github.com/goldfire/howler.js
+website_url: https://howlerjs.com/
+docs_url: https://github.com/goldfire/howler.js
+install_command: npm install howler
+
+category: Other
+tags: [web-audio, javascript, audio, browser, game-audio, media-player, html5]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Playing audio reliably across browsers is surprisingly inconsistent — codec support, autoplay rules,
+  and the low-level Web Audio API differ everywhere. howler.js abstracts HTML5 Audio and Web Audio
+  behind one simple API with codec fallbacks, sprite playback, and spatial audio, letting web
+  developers add sound to games, media players, and dashboards without per-browser workarounds.
+
+use_cases:
+  - Add cross-browser audio playback to web games, apps, and interactive demos
+  - Play audio sprites and sound effects with precise timing in game engines
+  - Implement spatial audio for 3D web experiences and virtual environments
+  - Build media players with codec fallbacks and consistent volume controls

--- a/tools/other/tone-js.yaml
+++ b/tools/other/tone-js.yaml
@@ -1,0 +1,27 @@
+name: Tone.js
+description: Web Audio framework for creating interactive music and sound in the browser. Provides a comprehensive set of synthesizers, effects, and scheduling primitives built on the Web Audio API — enabling generative music, audio-reactive visuals, and browser-based instruments without native plugins.
+tagline: Interactive music and sound in the browser
+
+github_url: https://github.com/Tonejs/Tone.js
+website_url: https://tonejs.github.io/
+docs_url: https://tonejs.github.io/
+install_command: npm install tone
+
+category: Other
+tags: [web-audio, music, javascript, browser, synthesizer, generative-music, audio]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Building interactive audio experiences in the browser — generative music, sound design, or
+  audio-visual installations — requires wrestling with the low-level Web Audio API. Tone.js wraps it
+  in a musical framework with synthesizers, effects, and sample-accurate scheduling, so developers can
+  compose and manipulate sound with readable code and ship audio features inside web apps and demos
+  without native audio plugins or desktop DAWs.
+
+use_cases:
+  - Create generative music and sound installations that run entirely in the browser
+  - Build web-based synthesizers and instruments with Tone.js's oscillator and sampler primitives
+  - Add audio-reactive visuals and sound effects to interactive AI demos and games
+  - Prototype musical ideas programmatically with tempo-synced scheduling and effects chains

--- a/tools/other/wavesurfer-js.yaml
+++ b/tools/other/wavesurfer-js.yaml
@@ -1,0 +1,27 @@
+name: wavesurfer.js
+description: Audio waveform visualization library for the web that renders waveforms, enables playback and regions, and supports zoom, markers, and plugins. Built on Web Audio and Canvas, it powers audio editors, transcription UIs, and speech-tool dashboards that need interactive waveform displays.
+tagline: Interactive audio waveform visualization
+
+github_url: https://github.com/katspaugh/wavesurfer.js
+website_url: https://wavesurfer.xyz/
+docs_url: https://wavesurfer.xyz/
+install_command: npm install wavesurfer.js
+
+category: Other
+tags: [audio, waveform, visualization, javascript, browser, transcription, web-audio]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Building audio tools — transcription editors, podcast players, or voice-interface dashboards —
+  requires showing an interactive waveform with playback, zoom, and region selection, which is complex
+  to implement from scratch. wavesurfer.js renders waveforms from audio files or live streams with a
+  plugin system for regions, markers, and timeline, so developers can ship polished audio UIs quickly
+  on top of Web Audio and Canvas.
+
+use_cases:
+  - Render interactive waveforms in transcription and audio-editing web applications
+  - Add playback, zoom, and region selection to podcast and media review tools
+  - Visualize audio for speech and sound-analysis dashboards and AI voice applications
+  - Annotate audio with markers and regions for labeling and QA workflows


### PR DESCRIPTION
## Summary

Adds 3 tools to the catalog:

| Tool | Category | Repo | Stars | License |
|---|---|---|---|---|
| Tone.js | Other | [Tonejs/Tone.js](https://github.com/Tonejs/Tone.js) | 14.7k | MIT |
| howler.js | Other | [goldfire/howler.js](https://github.com/goldfire/howler.js) | 25.3k | MIT |
| wavesurfer.js | Other | [katspaugh/wavesurfer.js](https://github.com/katspaugh/wavesurfer.js) | 10.4k | BSD-3-Clause |

All entries validated locally with `npx tsx scripts/validate-tool.ts` — all pass.

- Tone.js: Web Audio framework for interactive music/sound synthesis in the browser (Other)
- howler.js: cross-browser JS audio library — sprites, spatial audio, codec fallbacks (Other)
- wavesurfer.js: interactive audio waveform visualization for editors and transcription UIs (Other)
