### PR TITLE
Add Strands Agents, BeeAI Framework, SuperDuper, Godogen, NGT to catalog

### DIFF
--- a/tools/agent-frameworks/beeai-framework.yaml
+++ b/tools/agent-frameworks/beeai-framework.yaml
@@ -1,0 +1,28 @@
+name: BeeAI Framework
+description: Production-ready agent framework from IBM for both Python and TypeScript. Compose agents, tools, memory, and workflows with a shared API so teams can ship the same agent design in either language.
+tagline: Production agents in Python and TypeScript
+
+github_url: https://github.com/i-am-bee/beeai-framework
+website_url: https://framework.beeai.dev
+docs_url: https://framework.beeai.dev
+
+install_command: |
+  pip install beeai-framework
+  npm install beeai-framework
+
+category: Agents
+tags: [python, typescript, agents, ibm, workflows, memory, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Most agent frameworks are Python-only, leaving TypeScript teams to glue LLM SDKs
+  by hand. BeeAI Framework ships a production agent runtime in both languages with
+  the same primitives for tools, memory, and multi-step workflows.
+
+use_cases:
+  - Build a TypeScript agent with tools, memory, and structured workflows
+  - Port the same BeeAI agent design from Python to Node without changing architecture
+  - Orchestrate multi-step production agents with first-class error handling
+  - Integrate MCP and GitHub workflows into BeeAI agents for issue drafting and ops

--- a/tools/agent-frameworks/godogen.yaml
+++ b/tools/agent-frameworks/godogen.yaml
@@ -1,0 +1,25 @@
+name: Godogen
+description: Autonomous game-development agent pipeline that designs architecture, generates art, writes engine code, and iterates from live screenshots for Godot, Bevy, and Babylon.js using Claude Code or Codex.
+tagline: Autonomous game development for Godot, Bevy, and Babylon.js
+
+github_url: https://github.com/htdt/godogen
+website_url: https://github.com/htdt/godogen
+docs_url: https://github.com/htdt/godogen
+
+category: Agents
+tags: [agents, godot, bevy, gamedev, claude-code, codex, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Shipping a playable game with an LLM usually stops at code snippets that do not
+  compile or look wrong in-engine. Godogen runs an agent loop that designs the
+  project, writes engine code, captures screenshots from Godot, Bevy, or Babylon.js,
+  and fixes what does not look right until you have a real project.
+
+use_cases:
+  - Describe a game and generate a structured Godot 4 project with scenes and scripts
+  - Use Claude Code or Codex to iterate Bevy gameplay from engine screenshots
+  - Prototype Babylon.js games with an agent that writes code and repairs visual bugs
+  - Turn a one-line game idea into architecture, art assets, and runnable engine code

--- a/tools/agent-frameworks/strands-agents.yaml
+++ b/tools/agent-frameworks/strands-agents.yaml
@@ -1,0 +1,28 @@
+name: Strands Agents
+description: Open-source SDK for production AI agents in Python and TypeScript. Model-agnostic and cloud-agnostic, with a model-driven harness so you can build an agent loop and control it end to end.
+tagline: Model-driven agent SDK for Python and TypeScript
+
+github_url: https://github.com/strands-agents/harness-sdk
+website_url: https://strandsagents.com
+docs_url: https://strandsagents.com
+
+install_command: |
+  pip install strands-agents
+  npm install @strands-agents/sdk
+
+category: Agents
+tags: [python, typescript, agents, aws, sdk, tools, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Production agent stacks often lock you to one model vendor or one cloud runtime.
+  Strands Agents gives a portable harness, tools, and control loop so the same agent
+  code can run against any model on any cloud without rewriting orchestration.
+
+use_cases:
+  - Build a production Python agent with model-driven tools and an explicit control loop
+  - Ship the same agent logic in TypeScript using the official Strands SDK
+  - Swap model providers without rewriting tool calling, memory, or harness code
+  - Compose specialized tools from strands-agents-tools into a custom agent workflow

--- a/tools/agent-frameworks/superduper.yaml
+++ b/tools/agent-frameworks/superduper.yaml
@@ -1,0 +1,27 @@
+name: SuperDuper
+description: End-to-end open-source framework for building custom AI applications and agents on existing databases. Declarative composition with plugins for MongoDB, SQL, Snowflake, and Redis so models live next to your data.
+tagline: Build AI apps and agents on your database
+
+github_url: https://github.com/superduper-io/superduper
+website_url: https://superduper.io
+docs_url: https://superduper.io
+
+install_command: pip install superduper-framework
+
+category: Agents
+tags: [python, agents, database, mongodb, sql, declarative, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Teams often copy data out of operational databases into a separate AI stack, then
+  fight sync and deployment. SuperDuper lets you declare models, agents, and
+  vector search against MongoDB, SQL, Snowflake, or Redis so inference stays next
+  to the source of truth.
+
+use_cases:
+  - Add vector search and LLM agents on top of an existing MongoDB collection
+  - Declare a retrieval-plus-generation pipeline against SQL without a separate vector DB
+  - Run custom AI applications on Snowflake with SuperDuper plugins
+  - Build compositional agents that read and write through Redis or SQL backends

--- a/tools/vector-databases/ngt.yaml
+++ b/tools/vector-databases/ngt.yaml
@@ -1,0 +1,27 @@
+name: NGT
+description: Neighborhood Graph and Tree library for high-dimensional nearest neighbor search. Graph-based ANN indexing used for large-scale similarity search, embeddings retrieval, and vector lookup in production pipelines.
+tagline: Graph-and-tree ANN search for high-dimensional data
+
+github_url: https://github.com/NGT-labs/NGT
+website_url: https://github.com/NGT-labs/NGT
+docs_url: https://github.com/NGT-labs/NGT
+
+install_command: pip install ngt
+
+category: Vector DB
+tags: [ann, vector-search, embeddings, cplusplus, python, nearest-neighbor, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Exact nearest neighbor search collapses at high dimension and large corpus size.
+  NGT builds neighborhood graphs and trees so you can run approximate k-NN over
+  embedding vectors with better recall-latency tradeoffs than brute force, without
+  standing up a full vector database.
+
+use_cases:
+  - Index high-dimensional embeddings for fast approximate nearest neighbor lookup
+  - Power similarity search in a custom retrieval stack without a hosted vector DB
+  - Benchmark graph-based ANN against HNSW for large-scale embedding search
+  - Add Python NGT indexes to a local RAG prototype before moving to a managed store


### PR DESCRIPTION
## Summary
Add five catalog entries:

- **Strands Agents** (Agents): AWS open-source Python/TypeScript agent SDK (`strands-agents/harness-sdk`, 7.0k*, Apache-2.0)
- **BeeAI Framework** (Agents): IBM production agent framework for Python and TypeScript (`i-am-bee/beeai-framework`, 3.3k*, Apache-2.0)
- **SuperDuper** (Agents): declarative AI apps and agents on existing databases (`superduper-io/superduper`, 5.3k*, Apache-2.0)
- **Godogen** (Agents): autonomous game-development agent pipeline for Godot, Bevy, and Babylon.js (`htdt/godogen`, 6.6k*, MIT)
- **NGT** (Vector DB): Neighborhood Graph and Tree ANN library (`NGT-labs/NGT`, 1.3k*, Apache-2.0)

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for four AI agent frameworks: BeeAI, Godogen, Strands Agents, and SuperDuper.
  * Added a catalog entry for NGT, a vector database library supporting approximate nearest-neighbor search.
  * Included installation details, licensing, documentation links, capabilities, and practical use cases for each addition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->