### PR TITLE
Add EmotiVoice, edge-tts, SpeechT5 to catalog

### DIFF
--- a/tools/other/edge-tts.yaml
+++ b/tools/other/edge-tts.yaml
@@ -1,0 +1,27 @@
+name: edge-tts
+description: edge-tts is a Python library and CLI that uses Microsoft Edge's online text-to-speech service without Edge, Windows, or an API key. It lists neural voices, writes MP3 plus subtitles, and exposes rate, volume, and pitch controls for scripts and agents.
+tagline: Microsoft Edge neural TTS from Python with no API key
+
+github_url: https://github.com/rany2/edge-tts
+website_url: https://pypi.org/project/edge-tts/
+docs_url: https://github.com/rany2/edge-tts
+
+install_command: pip install edge-tts
+
+category: Other
+tags: [text-to-speech, tts, microsoft, cli, python, speech-synthesis, subtitles, open-source]
+pricing: free
+is_open_source: true
+license: LGPL-3.0
+
+problem_solved: |
+  High-quality neural TTS usually means Azure credentials, a Windows box, or a paid
+  voice API. edge-tts talks to Microsoft Edge's online TTS endpoint from any Python
+  environment so you can list voices, synthesize speech, and write subtitles without
+  an API key or the Edge browser.
+
+use_cases:
+  - Generate MP3 speech plus SRT subtitles from the command line
+  - Add free neural TTS to Python agents, bots, and accessibility tools
+  - Switch among hundreds of Microsoft neural voices by locale and personality
+  - Control speaking rate, volume, and pitch for narration pipelines

--- a/tools/other/emotivoice.yaml
+++ b/tools/other/emotivoice.yaml
@@ -1,0 +1,27 @@
+name: EmotiVoice
+description: EmotiVoice is an open-source English and Chinese text-to-speech engine with over 2,000 voices and prompt-controlled emotional synthesis. Generate happy, sad, angry, or excited speech from a web UI, a batch scripting interface, or an OpenAI-compatible TTS API.
+tagline: Prompt-controlled emotional TTS with 2,000-plus voices
+
+github_url: https://github.com/netease-youdao/EmotiVoice
+website_url: https://github.com/netease-youdao/EmotiVoice
+docs_url: https://github.com/netease-youdao/EmotiVoice/wiki
+
+install_command: pip install emotivoice
+
+category: Other
+tags: [text-to-speech, tts, emotion, multilingual, speech-synthesis, chinese, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Most open TTS engines produce a flat reading voice and struggle with Chinese-English
+  mixing or emotion control. EmotiVoice lets you prompt emotion (happy, excited, sad,
+  angry) across 2,000-plus voices, then generate speech from a web UI, scripts, Docker,
+  or an OpenAI-compatible API without a commercial TTS vendor.
+
+use_cases:
+  - Generate emotional English or Chinese narration for videos, agents, and games
+  - Batch-synthesize speech with a chosen speaker and emotion prompt
+  - Serve local TTS through EmotiVoice's OpenAI-compatible HTTP API
+  - Clone a voice with personal data using the DataBaker or LJSpeech recipes

--- a/tools/other/speecht5.yaml
+++ b/tools/other/speecht5.yaml
@@ -1,0 +1,25 @@
+name: SpeechT5
+description: SpeechT5 is Microsoft's unified-modal encoder-decoder for spoken language processing. One pretrained transformer covers automatic speech recognition, text-to-speech, voice conversion, speech translation, and speaker identification, with official checkpoints on GitHub and Hugging Face.
+tagline: Unified speech-text transformer for ASR, TTS, and translation
+
+github_url: https://github.com/microsoft/SpeechT5
+website_url: https://huggingface.co/blog/speecht5
+docs_url: https://arxiv.org/abs/2110.07205
+
+category: Other
+tags: [speech, tts, asr, voice-conversion, transformer, huggingface, microsoft, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Speech teams often train separate models for recognition, synthesis, translation,
+  and speaker ID. SpeechT5 pretrains a single encoder-decoder on speech and text so
+  you can fine-tune one architecture for ASR, TTS, voice conversion, enhancement,
+  and identification instead of maintaining a stack of unrelated networks.
+
+use_cases:
+  - Fine-tune SpeechT5 for text-to-speech with speaker embeddings on Hugging Face
+  - Run automatic speech recognition from a shared speech-text pretrained checkpoint
+  - Convert one speaker's voice to another with the voice-conversion head
+  - Research unified speech-text pretraining for translation and enhancement


### PR DESCRIPTION
## Summary

Add three speech tools to the Agentic AI For Good catalog:

- **EmotiVoice** (Other) — prompt-controlled emotional TTS with 2,000-plus English and Chinese voices
- **edge-tts** (Other) — Microsoft Edge neural TTS from Python with no API key
- **SpeechT5** (Other) — unified speech-text transformer for ASR, TTS, voice conversion, and translation

YAML files validated locally with `scripts/validate-tool.ts`.
