### PR TITLE
Add bat, starship, zoxide to catalog

### DIFF
--- a/tools/dev-tools/bat.yaml
+++ b/tools/dev-tools/bat.yaml
@@ -1,0 +1,26 @@
+name: bat
+description: bat is a cat(1) clone with syntax highlighting and Git integration. It pages output, shows line numbers, highlights code in many languages, and marks uncommitted changes so you can read source, configs, and logs more clearly than with plain cat.
+tagline: cat clone with syntax highlighting and Git integration
+
+github_url: https://github.com/sharkdp/bat
+website_url: https://github.com/sharkdp/bat
+docs_url: https://github.com/sharkdp/bat#readme
+
+install_command: brew install bat
+
+category: Dev Tools
+tags: [cli, cat, syntax-highlighting, git, rust, terminal, developer-tools, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Reading source and logs with cat dumps unformatted text into the terminal.
+  bat adds syntax highlighting, Git change markers, line numbers, and paging
+  so developers can inspect files quickly without opening an editor.
+
+use_cases:
+  - Preview source files with syntax highlighting in the terminal
+  - Use bat as an fzf previewer for interactive file search
+  - Review Git-modified files with change markers beside each line
+  - Replace cat in shell aliases for logs, configs, and Markdown

--- a/tools/dev-tools/starship.yaml
+++ b/tools/dev-tools/starship.yaml
@@ -1,0 +1,27 @@
+name: starship
+description: Starship is a fast, customizable prompt for any shell. Written in Rust, it shows Git status, language toolchains, cloud context, and command duration out of the box, and works with Bash, Zsh, Fish, PowerShell, and more from a single TOML config.
+tagline: Minimal, fast, customizable prompt for any shell
+
+github_url: https://github.com/starship/starship
+website_url: https://starship.rs
+docs_url: https://starship.rs/guide/
+
+install_command: brew install starship
+
+category: Dev Tools
+tags: [shell, prompt, rust, cli, git, terminal, developer-tools, open-source]
+pricing: free
+is_open_source: true
+license: ISC
+
+problem_solved: |
+  Default shell prompts hide Git branch, runtime versions, and error status
+  unless you maintain a heavy theme. Starship is a single Rust binary that
+  drops into any shell and shows repo, toolchain, and duration context from
+  one TOML file.
+
+use_cases:
+  - Show Git branch, dirty state, and language versions in the prompt
+  - Share one prompt config across Bash, Zsh, Fish, and PowerShell
+  - Speed up prompt rendering versus slow Python or shell themes
+  - Surface Kubernetes, AWS, and Python venv context while working

--- a/tools/dev-tools/zoxide.yaml
+++ b/tools/dev-tools/zoxide.yaml
@@ -1,0 +1,27 @@
+name: zoxide
+description: zoxide is a smarter cd command inspired by z and autojump. It ranks directories by how often and how recently you use them so you can jump with a few keystrokes, and it works in Bash, Zsh, Fish, PowerShell, and other major shells.
+tagline: Smarter cd that jumps to frequent directories
+
+github_url: https://github.com/ajeetdsouza/zoxide
+website_url: https://github.com/ajeetdsouza/zoxide
+docs_url: https://github.com/ajeetdsouza/zoxide#getting-started
+
+install_command: brew install zoxide
+
+category: Dev Tools
+tags: [cli, cd, navigation, shell, rust, fzf, developer-tools, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Jumping between deep project trees with cd means typing long paths or
+  maintaining aliases. zoxide remembers frequent directories and matches
+  fuzzy queries so you can move around a monorepo or ML workspace in a few
+  keystrokes, with optional fzf interactive selection.
+
+use_cases:
+  - Jump to ranked project directories with z instead of full paths
+  - Interactively pick a directory with zi and fzf
+  - Share the same jumper across Bash, Zsh, Fish, and PowerShell
+  - Navigate large monorepos and dataset folders from the terminal


### PR DESCRIPTION
## Summary

Add three developer CLI tools to the Agentic AI For Good catalog:

- **bat** (Dev Tools) — cat clone with syntax highlighting and Git integration
- **starship** (Dev Tools) — fast, customizable prompt for any shell
- **zoxide** (Dev Tools) — smarter cd that jumps to frequent directories

YAML files validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for bat, Starship, and zoxide.
  * Included descriptions, installation instructions, documentation links, licensing and pricing details, categories, tags, and practical use cases.
  * Documented features such as syntax highlighting, customizable shell prompts, and ranked directory navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->