### PR TITLE
Add F5-TTS, StyleTTS2, Zonos, DiffSinger, Descript Audio Codec to catalog

### DIFF
--- a/tools/other/descript-audio-codec.yaml
+++ b/tools/other/descript-audio-codec.yaml
@@ -1,0 +1,27 @@
+name: Descript Audio Codec
+description: Descript Audio Codec (DAC) is an open-source neural audio codec that compresses 44.1 kHz audio about 90x at around 8 kbps while keeping high fidelity. It works across speech, music, and environmental audio and is used as a discrete tokenizer for audio language models in place of Encodec.
+tagline: High-fidelity neural audio codec with about 90x compression
+
+github_url: https://github.com/descriptinc/descript-audio-codec
+website_url: https://descript.notion.site/Descript-Audio-Codec-11389fce0ce2419891d6591a68f814d5
+docs_url: https://github.com/descriptinc/descript-audio-codec
+
+install_command: pip install descript-audio-codec
+
+category: Other
+tags: [audio-codec, neural-codec, compression, speech, music, tokenization, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Generative audio models need compact discrete tokens without destroying 44.1 kHz
+  fidelity. Descript Audio Codec compresses speech, music, and environmental audio
+  about 90x at roughly 8 kbps so you can train or serve audio language models with
+  a universal codec instead of domain-specific tokenizers.
+
+use_cases:
+  - Tokenize speech, music, or environmental audio for audio language model training
+  - Compress high-sample-rate audio for storage and transmission with neural codecs
+  - Swap Encodec for DAC in AudioLM-style and MusicGen-style pipelines
+  - Encode and decode .dac files in batch with the official CLI

--- a/tools/other/diffsinger.yaml
+++ b/tools/other/diffsinger.yaml
@@ -1,0 +1,25 @@
+name: DiffSinger
+description: DiffSinger is an open-source singing voice synthesis and text-to-speech system that uses a shallow diffusion mechanism. It generates singing from lyrics plus MIDI or acoustic features, includes DiffSpeech for spoken TTS, and ships official PyTorch training and inference code from the AAAI 2022 paper.
+tagline: Shallow-diffusion singing voice synthesis and TTS
+
+github_url: https://github.com/MoonInTheRiver/DiffSinger
+website_url: https://github.com/MoonInTheRiver/DiffSinger
+docs_url: https://arxiv.org/abs/2105.02446
+
+category: Other
+tags: [singing-voice-synthesis, text-to-speech, tts, diffusion, svs, speech-synthesis, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  High-quality singing synthesis usually needs heavy vocoders and long diffusion chains
+  that are slow to sample. DiffSinger applies a shallow diffusion mechanism so singing
+  voice synthesis and spoken TTS can stay high quality while generating from lyrics,
+  MIDI, or acoustic features with fewer diffusion steps.
+
+use_cases:
+  - Synthesize singing vocals from lyrics and MIDI for music production prototypes
+  - Train or fine-tune a singing voice model on custom singer datasets
+  - Generate spoken TTS with the related DiffSpeech pipeline
+  - Research shallow diffusion versus full diffusion for audio generation

--- a/tools/other/f5-tts.yaml
+++ b/tools/other/f5-tts.yaml
@@ -1,0 +1,27 @@
+name: F5-TTS
+description: F5-TTS is an open-source flow-matching text-to-speech model that generates fluent, speaker-faithful speech from text plus a short reference clip. It uses a Diffusion Transformer with ConvNeXt V2 for faster training and inference, and Sway Sampling to improve generation quality at inference time.
+tagline: Flow-matching TTS that clones a voice from a short clip
+
+github_url: https://github.com/SWivid/F5-TTS
+website_url: https://swivid.github.io/F5-TTS/
+docs_url: https://github.com/SWivid/F5-TTS
+
+install_command: pip install f5-tts
+
+category: Other
+tags: [text-to-speech, tts, voice-cloning, flow-matching, diffusion, speech-synthesis, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Cloning a speaker with diffusion TTS is often slow to train and too heavy for interactive
+  inference. F5-TTS uses flow matching and a Diffusion Transformer with ConvNeXt V2 so you
+  can synthesize fluent, faithful speech from a short reference clip without the usual
+  diffusion-TTS training and latency tax.
+
+use_cases:
+  - Clone a speaker from a short reference clip and generate new speech in that voice
+  - Build local TTS pipelines for agents, audiobooks, and video voiceover
+  - Fine-tune or serve F5-TTS as an open alternative to commercial voice-cloning APIs
+  - Compare flow-matching TTS quality against diffusion and autoregressive baselines

--- a/tools/other/styletts2.yaml
+++ b/tools/other/styletts2.yaml
@@ -1,0 +1,25 @@
+name: StyleTTS2
+description: StyleTTS 2 is an open-source text-to-speech model that reaches human-level naturalness using style diffusion and adversarial training with large speech language models. It can sample a latent speaking style without a reference clip and also supports zero-shot speaker adaptation on multi-speaker data.
+tagline: Human-level TTS via style diffusion and speech language models
+
+github_url: https://github.com/yl4579/StyleTTS2
+website_url: https://styletts2.github.io/
+docs_url: https://github.com/yl4579/StyleTTS2
+
+category: Other
+tags: [text-to-speech, tts, style-diffusion, voice-synthesis, zero-shot, speech-synthesis, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Many TTS systems sound robotic or need a reference recording to pick a speaking style.
+  StyleTTS 2 models style as a latent variable with diffusion, then trains against large
+  speech language model discriminators so output can match human recordings on standard
+  English benchmarks and adapt to new speakers without a matched studio voice.
+
+use_cases:
+  - Generate highly natural English speech for narration, assistants, and product demos
+  - Adapt a multi-speaker StyleTTS 2 checkpoint to a new voice with limited data
+  - Research style-controlled TTS without requiring a reference waveform at inference
+  - Benchmark human-level TTS against commercial and open neural vocoder stacks

--- a/tools/other/zonos.yaml
+++ b/tools/other/zonos.yaml
@@ -1,0 +1,25 @@
+name: Zonos
+description: Zonos is Zyphra's open-weight text-to-speech model trained on more than 200k hours of multilingual speech. It clones a voice from a few seconds of audio, synthesizes 44 kHz speech, and exposes controls for emotion, speaking rate, pitch, and audio quality across English, Japanese, Chinese, French, and German.
+tagline: Open-weight multilingual TTS with emotion and voice cloning
+
+github_url: https://github.com/Zyphra/Zonos
+website_url: https://playground.zyphra.com/audio
+docs_url: https://www.zyphra.com/post/beta-release-of-zonos-v0-1
+
+category: Other
+tags: [text-to-speech, tts, voice-cloning, multilingual, emotion-control, speech-synthesis, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Open TTS models often lag commercial APIs on expressiveness, sample rate, and emotion
+  control. Zonos is trained on more than 200k hours of speech so you can clone a speaker
+  from a short clip, steer emotion and prosody, and generate 44 kHz audio in several
+  languages without sending audio to a closed TTS vendor.
+
+use_cases:
+  - Clone a speaker from a few seconds of reference audio and generate new lines
+  - Produce multilingual narration with control over emotion, pitch, and speaking rate
+  - Prototype voice agents that need expressive 44 kHz local or self-hosted TTS
+  - Compare open-weight TTS quality against hosted commercial speech APIs


### PR DESCRIPTION
## Summary

Add five speech/audio tools to the Agentic AI For Good catalog:

- **F5-TTS** (Other) — flow-matching TTS that clones a speaker from a short clip
- **StyleTTS2** (Other) — human-level TTS via style diffusion and speech language models
- **Zonos** (Other) — open-weight multilingual TTS with emotion and voice cloning
- **DiffSinger** (Other) — shallow-diffusion singing voice synthesis and TTS
- **Descript Audio Codec** (Other) — high-fidelity neural audio codec (~90x compression)

These YAML files were validated locally with `scripts/validate-tool.ts`. Distinct from the existing Descript editor entry (`tools/other/descript.yaml`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Catalog Entries**
  - Added listings for Descript Audio Codec, DiffSinger, F5-TTS, StyleTTS2, and Zonos.
  - Included descriptions, capabilities, use cases, licensing, pricing, supported tags, installation details, and links to project resources.
  - Highlighted applications including audio compression, singing synthesis, natural and multilingual speech generation, voice cloning, speaker adaptation, and text-to-speech experimentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->