### PR TITLE
Add mise, btop, hyperfine, Chonkie, nano-graphrag to catalog

### DIFF
--- a/tools/dev-tools/btop.yaml
+++ b/tools/dev-tools/btop.yaml
@@ -1,0 +1,27 @@
+name: btop
+description: A resource monitor for the terminal. btop shows CPU, memory, disks, network, and processes with a mouse-friendly TUI, so you can watch GPU hosts and training boxes without leaving SSH.
+tagline: Terminal resource monitor with a full TUI
+
+github_url: https://github.com/aristocratos/btop
+website_url: https://github.com/aristocratos/btop
+docs_url: https://github.com/aristocratos/btop#readme
+
+install_command: brew install btop
+
+category: Dev Tools
+tags: [cli, monitoring, tui, cpp, processes, developer-tools, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  top and htop show processes but bury disks, network, and at-a-glance load.
+  btop packs CPU, memory, disks, network, and a filterable process list into
+  one mouse-aware TUI, which makes spotting a runaway training job or a full
+  disk on a remote GPU box faster than hopping between tools.
+
+use_cases:
+  - Watch CPU, RAM, and disk while a local training job is running
+  - SSH into a workstation and filter processes that are eating memory
+  - Spot network or disk saturation during dataset downloads
+  - Replace htop with a denser, mouse-friendly resource dashboard

--- a/tools/dev-tools/hyperfine.yaml
+++ b/tools/dev-tools/hyperfine.yaml
@@ -1,0 +1,27 @@
+name: hyperfine
+description: A command-line benchmarking tool. hyperfine runs a command many times, warms caches, and reports mean, min, and max with statistical comparisons so you can measure inference scripts, data pipelines, and CLI tools fairly.
+tagline: Command-line benchmarking with statistical output
+
+github_url: https://github.com/sharkdp/hyperfine
+website_url: https://github.com/sharkdp/hyperfine
+docs_url: https://github.com/sharkdp/hyperfine#readme
+
+install_command: brew install hyperfine
+
+category: Dev Tools
+tags: [cli, benchmark, rust, performance, developer-tools, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Timing a script with time once is noisy and hides warmup effects. hyperfine
+  runs commands repeatedly, discards warmup, and compares alternatives with
+  confidence intervals, so you can tell whether a new tokenizer, chunker, or
+  CLI flag actually sped things up.
+
+use_cases:
+  - Compare two data-preprocessing scripts with warmup and multiple runs
+  - Benchmark an inference CLI before and after a model or flag change
+  - Measure install or test commands across machines with exportable results
+  - A/B test grep replacements, chunkers, or compression tools from the shell

--- a/tools/dev-tools/mise.yaml
+++ b/tools/dev-tools/mise.yaml
@@ -1,0 +1,27 @@
+name: mise
+description: Polyglot runtime and env manager (formerly rtx). mise installs language versions, sets per-project env vars, and runs tasks from one TOML config so ML and app teams can replace asdf, nvm, pyenv, and direnv with a single faster tool.
+tagline: Dev tools, env vars, and task runner in one
+
+github_url: https://github.com/jdx/mise
+website_url: https://mise.jdx.dev
+docs_url: https://mise.jdx.dev
+
+install_command: brew install mise
+
+category: Dev Tools
+tags: [cli, version-manager, asdf, rust, environment, developer-tools, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Teams juggle asdf, nvm, pyenv, and direnv to pin Node, Python, and CUDA-adjacent
+  toolchains per repo. mise is a fast asdf-compatible manager that also handles
+  env vars and tasks, so a mise.toml can install the right runtimes and export
+  keys without a stack of shell plugins.
+
+use_cases:
+  - Pin Python, Node, and Go versions for an ML repo in one mise.toml
+  - Replace asdf plus direnv with a single faster toolchain manager
+  - Run project tasks (test, lint, train) defined next to runtime pins
+  - Share reproducible developer setups across laptops and CI

--- a/tools/rag/chonkie.yaml
+++ b/tools/rag/chonkie.yaml
@@ -1,0 +1,27 @@
+name: Chonkie
+description: A lightweight document chunking library for RAG. Chonkie splits text with token-aware, semantic, and late-chunking strategies so pipelines get consistent chunks without pulling in a heavy ingestion framework.
+tagline: Fast, lightweight chunking for RAG pipelines
+
+github_url: https://github.com/feyninc/chonkie
+website_url: https://docs.chonkie.ai
+docs_url: https://docs.chonkie.ai
+
+install_command: pip install chonkie
+
+category: RAG
+tags: [python, rag, chunking, ingestion, embeddings, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  RAG quality often dies at chunking, and teams either hand-roll splitters or
+  import a full ingestion stack. Chonkie is a small library of token, sentence,
+  semantic, and late chunkers with a consistent API, so you can swap strategies
+  and feed a vector store without a heavy pipeline framework.
+
+use_cases:
+  - Token-aware chunk PDFs and markdown before embedding for RAG
+  - Try semantic or late chunking without rewriting the rest of the pipeline
+  - Keep ingestion light in a custom RAG service that already has a vector DB
+  - Benchmark chunkers with hyperfine or evals before locking a split strategy

--- a/tools/rag/nano-graphrag.yaml
+++ b/tools/rag/nano-graphrag.yaml
@@ -1,0 +1,27 @@
+name: nano-graphrag
+description: A small, easy-to-hack GraphRAG implementation. nano-graphrag builds entity graphs and community summaries from documents with a few hundred lines of readable Python, so you can learn or customize graph RAG without Microsoft GraphRAG's full stack.
+tagline: Minimal, hackable GraphRAG in a few hundred lines
+
+github_url: https://github.com/gusye1234/nano-graphrag
+website_url: https://github.com/gusye1234/nano-graphrag
+docs_url: https://github.com/gusye1234/nano-graphrag#readme
+
+install_command: pip install nano-graphrag
+
+category: RAG
+tags: [python, rag, graph-rag, knowledge-graph, research, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Microsoft GraphRAG is powerful but heavy to read, deploy, and fork. nano-graphrag
+  reimplements the core insert and query loop (entities, communities, local and
+  global search) in a compact codebase so researchers and product teams can
+  understand graph RAG and swap LLMs, stores, or prompts without a large platform.
+
+use_cases:
+  - Prototype graph RAG on a private corpus without standing up the full GraphRAG stack
+  - Teach or study entity extraction and community summaries from a short Python core
+  - Fork the insert and query loop to plug in a custom LLM or vector store
+  - Compare graph RAG answers with vector-only retrieval on the same documents


### PR DESCRIPTION
## Add mise, btop, hyperfine, Chonkie, nano-graphrag to catalog

| Tool | Category | Repo | Stars |
|------|----------|------|------:|
| mise | Dev Tools | [jdx/mise](https://github.com/jdx/mise) | 33k |
| btop | Dev Tools | [aristocratos/btop](https://github.com/aristocratos/btop) | 34k |
| hyperfine | Dev Tools | [sharkdp/hyperfine](https://github.com/sharkdp/hyperfine) | 28k |
| Chonkie | RAG | [feyninc/chonkie](https://github.com/feyninc/chonkie) | 4.7k |
| nano-graphrag | RAG | [gusye1234/nano-graphrag](https://github.com/gusye1234/nano-graphrag) | 4.0k |

- YAML validated locally
- nano-graphrag is a distinct compact GraphRAG implementation, not a Microsoft GraphRAG variant
- Chonkie install verified on PyPI (`pip install chonkie`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for three developer tools: btop, hyperfine, and mise.
  * Added catalog entries for two RAG tools: Chonkie and nano-graphrag.
  * Included descriptions, installation instructions, links, licensing details, tags, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->