### PR TITLE
Add fd, eza, atuin, direnv, just to catalog

### DIFF
--- a/tools/dev-tools/atuin.yaml
+++ b/tools/dev-tools/atuin.yaml
@@ -1,0 +1,27 @@
+name: atuin
+description: Magical shell history. Atuin replaces your shell history with a SQLite database, encrypted sync across machines, and a fuzzy search TUI so you can recall commands, filter by directory or exit code, and share history without leaking secrets.
+tagline: Magical, searchable, syncable shell history
+
+github_url: https://github.com/atuinsh/atuin
+website_url: https://atuin.sh
+docs_url: https://docs.atuin.sh
+
+install_command: brew install atuin
+
+category: Dev Tools
+tags: [cli, shell, history, rust, sync, developer-tools, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Default shell history is a short, unsearchable file that does not sync across
+  laptops and mixes secrets with useful commands. Atuin stores history in SQLite,
+  encrypts optional cloud or self-hosted sync, and lets you search by cwd, exit
+  code, or host so training and deploy commands are recoverable.
+
+use_cases:
+  - Fuzzy-search last week's training or docker commands from any machine
+  - Sync encrypted shell history across a laptop and a GPU workstation
+  - Filter history to the current project directory or failed commands only
+  - Replace Ctrl-R with a TUI that shows context, duration, and exit status

--- a/tools/dev-tools/direnv.yaml
+++ b/tools/dev-tools/direnv.yaml
@@ -1,0 +1,27 @@
+name: direnv
+description: direnv loads and unloads environment variables as you cd into a directory. A .envrc file can export API keys, Python venvs, and CUDA paths for a project, then wipe them when you leave so your shell stays uncluttered.
+tagline: Per-directory environment variables for your shell
+
+github_url: https://github.com/direnv/direnv
+website_url: https://direnv.net
+docs_url: https://direnv.net
+
+install_command: brew install direnv
+
+category: Dev Tools
+tags: [cli, environment, shell, golang, secrets, developer-tools, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Global .profile files accumulate API keys, CUDA paths, and venv activations
+  that leak across projects. direnv evaluates a per-directory .envrc on cd and
+  unloads it when you leave, so each ML repo gets the right Python, keys, and
+  tool versions without polluting the rest of your shell.
+
+use_cases:
+  - Auto-activate a project Python venv and CUDA toolkit when you enter the repo
+  - Load OPENAI_API_KEY and other secrets only inside a trusted project directory
+  - Switch NODE_ENV, AWS profiles, or kube contexts per folder without aliases
+  - Keep a clean shell when hopping between client and open-source codebases

--- a/tools/dev-tools/eza.yaml
+++ b/tools/dev-tools/eza.yaml
@@ -1,0 +1,27 @@
+name: eza
+description: A modern, maintained replacement for ls. eza lists files with Git status, icons, tree views, and human-readable sizes, giving ML and infra teams a faster, more informative directory listing than classic ls.
+tagline: Modern ls with Git status and tree view
+
+github_url: https://github.com/eza-community/eza
+website_url: https://eza.rocks
+docs_url: https://github.com/eza-community/eza#readme
+
+install_command: brew install eza
+
+category: Dev Tools
+tags: [cli, ls, rust, git, filesystem, developer-tools, open-source]
+pricing: free
+is_open_source: true
+license: EUPL-1.2
+
+problem_solved: |
+  Plain ls shows names and little else, so you bounce to git status or du to
+  understand a directory. eza adds Git change markers, file types, tree output,
+  and readable sizes in one listing, which makes inspecting experiment dirs,
+  model artifacts, and project trees faster.
+
+use_cases:
+  - List experiment directories with Git status next to each file
+  - Tree-view a dataset or checkpoint folder without installing a separate tree tool
+  - Alias ls to eza for human-readable sizes and icons in daily terminal work
+  - Inspect large artifact trees before uploading them to object storage

--- a/tools/dev-tools/fd.yaml
+++ b/tools/dev-tools/fd.yaml
@@ -1,0 +1,27 @@
+name: fd
+description: A simple, fast, and user-friendly alternative to find. fd uses sensible defaults, colorized output, and a concise syntax so you can search files by name without fighting find flags, while ignoring hidden files and gitignored paths by default.
+tagline: Fast, user-friendly find alternative
+
+github_url: https://github.com/sharkdp/fd
+website_url: https://github.com/sharkdp/fd
+docs_url: https://github.com/sharkdp/fd#readme
+
+install_command: brew install fd
+
+category: Dev Tools
+tags: [cli, find, search, rust, filesystem, developer-tools, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Classic find is powerful but verbose, slow on large trees, and easy to misuse.
+  fd gives a short, regex-friendly syntax, parallel search, and safe defaults
+  (skips hidden and gitignored files) so developers can locate datasets, configs,
+  and source files in ML repos without writing a find incantation.
+
+use_cases:
+  - Find training data, checkpoints, or config files by name in a large repo
+  - Locate source files with a regex while automatically skipping .git and node_modules
+  - Pipe matched paths into xargs, fzf, or a preprocessing script
+  - Replace find in shell aliases for everyday file discovery

--- a/tools/dev-tools/just.yaml
+++ b/tools/dev-tools/just.yaml
@@ -1,0 +1,28 @@
+name: just
+description: A command runner for project-specific tasks. just reads a justfile of recipes and runs them with a Make-like syntax that is easier to write, so teams can share build, test, and data-pipeline commands without Make's quirks.
+tagline: Handy command runner for project recipes
+
+github_url: https://github.com/casey/just
+website_url: https://just.systems
+docs_url: https://just.systems/man/en/
+
+install_command: brew install just
+
+category: Dev Tools
+tags: [cli, task-runner, rust, makefile, developer-tools, open-source]
+pricing: free
+is_open_source: true
+license: CC0-1.0
+
+problem_solved: |
+  Makefiles are the default way to share project commands, but Make's syntax
+  (tabs, implicit rules, phony targets) fights simple scripts. just gives a
+  readable justfile of named recipes with arguments, dotenv loading, and
+  cross-platform shebang recipes so ML teams can run train, lint, and sync
+  commands the same way on every machine.
+
+use_cases:
+  - Define just train, just eval, and just sync recipes for an ML project
+  - Replace a tangle of npm scripts and Makefiles with one justfile
+  - Pass arguments to recipes for dataset paths or model checkpoints
+  - Share onboarding commands (setup, test, fmt) without documenting a wiki


### PR DESCRIPTION
## Add CLI developer tools to the catalog

Five high-star terminal tools used daily in ML and agent engineering workflows:

| Tool | Category | Repo | Stars |
|------|----------|------|------:|
| fd | Dev Tools | [sharkdp/fd](https://github.com/sharkdp/fd) | 44k |
| eza | Dev Tools | [eza-community/eza](https://github.com/eza-community/eza) | 23k |
| atuin | Dev Tools | [atuinsh/atuin](https://github.com/atuinsh/atuin) | 31k |
| direnv | Dev Tools | [direnv/direnv](https://github.com/direnv/direnv) | 15k |
| just | Dev Tools | [casey/just](https://github.com/casey/just) | 35k |

- YAML validated locally with `npx tsx scripts/validate-tool.ts`
- Open source, brew-installable, not already in the catalog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for five developer tools: Atuin, direnv, eza, fd, and just.
  * Included descriptions, tags, categories, licensing, pricing, installation commands, project links, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->