### PR TITLE
Add PowerInfer, Mooncake, Text Embeddings Inference, NVIDIA Dynamo, Google ADK to catalog

### DIFF
--- a/tools/agent-frameworks/google-adk.yaml
+++ b/tools/agent-frameworks/google-adk.yaml
@@ -1,0 +1,27 @@
+name: Google ADK
+description: Google's open-source, code-first Agent Development Kit for building, evaluating, and deploying multi-agent workflows in Python, optimized for Gemini but model-agnostic and deployment-agnostic.
+tagline: Code-first toolkit for Gemini and multi-agent workflows
+
+github_url: https://github.com/google/adk-python
+website_url: https://google.github.io/adk-docs/
+docs_url: https://google.github.io/adk-docs/
+
+install_command: pip install google-adk
+
+category: Agents
+tags: [python, agents, google, gemini, multi-agent, evaluation, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Teams building production agents on Gemini often stitch SDKs, eval harnesses, and
+  deploy targets by hand. Google ADK applies software-engineering structure to agent
+  graphs, tools, evaluation, and deployment so the same code can run locally, on
+  Vertex AI, or behind a custom runtime without rewriting the agent loop.
+
+use_cases:
+  - Build multi-agent Gemini workflows in Python with first-class tools and callbacks
+  - Evaluate agent quality with ADK's built-in evaluation before shipping to production
+  - Deploy the same agent code to Vertex AI Agent Engine or a self-hosted runtime
+  - Orchestrate sequential and parallel agent graphs without locking into one model vendor

--- a/tools/llm/mooncake.yaml
+++ b/tools/llm/mooncake.yaml
@@ -1,0 +1,27 @@
+name: Mooncake
+description: A KVCache-centric disaggregated serving platform from Moonshot AI that shares KV cache across inference instances over RDMA, used in production by Kimi to raise throughput under SLO constraints.
+tagline: Disaggregated KV cache serving for large-scale LLM inference
+
+github_url: https://github.com/kvcache-ai/Mooncake
+website_url: https://kvcache-ai.github.io/Mooncake/
+docs_url: https://kvcache-ai.github.io/Mooncake/
+
+install_command: pip install mooncake-transfer-engine
+
+category: LLM
+tags: [llm, inference, kv-cache, rdma, vllm, sglang, serving, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Prefill and decode fight for the same GPUs, and KV cache is recomputed or copied
+  over slow paths when instances cannot share it. Mooncake splits serving around a
+  distributed KV cache store and RDMA transfer engine so vLLM and SGLang clusters
+  reuse cache across nodes and raise tokens per second without breaking latency SLOs.
+
+use_cases:
+  - Share KV cache across vLLM instances with Mooncake Store for higher throughput
+  - Move hidden states and weights over RDMA during disaggregated RL rollout and training
+  - Back SGLang P2P weight updates for trillion-parameter models without huge offline storage
+  - Deploy Kimi-style prefill/decode disaggregation on a multi-node GPU cluster

--- a/tools/llm/nvidia-dynamo.yaml
+++ b/tools/llm/nvidia-dynamo.yaml
@@ -1,0 +1,28 @@
+name: NVIDIA Dynamo
+description: An open-source datacenter-scale inference orchestration layer that coordinates vLLM, SGLang, and TensorRT-LLM across nodes with disaggregated serving, routing, and multi-tier KV caching.
+tagline: Datacenter-scale orchestration above LLM inference engines
+
+github_url: https://github.com/ai-dynamo/dynamo
+website_url: https://docs.nvidia.com/dynamo/latest
+docs_url: https://docs.nvidia.com/dynamo/latest
+
+install_command: uv pip install --prerelease=allow "ai-dynamo[sglang]"
+
+category: LLM
+tags: [llm, inference, nvidia, serving, kv-cache, vllm, sglang, tensorrt-llm, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  A single inference engine cannot schedule prefill versus decode, route across a
+  fleet, or share KV cache at datacenter scale. NVIDIA Dynamo sits above vLLM,
+  SGLang, and TensorRT-LLM to coordinate disaggregated serving, intelligent routing,
+  multi-tier KV caching, and autoscaling so LLM and multimodal workloads use GPUs
+  more efficiently.
+
+use_cases:
+  - Orchestrate multi-node vLLM or SGLang clusters with disaggregated prefill and decode
+  - Route requests and share KV cache across GPU pools to raise tokens per second
+  - Serve reasoning, multimodal, and video generation models with automatic scaling
+  - Run TensorRT-LLM workers under one control plane instead of ad-hoc engine scripts

--- a/tools/llm/powerinfer.yaml
+++ b/tools/llm/powerinfer.yaml
@@ -1,0 +1,23 @@
+name: PowerInfer
+description: A CPU/GPU LLM inference engine that exploits activation locality so large sparse models can run fast on a single consumer GPU, with large speedups versus llama.cpp on the same hardware.
+tagline: Fast local LLM serving on a consumer GPU
+
+github_url: https://github.com/Tiiny-AI/PowerInfer
+
+category: LLM
+tags: [llm, inference, local, gpu, cpu, sparse-models, llama-cpp, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Full-precision LLM serving on a desktop GPU usually means swapping layers to CPU
+  or shrinking the model. PowerInfer uses activation locality and sparse predictors
+  to keep hot neurons on GPU and cold ones on CPU, so models far larger than VRAM
+  still generate tokens quickly on one consumer card.
+
+use_cases:
+  - Run sparse Llama and Mixtral-class models locally on a single RTX GPU without offloading the whole model
+  - Serve ReLU-sparsified checkpoints faster than llama.cpp on the same desktop hardware
+  - Prototype on-device inference for smartphones with the PowerInfer-2 stack
+  - Convert Hugging Face sparse models to PowerInfer GGUF for local chat and coding assistants

--- a/tools/llm/text-embeddings-inference.yaml
+++ b/tools/llm/text-embeddings-inference.yaml
@@ -1,0 +1,27 @@
+name: Text Embeddings Inference
+description: Hugging Face's high-performance server for embedding, reranker, and sequence-classification models, built in Rust with Docker and Homebrew installs and an OpenAI-compatible HTTP API.
+tagline: Blazing-fast Hugging Face text embeddings server
+
+github_url: https://github.com/huggingface/text-embeddings-inference
+website_url: https://huggingface.co/docs/text-embeddings-inference/quick_tour
+docs_url: https://huggingface.co/docs/text-embeddings-inference/quick_tour
+
+install_command: brew install text-embeddings-inference
+
+category: LLM
+tags: [embeddings, inference, huggingface, rust, reranker, rag, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Python embedding servers waste GPU cycles on framework overhead and struggle with
+  dynamic batching at production QPS. Text Embeddings Inference serves Hugging Face
+  embedding and rerank models from a Rust runtime with token streaming, CUDA and
+  Metal backends, and an OpenAI-compatible API so RAG pipelines get low-latency vectors.
+
+use_cases:
+  - Host BGE, E5, or GTE embedding models behind an OpenAI-compatible embeddings API
+  - Serve cross-encoder rerankers next to a vector database for RAG quality boosts
+  - Deploy embeddings air-gapped with Docker images when models cannot leave the network
+  - Run sequence classification or SPLADE sparse retrieval without a Python serving stack


### PR DESCRIPTION
## Add 5 tools to the catalog

- **PowerInfer** (LLM) — CPU/GPU LLM inference engine using activation locality for fast local serving on a consumer GPU. https://github.com/Tiiny-AI/PowerInfer
- **Mooncake** (LLM) — KVCache-centric disaggregated serving platform from Moonshot AI (Kimi). https://github.com/kvcache-ai/Mooncake
- **Text Embeddings Inference** (LLM) — Hugging Face high-performance embeddings/reranker server. https://github.com/huggingface/text-embeddings-inference
- **NVIDIA Dynamo** (LLM) — Datacenter-scale inference orchestration above vLLM, SGLang, and TensorRT-LLM. https://github.com/ai-dynamo/dynamo
- **Google ADK** (Agents) — Google Agent Development Kit for building, evaluating, and deploying agents. https://github.com/google/adk-python

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Google ADK, an agent development framework for multi-agent workflows.
  * Added entries for Mooncake, NVIDIA Dynamo, and PowerInfer, covering LLM serving, inference orchestration, caching, and local execution.
  * Added a Text Embeddings Inference entry for embedding, reranking, and sequence-classification serving.
  * Included project links, installation details, licensing, pricing, capabilities, and representative use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->