### PR TITLE
Add Model2Vec, WordLlama, UForm, GPT-NeoX, TorchTitan to catalog

### DIFF
--- a/tools/fine-tuning/gpt-neox.yaml
+++ b/tools/fine-tuning/gpt-neox.yaml
@@ -1,0 +1,25 @@
+name: GPT-NeoX
+description: EleutherAI's library for training large autoregressive transformers on GPUs. GPT-NeoX combines Megatron-LM style model parallelism with DeepSpeed to train GPT-scale models, and it is the codebase behind GPT-NeoX-20B.
+tagline: Megatron plus DeepSpeed for large transformer training
+
+github_url: https://github.com/EleutherAI/gpt-neox
+website_url: https://www.eleuther.ai/
+docs_url: https://github.com/EleutherAI/gpt-neox#readme
+
+category: Fine-tuning
+tags: [python, training, megatron, deepspeed, gpt, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Training GPT-scale models needs tensor and pipeline parallelism that a
+  plain PyTorch loop does not provide. GPT-NeoX packages Megatron-style
+  parallelism with DeepSpeed so research labs can train and continue
+  pretraining large autoregressive models on multi-GPU clusters.
+
+use_cases:
+  - Pretrain or continue-pretrain a GPT-style model on a GPU cluster
+  - Study model-parallel training configs used for GPT-NeoX-20B
+  - Fine-tune a large decoder model with DeepSpeed ZeRO and Megatron splits
+  - Benchmark multi-GPU training throughput before moving to a custom trainer

--- a/tools/fine-tuning/torchtitan.yaml
+++ b/tools/fine-tuning/torchtitan.yaml
@@ -1,0 +1,28 @@
+name: TorchTitan
+description: A PyTorch-native platform for training generative AI models. TorchTitan is Meta's 4D-parallel (data, tensor, pipeline, context) trainer for large transformers, with Llama recipes and composable parallelism instead of a Megatron fork.
+tagline: PyTorch-native large-scale generative model training
+
+github_url: https://github.com/pytorch/torchtitan
+website_url: https://github.com/pytorch/torchtitan
+docs_url: https://github.com/pytorch/torchtitan#readme
+
+install_command: pip install torchtitan
+
+category: Fine-tuning
+tags: [python, pytorch, training, llama, distributed, open-source]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Many large-model trainers are Megatron forks that drift from upstream
+  PyTorch. TorchTitan trains generative models with native PyTorch
+  distributed APIs (FSDP, tensor, pipeline, context parallel) so teams can
+  scale Llama-class pretraining and finetuning without leaving the PyTorch
+  ecosystem.
+
+use_cases:
+  - Pretrain or finetune Llama-class models with 4D parallelism
+  - Experiment with FSDP2, tensor parallel, and pipeline parallel in one trainer
+  - Adopt Meta's PyTorch-native recipes instead of a Megatron fork
+  - Benchmark multi-node generative training on a GPU cluster

--- a/tools/rag/model2vec.yaml
+++ b/tools/rag/model2vec.yaml
@@ -1,0 +1,27 @@
+name: Model2Vec
+description: Distill a sentence transformer into static embeddings that stay strong on retrieval. Model2Vec trains tiny, fast vectors you can load without a GPU, so RAG and classification pipelines get transformer-quality embeddings at a fraction of the cost.
+tagline: Distill sentence transformers into static embeddings
+
+github_url: https://github.com/MinishLab/model2vec
+website_url: https://minish.ai/packages/model2vec/introduction
+docs_url: https://github.com/MinishLab/model2vec#readme
+
+install_command: pip install model2vec
+
+category: RAG
+tags: [python, embeddings, rag, distillation, sentence-transformers, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Sentence transformers are accurate but heavy to serve for every query.
+  Model2Vec distills them into static token embeddings that average into a
+  sentence vector, cutting latency and GPU cost while keeping enough quality
+  for search, clustering, and classification.
+
+use_cases:
+  - Serve fast static embeddings for RAG retrieval without a GPU
+  - Distill a domain sentence transformer into a tiny production model
+  - Cluster or classify large document sets cheaper than full transformers
+  - Swap a slow embedding endpoint for Model2Vec in a latency-sensitive search path

--- a/tools/rag/uform.yaml
+++ b/tools/rag/uform.yaml
@@ -1,0 +1,27 @@
+name: UForm
+description: Pocket-sized multimodal AI for understanding text and images. UForm ships tiny CLIP-like encoders that run on CPU and edge devices, up to several times faster than OpenAI CLIP, for multilingual search and retrieval.
+tagline: Tiny multimodal embeddings for text and images
+
+github_url: https://github.com/unum-cloud/UForm
+website_url: https://unum-cloud.github.io/UForm
+docs_url: https://unum-cloud.github.io/UForm
+
+install_command: pip install uform
+
+category: RAG
+tags: [python, embeddings, multimodal, clip, rag, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  CLIP-class models are too large for many CPU and edge retrieval setups.
+  UForm provides compact multimodal encoders for text and images so you can
+  build multilingual visual search and RAG over screenshots, product photos,
+  and captions without a GPU.
+
+use_cases:
+  - Embed product images and captions into one space for visual search
+  - Run multilingual image-text retrieval on CPU or edge hardware
+  - Index screenshots and UI images for multimodal RAG
+  - Replace a heavy CLIP checkpoint with a smaller UForm encoder

--- a/tools/rag/wordllama.yaml
+++ b/tools/rag/wordllama.yaml
@@ -1,0 +1,27 @@
+name: WordLlama
+description: Things you can do with LLM token embeddings. WordLlama extracts and recycles tokenizer embeddings from models like Llama into a tiny embedding space for cheap similarity, clustering, and lightweight RAG without running the full LLM.
+tagline: Cheap embeddings from LLM tokenizer weights
+
+github_url: https://github.com/dleemiller/WordLlama
+website_url: https://github.com/dleemiller/WordLlama
+docs_url: https://github.com/dleemiller/WordLlama#readme
+
+install_command: pip install wordllama
+
+category: RAG
+tags: [python, embeddings, rag, llama, tokenizer, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Many teams need decent text similarity but cannot afford a GPU embedding
+  model on every request. WordLlama reuses the token embedding table of an
+  LLM as a small, CPU-friendly embedding model for clustering, reranking, and
+  lightweight retrieval.
+
+use_cases:
+  - Embed queries and docs on CPU for a small RAG index
+  - Cluster support tickets or papers without a sentence-transformer GPU
+  - Prototype similarity search before paying for a hosted embedding API
+  - Deduplicate or fuzzy-match strings using Llama tokenizer embeddings


### PR DESCRIPTION
## Add Model2Vec, WordLlama, UForm, GPT-NeoX, TorchTitan to catalog

| Tool | Category | Repo | Stars |
|------|----------|------|------:|
| Model2Vec | RAG | [MinishLab/model2vec](https://github.com/MinishLab/model2vec) | 2.2k |
| WordLlama | RAG | [dleemiller/WordLlama](https://github.com/dleemiller/WordLlama) | 1.5k |
| UForm | RAG | [unum-cloud/UForm](https://github.com/unum-cloud/UForm) | 1.2k |
| GPT-NeoX | Fine-tuning | [EleutherAI/gpt-neox](https://github.com/EleutherAI/gpt-neox) | 7.5k |
| TorchTitan | Fine-tuning | [pytorch/torchtitan](https://github.com/pytorch/torchtitan) | 5.7k |

- YAML validated locally
- GPT-NeoX has no pip package (cluster training codebase); install_command omitted
- WordLlama, Model2Vec, UForm, TorchTitan verified on PyPI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPT-NeoX and TorchTitan to the fine-tuning tool catalog.
  * Added Model2Vec, UForm, and WordLlama to the retrieval-augmented generation catalog.
  * Added descriptions, use cases, installation details, links, categories, tags, pricing, and licensing information for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->