### PR TITLE
Add PaddleSpeech, Vosk, Biome, SWC, Keycloak to catalog

### DIFF
--- a/tools/dev-tools/biome.yaml
+++ b/tools/dev-tools/biome.yaml
@@ -1,0 +1,27 @@
+name: Biome
+description: Biome is a fast Rust toolchain for web projects that combines a formatter, linter, and more in one tool. It is usable from the CLI and LSP, aims to replace Prettier and ESLint with a single binary, and is designed for large JavaScript and TypeScript codebases.
+tagline: Fast Rust formatter and linter for JavaScript and TypeScript
+
+github_url: https://github.com/biomejs/biome
+website_url: https://biomejs.dev
+docs_url: https://biomejs.dev/guides/getting-started/
+
+install_command: npm install --save-dev --save-exact @biomejs/biome
+
+category: Dev Tools
+tags: [javascript, typescript, linter, formatter, rust, lsp, code-quality, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Front-end teams often run Prettier, ESLint, and several plugins with overlapping
+  configs that slow CI. Biome ships formatter and linter in one Rust binary with
+  CLI and LSP support so JavaScript and TypeScript repos can lint and format
+  without a multi-tool toolchain.
+
+use_cases:
+  - Format and lint JavaScript and TypeScript in a single CI step
+  - Replace Prettier plus ESLint with one dependency in a Next.js or Vite app
+  - Use the Biome LSP for editor diagnostics without a Node plugin stack
+  - Enforce consistent style across monorepos with one config file

--- a/tools/dev-tools/keycloak.yaml
+++ b/tools/dev-tools/keycloak.yaml
@@ -1,0 +1,25 @@
+name: Keycloak
+description: Keycloak is an open-source identity and access management server for modern apps and services. It provides single sign-on, identity brokering, user federation, and standard protocols such as OpenID Connect, OAuth 2.0, and SAML without locking you into a commercial IdP.
+tagline: Open-source SSO and identity management for apps and APIs
+
+github_url: https://github.com/keycloak/keycloak
+website_url: https://www.keycloak.org
+docs_url: https://www.keycloak.org/documentation
+
+category: Dev Tools
+tags: [identity, sso, oauth, oidc, saml, authentication, security, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Product teams often pay a SaaS identity vendor or hand-roll OAuth for every
+  app. Keycloak is a self-hosted IAM server with SSO, social login, user
+  federation, and OpenID Connect so you can protect APIs and agent dashboards
+  without a commercial IdP or custom auth code.
+
+use_cases:
+  - Add single sign-on to internal tools, ML consoles, and customer apps
+  - Broker identity from LDAP, Active Directory, or social providers
+  - Issue OAuth 2.0 and OpenID Connect tokens for microservices and APIs
+  - Self-host authentication instead of depending on a commercial IdP

--- a/tools/dev-tools/swc.yaml
+++ b/tools/dev-tools/swc.yaml
@@ -1,0 +1,27 @@
+name: SWC
+description: SWC is a Rust-based platform for the web that compiles, minifies, and bundles JavaScript and TypeScript far faster than Babel. It powers Next.js transforms and is available as @swc/core for Node and as a standalone CLI for production front-end builds.
+tagline: Rust compiler and minifier that replaces Babel for JS and TS
+
+github_url: https://github.com/swc-project/swc
+website_url: https://swc.rs
+docs_url: https://swc.rs/docs/getting-started
+
+install_command: npm install @swc/core
+
+category: Dev Tools
+tags: [javascript, typescript, compiler, rust, babel, nextjs, bundler, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Babel transforms are a common bottleneck in large JS and TS builds. SWC
+  implements compilation, minification, and bundling in Rust so Next.js and
+  other toolchains can transpile TypeScript and modern JavaScript in a fraction
+  of Babel's time without changing the source language.
+
+use_cases:
+  - Speed up Next.js and custom bundler transforms with @swc/core
+  - Minify production JavaScript with a Rust minifier instead of Terser
+  - Compile TypeScript in CI without a slower Babel pipeline
+  - Embed SWC in Node tooling for custom transpilers and code mods

--- a/tools/other/paddlespeech.yaml
+++ b/tools/other/paddlespeech.yaml
@@ -1,0 +1,27 @@
+name: PaddleSpeech
+description: PaddleSpeech is Baidu's open-source speech toolkit covering self-supervised models, streaming ASR with punctuation, streaming TTS, speaker verification, speech translation, and keyword spotting. It won the NAACL 2022 Best Demo Award and ships pretrained models plus a Python API.
+tagline: All-in-one streaming ASR, TTS, and speaker toolkit
+
+github_url: https://github.com/PaddlePaddle/PaddleSpeech
+website_url: https://paddlespeech.readthedocs.io
+docs_url: https://paddlespeech.readthedocs.io
+
+install_command: pip install paddlespeech
+
+category: Other
+tags: [speech, asr, tts, speaker-verification, translation, paddlepaddle, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Shipping speech features usually means wiring separate ASR, TTS, and speaker
+  stacks. PaddleSpeech puts streaming recognition, synthesis, verification,
+  translation, and keyword spotting in one PaddlePaddle toolkit so you can
+  prototype and serve multilingual speech pipelines from a single Python API.
+
+use_cases:
+  - Run streaming ASR with punctuation for live captions and voice agents
+  - Generate streaming TTS with a text frontend for assistants and IVR
+  - Verify speakers or spot keywords in call-center and security audio
+  - Fine-tune speech translation models on custom language pairs

--- a/tools/other/vosk.yaml
+++ b/tools/other/vosk.yaml
@@ -1,0 +1,27 @@
+name: Vosk
+description: Vosk is an offline speech recognition API for Android, iOS, Raspberry Pi, and servers. It runs without a network connection, supports 20-plus languages, and exposes Python, Java, C#, and Node bindings so you can add on-device ASR to apps and agents.
+tagline: Offline multilingual speech recognition for devices and servers
+
+github_url: https://github.com/alphacep/vosk-api
+website_url: https://alphacephei.com/vosk/
+docs_url: https://alphacephei.com/vosk/install
+
+install_command: pip install vosk
+
+category: Other
+tags: [speech-recognition, asr, offline, on-device, python, android, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Cloud ASR APIs need a network link, send audio off-device, and cost per minute.
+  Vosk runs compact models locally on phones, Raspberry Pi, and servers so you
+  can transcribe speech in 20-plus languages with no API key and no audio leaving
+  the device.
+
+use_cases:
+  - Add offline speech-to-text to mobile and IoT applications
+  - Transcribe meetings or commands on a Raspberry Pi without internet
+  - Build privacy-preserving voice agents that never send audio to the cloud
+  - Integrate ASR from Python, Java, C#, or Node with the same model files


### PR DESCRIPTION
## Summary

Add five tools to the Agentic AI For Good catalog:

- **PaddleSpeech** (Other) — streaming ASR, TTS, speaker verification, and speech translation toolkit
- **Vosk** (Other) — offline multilingual speech recognition for devices and servers
- **Biome** (Dev Tools) — fast Rust formatter and linter for JavaScript and TypeScript
- **SWC** (Dev Tools) — Rust compiler and minifier that replaces Babel for JS and TS
- **Keycloak** (Dev Tools) — open-source SSO and identity management server

YAML files validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Biome, Keycloak, and SWC, including descriptions, links, licensing, installation details, and use cases.
  * Added catalog entries for PaddleSpeech and Vosk, documenting speech recognition, synthesis, translation, and related capabilities.
  * Expanded developer-tool and other-tool discovery with searchable metadata and categorized use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->