### PR TITLE
Add FairScale, MaxText, GaLore, EasyLM to catalog

### DIFF
--- a/tools/fine-tuning/easylm.yaml
+++ b/tools/fine-tuning/easylm.yaml
@@ -1,0 +1,25 @@
+name: EasyLM
+description: One-stop JAX/Flax tooling for pretraining, finetuning, evaluating, and serving LLMs. EasyLM wraps large models (LLaMA and friends) with simple scripts so you can run the full lifecycle without assembling a custom JAX stack.
+tagline: JAX/Flax pretrain, finetune, eval, and serve for LLMs
+
+github_url: https://github.com/young-geng/EasyLM
+website_url: https://github.com/young-geng/EasyLM
+docs_url: https://github.com/young-geng/EasyLM#readme
+
+category: Fine-tuning
+tags: [python, jax, flax, llama, training, serving, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  JAX LLM work usually means gluing training, checkpoint conversion, eval,
+  and serving yourself. EasyLM packages those steps for LLaMA-class models
+  so a small team can pretrain or finetune in Flax and serve the result
+  without a Megatron or Hugging Face Trainer rewrite.
+
+use_cases:
+  - Finetune a LLaMA-class model in JAX/Flax with published scripts
+  - Convert and serve a JAX checkpoint after pretraining
+  - Evaluate generated text without leaving the EasyLM workflow
+  - Prototype JAX training on TPU or GPU before moving to MaxText

--- a/tools/fine-tuning/fairscale.yaml
+++ b/tools/fine-tuning/fairscale.yaml
@@ -1,0 +1,27 @@
+name: FairScale
+description: PyTorch extensions for high-performance, large-scale training. FairScale adds FSDP, pipeline parallel, and optimizer sharding so you can train bigger models on the GPUs you already have without rewriting the training loop from scratch.
+tagline: PyTorch extensions for large-scale training
+
+github_url: https://github.com/facebookresearch/fairscale
+website_url: https://github.com/facebookresearch/fairscale
+docs_url: https://fairscale.readthedocs.io
+
+install_command: pip install fairscale
+
+category: Fine-tuning
+tags: [python, pytorch, fsdp, distributed, training, open-source]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Fitting large models on limited GPUs needs sharding that vanilla PyTorch
+  used to leave to research forks. FairScale brought FSDP, pipeline
+  parallel, and ZeRO-style optimizer sharding into reusable PyTorch APIs so
+  teams can scale training without a full Megatron stack.
+
+use_cases:
+  - Wrap a PyTorch model in FSDP to shard parameters across GPUs
+  - Pipeline-parallel a deep transformer when a single GPU cannot hold it
+  - Shard optimizer state to cut peak memory during LLM finetuning
+  - Prototype distributed training before moving to TorchTitan or Megatron

--- a/tools/fine-tuning/galore.yaml
+++ b/tools/fine-tuning/galore.yaml
@@ -1,0 +1,27 @@
+name: GaLore
+description: Memory-efficient LLM training via Gradient Low-Rank Projection. GaLore projects gradients into a compact subspace during Adam-style updates so you can train or finetune large models with far less optimizer memory.
+tagline: Low-rank gradient projections for cheaper LLM training
+
+github_url: https://github.com/jiaweizzhao/GaLore
+website_url: https://github.com/jiaweizzhao/GaLore
+docs_url: https://github.com/jiaweizzhao/GaLore#readme
+
+install_command: pip install galore-torch
+
+category: Fine-tuning
+tags: [python, pytorch, optimizer, lora, memory, training, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AdamW stores optimizer states that dwarf the model weights, so full
+  finetuning OOMs on a single GPU. GaLore projects gradients to a low-rank
+  subspace, cutting optimizer memory while staying closer to full-rank
+  training than parameter-efficient adapters alone.
+
+use_cases:
+  - Full-parameter finetune a 7B model on fewer GPUs by shrinking optimizer state
+  - Combine GaLore with 8-bit optimizers for even tighter memory budgets
+  - Compare GaLore against LoRA on the same downstream task
+  - Train larger models on a workstation that previously only fit LoRA

--- a/tools/fine-tuning/maxtext.yaml
+++ b/tools/fine-tuning/maxtext.yaml
@@ -1,0 +1,26 @@
+name: MaxText
+description: A simple, performant, scalable JAX LLM trainer from Google. MaxText trains decoder-only transformers on TPUs and GPUs with well-tuned configs, aimed at high MFU rather than a kitchen-sink research framework.
+tagline: Simple, scalable JAX LLM training
+
+github_url: https://github.com/AI-Hypercomputer/maxtext
+website_url: https://maxtext.readthedocs.io
+docs_url: https://maxtext.readthedocs.io
+
+category: Fine-tuning
+tags: [python, jax, tpu, llm, training, google, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  JAX LLM training stacks are often research mazes with poor out-of-box
+  throughput. MaxText is a relatively small, config-driven trainer tuned
+  for high model-flop utilization on Cloud TPU and GPU, so labs can
+  pretrain or finetune decoder models without assembling Pax and MaxText
+  forks themselves.
+
+use_cases:
+  - Pretrain a decoder LLM on Cloud TPU with a documented high-MFU config
+  - Finetune a JAX transformer without standing up a full Pax stack
+  - Compare TPU training efficiency against a PyTorch trainer on the same model
+  - Fork a compact JAX trainer to test architecture or data changes


### PR DESCRIPTION
## Add FairScale, MaxText, GaLore, EasyLM to catalog

| Tool | Category | Repo | Stars |
|------|----------|------|------:|
| FairScale | Fine-tuning | [facebookresearch/fairscale](https://github.com/facebookresearch/fairscale) | 3.4k |
| MaxText | Fine-tuning | [AI-Hypercomputer/maxtext](https://github.com/AI-Hypercomputer/maxtext) | 2.4k |
| GaLore | Fine-tuning | [jiaweizzhao/GaLore](https://github.com/jiaweizzhao/GaLore) | 1.7k |
| EasyLM | Fine-tuning | [young-geng/EasyLM](https://github.com/young-geng/EasyLM) | 2.5k |

- YAML validated locally
- Fairseq was in this tracker batch but skipped (`facebookresearch/fairseq` is archived)
- GaLore install is `pip install galore-torch` (the `galore` PyPI package is unrelated)
- MaxText and EasyLM have no pip package; install_command omitted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for EasyLM, FairScale, GaLore, and MaxText.
  - Included descriptions, links, installation details, licensing, pricing, supported technologies, and use cases.
  - Highlighted capabilities including LLM pretraining and fine-tuning, distributed training, memory-efficient optimization, checkpoint conversion, evaluation, and model serving.
  - Added guidance for workflows such as full-parameter fine-tuning, optimizer sharding, pipeline parallelism, and training larger models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->