### PR TITLE
Add PostgREST, yq, Podman, k3s, Argo CD to catalog

### DIFF
--- a/tools/data/postgrest.yaml
+++ b/tools/data/postgrest.yaml
@@ -1,0 +1,25 @@
+name: PostgREST
+description: Turns any PostgreSQL database into a RESTful API automatically. Exposes tables, views, and functions as HTTP endpoints with JWT auth, so ML feature stores and app backends can query Postgres without writing a custom API layer.
+tagline: Instant REST API for any Postgres database
+
+github_url: https://github.com/PostgREST/postgrest
+website_url: https://postgrest.org
+docs_url: https://postgrest.org/en/stable/
+
+category: Data
+tags: [postgres, rest, api, haskell, sql, backend, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Teams wiring ML apps to Postgres often build a one-off CRUD API that drifts from
+  the schema. PostgREST reads the database schema and serves a versioned REST API
+  with auth, filtering, and stored-procedure RPCs so the database remains the
+  contract instead of a handwritten backend.
+
+use_cases:
+  - Expose a Postgres feature store as a REST API for training and inference services
+  - Serve CRUD endpoints for an ML labeling or evaluation UI without writing a backend
+  - Call Postgres functions as RPCs for scoring, retrieval, or feature computation
+  - Put JWT-authenticated HTTP in front of existing tables and views for internal tools

--- a/tools/dev-tools/argo-cd.yaml
+++ b/tools/dev-tools/argo-cd.yaml
@@ -1,0 +1,24 @@
+name: Argo CD
+description: Declarative GitOps continuous delivery for Kubernetes. Syncs cluster state to Git so ML serving, agents, and data jobs deploy the same way every time, with diffs, rollback, and multi-cluster sync.
+tagline: GitOps continuous delivery for Kubernetes
+
+github_url: https://github.com/argoproj/argo-cd
+website_url: https://argo-cd.readthedocs.io
+docs_url: https://argo-cd.readthedocs.io
+
+category: Dev Tools
+tags: [gitops, kubernetes, cicd, cd, helm, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  kubectl apply from laptops drifts clusters and hides what is actually running. Argo CD
+  continuously reconciles Kubernetes apps from Git, showing diffs and health so model
+  serving, agents, and feature pipelines stay in the revision you reviewed.
+
+use_cases:
+  - Deploy LLM serving charts from Git and keep the cluster synced to main
+  - Roll back a bad inference release by reverting the Git commit Argo CD watches
+  - Manage multi-cluster agent runtimes from one GitOps source of truth
+  - Review live vs desired Helm diffs before promoting an ML workload

--- a/tools/dev-tools/k3s.yaml
+++ b/tools/dev-tools/k3s.yaml
@@ -1,0 +1,26 @@
+name: k3s
+description: Lightweight certified Kubernetes distribution from SUSE Rancher. A single binary with an embedded container runtime, etcd or SQLite, and ingress, made for edge, CI, and compact GPU clusters that still need a real K8s API.
+tagline: Lightweight Kubernetes in a single binary
+
+github_url: https://github.com/k3s-io/k3s
+website_url: https://k3s.io
+docs_url: https://docs.k3s.io
+
+install_command: curl -sfL https://get.k3s.io | sh -
+
+category: Dev Tools
+tags: [kubernetes, edge, rancher, cluster, mlops, gpu, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Full Kubernetes is heavy for a laptop, a single GPU box, or an edge node. k3s ships a
+  certified Kubernetes API as one binary with batteries included so teams can run agents,
+  inference, and CI workloads on small machines without a six-node control plane.
+
+use_cases:
+  - Stand up a single-node Kubernetes cluster for local agent and inference workloads
+  - Run compact GPU clusters at the edge with a certified K8s API
+  - Use k3s in CI to test Helm charts and ML serving manifests
+  - Replace a heavy kubeadm stack on a homelab or workshop cluster

--- a/tools/dev-tools/podman.yaml
+++ b/tools/dev-tools/podman.yaml
@@ -1,0 +1,27 @@
+name: Podman
+description: Daemonless OCI container engine for building, running, and managing containers and pods. Drop-in Docker CLI compatible, rootless by default, used to run local ML services and reproducible training environments.
+tagline: Daemonless containers and pods, Docker-compatible
+
+github_url: https://github.com/containers/podman
+website_url: https://podman.io
+docs_url: https://docs.podman.io
+
+install_command: brew install podman
+
+category: Dev Tools
+tags: [containers, oci, docker, linux, kubernetes, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Docker's daemon and rootful default are a poor fit for shared GPU boxes and locked-down
+  laptops. Podman runs OCI containers and Kubernetes-style pods without a daemon, as a
+  regular user, while keeping a Docker-compatible CLI so existing Dockerfiles and compose
+  files still work.
+
+use_cases:
+  - Run local LLM inference and vector DB containers without a Docker daemon
+  - Build reproducible training images with a Docker-compatible CLI
+  - Run rootless containers on shared GPU machines where Docker socket access is banned
+  - Group related ML services into pods that mirror Kubernetes locally

--- a/tools/dev-tools/yq.yaml
+++ b/tools/dev-tools/yq.yaml
@@ -1,0 +1,27 @@
+name: yq
+description: Portable command-line processor for YAML, JSON, XML, CSV, TOML, and HCL. Lets you query, merge, and rewrite config the way jq does for JSON, which is essential in ML pipeline and Kubernetes manifests.
+tagline: jq for YAML, JSON, XML, CSV, and TOML
+
+github_url: https://github.com/mikefarah/yq
+website_url: https://mikefarah.gitbook.io/yq/
+docs_url: https://mikefarah.gitbook.io/yq/
+
+install_command: brew install yq
+
+category: Dev Tools
+tags: [yaml, json, cli, golang, kubernetes, config, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  ML and infra configs live in YAML, but jq only speaks JSON. yq gives the same
+  filter-and-rewrite power across YAML, JSON, XML, CSV, TOML, and HCL so you can
+  patch Helm values, compose experiment configs, and extract fields in CI without
+  a custom parser.
+
+use_cases:
+  - Patch Kubernetes and Helm YAML in CI without a Python script
+  - Extract model hyperparameters from experiment YAML into JSON for dashboards
+  - Merge overlay configs for training jobs across environments
+  - Convert between YAML, JSON, and TOML in data and IaC pipelines


### PR DESCRIPTION
## Summary
Add five catalog entries:

- **PostgREST** (Data): REST API for any Postgres database (`PostgREST/postgrest`, 27k*, MIT)
- **yq** (Dev Tools): CLI processor for YAML/JSON/XML/CSV/TOML (`mikefarah/yq`, 15k*, MIT)
- **Podman** (Dev Tools): daemonless OCI containers and pods (`containers/podman`, 32k*, Apache-2.0)
- **k3s** (Dev Tools): lightweight Kubernetes (`k3s-io/k3s`, 33k*, Apache-2.0)
- **Argo CD** (Dev Tools): GitOps continuous delivery for Kubernetes (`argoproj/argo-cd`, 24k*, Apache-2.0)

Local validation passed for all five YAML files.
