### PR TITLE
Add Prisma, Pixi, Gradle, OpenTofu, Cadence to catalog

### DIFF
--- a/tools/dev-tools/cadence.yaml
+++ b/tools/dev-tools/cadence.yaml
@@ -1,0 +1,26 @@
+name: Cadence
+description: Uber's distributed workflow engine for durable, long-running business logic. Orchestrates retries, timers, and stateful sagas so ML pipelines, human-in-the-loop reviews, and agent jobs survive process crashes.
+tagline: Durable workflow engine for long-running orchestration
+
+github_url: https://github.com/uber/cadence
+website_url: https://cadenceworkflow.io
+docs_url: https://cadenceworkflow.io/docs/
+
+install_command: brew install cadence-workflow
+
+category: Dev Tools
+tags: [workflows, orchestration, java, go, distributed, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Cron jobs and in-process queues drop state when a worker dies mid-training or
+  mid-review. Cadence records workflow history so multi-day ML jobs, approvals, and
+  agent loops resume from the last durable decision instead of restarting.
+
+use_cases:
+  - Orchestrate multi-day training and evaluation jobs with durable retries
+  - Run human-in-the-loop review sagas that wait days without holding a process
+  - Coordinate agent tool calls that must survive worker restarts
+  - Replace ad-hoc cron plus database locks with Cadence workflow histories

--- a/tools/dev-tools/gradle.yaml
+++ b/tools/dev-tools/gradle.yaml
@@ -1,0 +1,27 @@
+name: Gradle
+description: Adaptable build automation for JVM and polyglot projects. Powers Android, Kotlin, and Java ML libraries with incremental builds, dependency management, and a Groovy or Kotlin DSL used across the JVM AI stack.
+tagline: Fast, adaptable build automation for JVM projects
+
+github_url: https://github.com/gradle/gradle
+website_url: https://gradle.org
+docs_url: https://docs.gradle.org
+
+install_command: brew install gradle
+
+category: Dev Tools
+tags: [java, kotlin, build, jvm, android, ci, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  JVM ML libraries and Android inference apps need incremental, cacheable builds
+  that Maven struggles to express. Gradle's task graph, build cache, and Kotlin DSL
+  compile large multi-module Java/Kotlin projects without a full rebuild on every
+  model-SDK change.
+
+use_cases:
+  - Build and test Kotlin/Java ML SDKs with incremental Gradle tasks
+  - Cache CI builds for Android apps that embed on-device inference
+  - Manage multi-module JVM projects that wrap ONNX Runtime or TensorFlow Java
+  - Publish versioned Java libraries used by agent backends on the JVM

--- a/tools/dev-tools/opentofu.yaml
+++ b/tools/dev-tools/opentofu.yaml
@@ -1,0 +1,27 @@
+name: OpenTofu
+description: Open-source fork of Terraform under the Linux Foundation. Declarative IaC for cloud GPUs, Kubernetes, and data stores with an MPL-2.0 license, so teams can provision ML infra without HashiCorp BSL constraints.
+tagline: Open-source Terraform-compatible infrastructure as code
+
+github_url: https://github.com/opentofu/opentofu
+website_url: https://opentofu.org
+docs_url: https://opentofu.org/docs/
+
+install_command: brew install opentofu
+
+category: Dev Tools
+tags: [iac, terraform, cloud, kubernetes, gpu, mlops, open-source]
+pricing: free
+is_open_source: true
+license: MPL-2.0
+
+problem_solved: |
+  Terraform's BSL license blocks some production and redistribution uses. OpenTofu
+  keeps the Terraform workflow (plan, apply, state, providers) under MPL-2.0 so
+  teams can still declare GPU VMs, Kubernetes clusters, and object storage without
+  a proprietary IaC license.
+
+use_cases:
+  - Provision GPU training clusters with Terraform-compatible modules under MPL-2.0
+  - Plan and apply Kubernetes plus object-storage stacks for model artifacts
+  - Migrate existing Terraform roots to OpenTofu without rewriting providers
+  - Keep IaC open-source for org policies that reject BSL tooling

--- a/tools/dev-tools/pixi.yaml
+++ b/tools/dev-tools/pixi.yaml
@@ -1,0 +1,27 @@
+name: Pixi
+description: Cross-platform, conda-based package manager written in Rust. Locks system-level and Python dependencies for Linux, macOS, and Windows so ML environments stay reproducible without a heavyweight Conda install.
+tagline: Fast conda-based package manager in Rust
+
+github_url: https://github.com/prefix-dev/pixi
+website_url: https://pixi.sh
+docs_url: https://pixi.sh
+
+install_command: brew install pixi
+
+category: Dev Tools
+tags: [python, rust, conda, packaging, reproducibility, mlops, open-source]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Conda environments are slow and hard to lock across machines; pip-only locks miss
+  CUDA, MKL, and system libs. Pixi uses the conda ecosystem with a Rust CLI and
+  lockfiles so training boxes, laptops, and CI share the same Python plus native
+  stack.
+
+use_cases:
+  - Lock CUDA-aware Python training deps with conda packages and a Pixi lockfile
+  - Share a cross-platform ML environment across Linux GPU boxes and macOS laptops
+  - Replace slow conda env create in CI with a faster Pixi install
+  - Mix conda-forge scientific stacks with project-local tasks in pixi.toml

--- a/tools/dev-tools/prisma.yaml
+++ b/tools/dev-tools/prisma.yaml
@@ -1,0 +1,27 @@
+name: Prisma
+description: Next-generation ORM for Node.js and TypeScript with a declarative schema, type-safe client, and migrations. Talks to PostgreSQL, MySQL, MariaDB, SQL Server, SQLite, MongoDB, and CockroachDB from one schema file.
+tagline: Type-safe ORM for Node.js and TypeScript
+
+github_url: https://github.com/prisma/prisma
+website_url: https://www.prisma.io
+docs_url: https://www.prisma.io/docs
+
+install_command: npm install prisma
+
+category: Dev Tools
+tags: [typescript, orm, postgres, mysql, mongodb, nodejs, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Hand-written SQL and loosely typed query builders leak schema mistakes into
+  production. Prisma generates a type-safe client from a single schema so app and
+  agent backends get compile-time checks, migrations, and multi-database support
+  without switching ORMs per engine.
+
+use_cases:
+  - Model a Postgres-backed agent memory store with a type-safe TypeScript client
+  - Migrate an ML labeling app schema across Postgres and SQLite with one Prisma schema
+  - Query MongoDB or CockroachDB from a Node inference API without a custom data layer
+  - Generate types from the database so LLM tool handlers cannot pass invalid fields


### PR DESCRIPTION
## Summary
Add five catalog entries:

- **Prisma** (Dev Tools): type-safe ORM for Node.js and TypeScript (`prisma/prisma`, 47k*, Apache-2.0)
- **Pixi** (Dev Tools): conda-based package manager in Rust (`prefix-dev/pixi`, 7.6k*, BSD-3-Clause)
- **Gradle** (Dev Tools): JVM build automation (`gradle/gradle`, 18k*, Apache-2.0)
- **OpenTofu** (Dev Tools): open-source Terraform-compatible IaC (`opentofu/opentofu`, 30k*, MPL-2.0)
- **Cadence** (Dev Tools): Uber durable workflow engine (`uber/cadence`, 9.4k*, Apache-2.0)

Local validation passed for all five YAML files.
