### PR TITLE
Add Kind, k9s, Tekton, Crossplane, Portainer to catalog

### DIFF
--- a/tools/dev-tools/crossplane.yaml
+++ b/tools/dev-tools/crossplane.yaml
@@ -1,0 +1,25 @@
+name: Crossplane
+description: Cloud-native control plane that turns cloud APIs into Kubernetes resources. Declare GPU VMs, databases, and buckets as YAML so ML platforms provision infra with the same GitOps workflow as applications.
+tagline: Kubernetes control plane for cloud infrastructure
+
+github_url: https://github.com/crossplane/crossplane
+website_url: https://www.crossplane.io
+docs_url: https://docs.crossplane.io
+
+category: Dev Tools
+tags: [kubernetes, iac, gitops, cloud, gpu, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  App GitOps and infra Terraform usually live in two worlds. Crossplane extends
+  the Kubernetes API with cloud resources so a platform team can request a GPU
+  node pool, database, or bucket as YAML and let the control plane reconcile it
+  like any other cluster object.
+
+use_cases:
+  - Provision GPU node pools and object storage as Kubernetes custom resources
+  - Offer a self-service ML environment API composed from cloud provider resources
+  - GitOps cloud databases used by feature stores alongside app deployments
+  - Replace ticket-driven infra with Crossplane claims for training clusters

--- a/tools/dev-tools/k9s.yaml
+++ b/tools/dev-tools/k9s.yaml
@@ -1,0 +1,27 @@
+name: k9s
+description: Terminal UI for Kubernetes clusters. Browse pods, logs, events, and resources in a vim-like TUI so ML ops and platform engineers can debug inference, training jobs, and agents without a web dashboard.
+tagline: Stylish Kubernetes CLI to manage clusters in the terminal
+
+github_url: https://github.com/derailed/k9s
+website_url: https://k9scli.io
+docs_url: https://k9scli.io
+
+install_command: brew install k9s
+
+category: Dev Tools
+tags: [kubernetes, tui, cli, devops, debugging, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  kubectl get/describe/logs is verbose when a training job or inference pod is
+  crash-looping. k9s puts pods, logs, events, and port-forwards in a fast TUI so
+  you can jump from a failing GPU job to its logs without assembling kubectl
+  flags.
+
+use_cases:
+  - Watch GPU training pods and jump into logs when a job OOMs
+  - Port-forward a local inference service from the TUI during debugging
+  - Inspect events and CrashLoopBackOff on agent worker deployments
+  - Navigate multi-namespace ML platforms faster than raw kubectl

--- a/tools/dev-tools/kind.yaml
+++ b/tools/dev-tools/kind.yaml
@@ -1,0 +1,27 @@
+name: Kind
+description: Kubernetes IN Docker. Runs local Kubernetes clusters inside Docker, Podman, or nerdctl so you can test Helm charts, operators, and ML serving manifests without a cloud account or a full kubeadm stack.
+tagline: Local Kubernetes clusters inside Docker
+
+github_url: https://github.com/kubernetes-sigs/kind
+website_url: https://kind.sigs.k8s.io
+docs_url: https://kind.sigs.k8s.io/docs/user/quick-start/
+
+install_command: brew install kind
+
+category: Dev Tools
+tags: [kubernetes, docker, testing, ci, local, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Cloud Kubernetes clusters are slow and expensive for iterating on charts and
+  operators. kind boots a multi-node Kubernetes API inside containers so CI and
+  laptops can apply the same ML serving YAML you will ship, then throw the cluster
+  away.
+
+use_cases:
+  - Test Helm charts for LLM serving in CI with a disposable Kubernetes cluster
+  - Develop Kubernetes operators for GPU scheduling against a local kind cluster
+  - Reproduce production K8s API behavior on a laptop without a cloud account
+  - Run integration tests for agent runtimes that assume a kubeconfig

--- a/tools/dev-tools/portainer.yaml
+++ b/tools/dev-tools/portainer.yaml
@@ -1,0 +1,25 @@
+name: Portainer
+description: Web UI for Docker, Swarm, and Kubernetes. Lets teams manage containers, stacks, and cluster resources from a browser so ML engineers can run inference and notebooks without living in the Docker CLI.
+tagline: Simple Docker and Kubernetes management UI
+
+github_url: https://github.com/portainer/portainer
+website_url: https://www.portainer.io
+docs_url: https://docs.portainer.io
+
+category: Dev Tools
+tags: [docker, kubernetes, ui, containers, devops, mlops, open-source]
+pricing: freemium
+is_open_source: true
+license: Zlib
+
+problem_solved: |
+  Docker CLI and kubectl are steep for researchers who just need to start a GPU
+  notebook or inference container. Portainer gives a browser UI over Docker and
+  Kubernetes so stacks, logs, and access control are visible without teaching
+  everyone kubectl.
+
+use_cases:
+  - Give researchers a UI to start GPU notebook and inference containers
+  - Manage Docker Compose stacks for local RAG demos from a browser
+  - Apply RBAC so only some users can deploy to a shared Kubernetes namespace
+  - Inspect container logs and resource use without SSH on a lab GPU box

--- a/tools/dev-tools/tekton.yaml
+++ b/tools/dev-tools/tekton.yaml
@@ -1,0 +1,25 @@
+name: Tekton
+description: Cloud-native CI/CD pipelines as Kubernetes custom resources. Define Tasks and Pipelines that build, test, and deploy models on the cluster, with steps running as pods next to your training and serving workloads.
+tagline: Kubernetes-native CI/CD pipelines
+
+github_url: https://github.com/tektoncd/pipeline
+website_url: https://tekton.dev
+docs_url: https://tekton.dev/docs/
+
+category: Dev Tools
+tags: [cicd, kubernetes, pipelines, devops, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  External CI often cannot see GPUs, cluster secrets, or in-cluster registries.
+  Tekton runs each pipeline step as a Kubernetes pod, so model build, test, and
+  deploy share the same cluster, service accounts, and hardware as production
+  serving.
+
+use_cases:
+  - Build and push model images inside the cluster that will serve them
+  - Run GPU-backed evaluation Tasks as Kubernetes pods in a Tekton Pipeline
+  - Deploy agent runtimes with in-cluster CI instead of a SaaS runner
+  - Standardize ML release steps as reusable Tekton Tasks across teams


### PR DESCRIPTION
## Summary
Add five catalog entries:

- **Kind** (Dev Tools): Kubernetes IN Docker (`kubernetes-sigs/kind`, 15k*, Apache-2.0)
- **k9s** (Dev Tools): Kubernetes TUI (`derailed/k9s`, 34k*, Apache-2.0)
- **Tekton** (Dev Tools): Kubernetes-native CI/CD (`tektoncd/pipeline`, 9.0k*, Apache-2.0)
- **Crossplane** (Dev Tools): cloud-native control plane (`crossplane/crossplane`, 12k*, Apache-2.0)
- **Portainer** (Dev Tools): Docker and Kubernetes management UI (`portainer/portainer`, 38k*, Zlib)

Local validation passed for all five YAML files.
