### PR TITLE
Add Flyway, BullMQ, Restic, Dokku, Coolify to catalog

### DIFF
--- a/tools/dev-tools/bullmq.yaml
+++ b/tools/dev-tools/bullmq.yaml
@@ -1,0 +1,22 @@
+name: BullMQ
+description: Redis-backed job queue and batch processor for Node.js, Python, .NET, Elixir, Rust, and PHP that handles delayed jobs, retries, rate limits, and workers so AI apps can run embeddings, evals, and agent tasks reliably in the background.
+tagline: Redis job queues for background AI workloads
+github_url: https://github.com/taskforcesh/bullmq
+website_url: https://bullmq.io
+docs_url: https://docs.bullmq.io
+install_command: npm install bullmq
+category: Dev Tools
+tags: [nodejs, redis, queue, jobs, workers, background-tasks]
+pricing: freemium
+is_open_source: true
+license: MIT
+problem_solved: |
+  LLM calls, embedding batches, and agent runs cannot live in the HTTP request
+  path without timeouts and lost work. BullMQ puts those jobs on Redis (or
+  PostgreSQL) with retries, backoff, concurrency, and delayed schedules so
+  workers process them independently of the API process and failed jobs can
+  be inspected and replayed instead of silently dropped.
+use_cases:
+  - Queue embedding generation and document-ingestion jobs so web requests stay fast
+  - Retry failed LLM API calls with exponential backoff without blocking the user request
+  - Run nightly eval batches and agent workflows as scheduled workers with concurrency limits

--- a/tools/dev-tools/coolify.yaml
+++ b/tools/dev-tools/coolify.yaml
@@ -1,0 +1,22 @@
+name: Coolify
+description: Open-source, self-hostable PaaS alternative to Vercel, Heroku, and Netlify that deploys static sites, databases, full-stack apps, and 280-plus one-click services on your own servers with git-based workflows and a web UI.
+tagline: Self-hosted Vercel and Heroku alternative
+github_url: https://github.com/coollabsio/coolify
+website_url: https://coolify.io
+docs_url: https://coolify.io/docs
+install_command: curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash
+category: Dev Tools
+tags: [paas, self-hosted, docker, deployment, vercel, heroku]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  AI teams outgrow managed PaaS pricing once they run GPUs, long workers,
+  and private databases. Coolify gives a Vercel-like UI on hardware you
+  control. Connect a git repo, pick a Dockerfile or Nixpacks build, and
+  deploy web apps, Postgres, Redis, and one-click services without vendor
+  lock-in or per-seat hosting bills.
+use_cases:
+  - Deploy a Next.js catalog, FastAPI inference service, and Postgres on one self-hosted cluster
+  - One-click stand up Redis, Qdrant, or MinIO next to an agent backend without writing Compose files
+  - Git-push preview environments for ML demos without paying Vercel or Heroku for always-on workers

--- a/tools/dev-tools/dokku.yaml
+++ b/tools/dev-tools/dokku.yaml
@@ -1,0 +1,21 @@
+name: Dokku
+description: Docker-powered, Heroku-like PaaS you install on your own server. Push with git to build, run, and scale web apps, model APIs, and worker processes with buildpacks or Dockerfiles and zero Kubernetes overhead.
+tagline: Git-push PaaS for apps and model APIs
+github_url: https://github.com/dokku/dokku
+website_url: https://dokku.com
+docs_url: https://dokku.com/docs/getting-started/installation/
+category: Dev Tools
+tags: [paas, docker, git, heroku, deployment, self-hosted]
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: |
+  Shipping a FastAPI model server or Next.js catalog site usually means
+  hand-rolling Docker, nginx, SSL, and process restarts. Dokku turns a
+  single VPS into a git-push PaaS. heroku-style buildpacks or a Dockerfile
+  produce a container, and plugins handle domains, Let's Encrypt, Postgres,
+  Redis, and scaling without a Kubernetes cluster.
+use_cases:
+  - Git-push a FastAPI or Flask inference API to a VPS and get HTTPS plus process restarts
+  - Host a Next.js tool catalog and a Redis-backed worker on one cheap Docker host
+  - Add Postgres and Redis plugins next to an agent backend without managing Compose by hand

--- a/tools/dev-tools/flyway.yaml
+++ b/tools/dev-tools/flyway.yaml
@@ -1,0 +1,22 @@
+name: Flyway
+description: Open-source database migration tool from Redgate that versions schema changes as ordered SQL or Java scripts, applies them to PostgreSQL, MySQL, SQL Server, Oracle, and more, and records which versions have run so teams can evolve schemas safely across environments.
+tagline: Version-controlled database migrations for any SQL database
+github_url: https://github.com/flyway/flyway
+website_url: https://flywaydb.org
+docs_url: https://documentation.red-gate.com/flyway
+install_command: brew install flyway
+category: Dev Tools
+tags: [database, migrations, sql, schema, java, devops]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  AI apps that persist embeddings, traces, and user data outgrow ad-hoc schema
+  changes. Flyway versions every SQL change as a numbered migration, applies
+  pending scripts in order, and tracks history in a schema table so Postgres
+  feature stores, MySQL metadata DBs, and SQL Server warehouses stay in sync
+  across local, staging, and production without manual ALTER scripts.
+use_cases:
+  - Version vector-store metadata tables and apply the same SQL migrations across local, staging, and production
+  - Generate repeatable schema baselines for RAG document indexes and experiment-tracking databases
+  - Roll forward new columns for traces, eval scores, and user memory without hand-running ALTER statements

--- a/tools/dev-tools/restic.yaml
+++ b/tools/dev-tools/restic.yaml
@@ -1,0 +1,22 @@
+name: Restic
+description: Fast, encrypted backup program that deduplicates data and stores snapshots in S3, GCS, Azure, SFTP, or local disks so teams can protect model checkpoints, datasets, and experiment artifacts without paying for a proprietary backup appliance.
+tagline: Encrypted, deduplicated backups for model artifacts
+github_url: https://github.com/restic/restic
+website_url: https://restic.net
+docs_url: https://restic.readthedocs.io
+install_command: brew install restic
+category: Dev Tools
+tags: [backup, encryption, s3, devops, snapshots, storage]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+problem_solved: |
+  Training runs produce large checkpoints and datasets that are expensive to
+  recopy and easy to lose. Restic encrypts client-side, deduplicates across
+  snapshots, and writes to object storage or remote disks so ML teams can
+  keep incremental backups of models, feature stores, and configs without
+  sending plaintext artifacts to a third-party backup vendor.
+use_cases:
+  - Snapshot model checkpoints and LoRA adapters to S3 with client-side encryption
+  - Deduplicate daily backups of training datasets so only changed chunks are uploaded
+  - Restore a previous experiment workspace from a restic snapshot after a failed training run


### PR DESCRIPTION
Add Flyway, BullMQ, Restic, Dokku, and Coolify to the catalog.

Dev Tools batch:

- **Flyway** (flyway/flyway, 10.0k, Apache-2.0) — SQL schema migrations
- **BullMQ** (taskforcesh/bullmq, 9.4k, MIT) — Redis job queues for Node.js
- **Restic** (restic/restic, 35.8k, BSD-2-Clause) — encrypted, deduplicated backups
- **Dokku** (dokku/dokku, 32.1k, MIT) — git-push Docker PaaS
- **Coolify** (coollabsio/coolify, 61.3k, Apache-2.0) — self-hosted Vercel/Heroku alternative

All files passed local `validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added BullMQ, Coolify, Dokku, Flyway, and Restic to the developer tools catalog.
  - Included descriptions, links, installation guidance, licensing, pricing, categories, and relevant AI-development use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->