### PR TITLE
Add containerd, Cilium, Velero, Skaffold, Tilt to catalog

### DIFF
--- a/tools/dev-tools/cilium.yaml
+++ b/tools/dev-tools/cilium.yaml
@@ -1,0 +1,21 @@
+name: Cilium
+description: eBPF-based networking, security, and observability platform for Kubernetes that replaces kube-proxy, enforces identity-aware network policy, and traces service traffic so ML clusters can lock down inference APIs without iptables sprawl.
+tagline: eBPF networking and security for Kubernetes
+github_url: https://github.com/cilium/cilium
+website_url: https://cilium.io
+docs_url: https://docs.cilium.io
+category: Dev Tools
+tags: [ebpf, kubernetes, networking, security, observability, cni]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  GPU clusters running many inference services leak traffic through default
+  allow-all CNI policies and struggle to debug latency. Cilium uses eBPF to
+  replace kube-proxy, apply L3-L7 network policy by workload identity, and
+  export Hubble flows so teams can see which agent, vector DB, or model
+  server talks to whom.
+use_cases:
+  - Enforce network policies so only the API gateway can reach a model-serving namespace
+  - Replace kube-proxy with eBPF load balancing for high-QPS embedding endpoints
+  - Trace latency between a RAG API, vector DB, and GPU inference pods with Hubble

--- a/tools/dev-tools/containerd.yaml
+++ b/tools/dev-tools/containerd.yaml
@@ -1,0 +1,20 @@
+name: containerd
+description: CNCF container runtime that pulls images, manages snapshots and namespaces, and runs containers for Docker, Kubernetes, and nerdctl. It is the low-level engine most ML clusters use to start training and inference pods.
+tagline: Industry-standard container runtime for K8s and Docker
+github_url: https://github.com/containerd/containerd
+website_url: https://containerd.io
+docs_url: https://containerd.io/docs/
+category: Dev Tools
+tags: [containers, kubernetes, docker, runtime, cncf, cni]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Training and inference jobs need a stable way to pull images and start
+  processes on GPU nodes. containerd is the CRI runtime Kubernetes talks to,
+  handling image pull, snapshot layers, and container lifecycle so ML
+  platforms do not depend on the full Docker daemon.
+use_cases:
+  - Run Kubernetes GPU nodes with containerd as the CRI instead of Docker
+  - Pull and cache large CUDA training images with snapshotter-backed layers
+  - Inspect and manage inference containers with nerdctl against a containerd socket

--- a/tools/dev-tools/skaffold.yaml
+++ b/tools/dev-tools/skaffold.yaml
@@ -1,0 +1,21 @@
+name: Skaffold
+description: Google tool for repeatable Kubernetes development that watches source, rebuilds images, and redeploys to a cluster so ML engineers can iterate on training jobs and inference APIs without writing custom docker-build plus kubectl loops.
+tagline: Repeatable inner-loop Kubernetes development
+github_url: https://github.com/GoogleContainerTools/skaffold
+website_url: https://skaffold.dev
+docs_url: https://skaffold.dev/docs/
+install_command: brew install skaffold
+category: Dev Tools
+tags: [kubernetes, devops, ci-cd, containers, google, inner-loop]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Changing a FastAPI inference handler usually means rebuild, retag, push,
+  and kubectl apply by hand. Skaffold watches files, builds with Docker or
+  Buildkit, tags images, and deploys renderable manifests so the inner loop
+  on a GPU cluster matches what CI will ship.
+use_cases:
+  - Live-reload a model API Deployment on a local Kind or GKE cluster while editing Python
+  - Share one skaffold.yaml that builds CUDA images and applies Helm or Kustomize overlays
+  - Run skaffold in CI to build, test, and deploy the same inference stack used on a laptop

--- a/tools/dev-tools/tilt.yaml
+++ b/tools/dev-tools/tilt.yaml
@@ -1,0 +1,22 @@
+name: Tilt
+description: Dev environment-as-code for microservice apps on Kubernetes. A Tiltfile describes how to build and run each service, then Tilt live-updates containers and shows a unified UI so teams iterating on agent backends, APIs, and workers stay in one inner loop.
+tagline: Dev environment as code for Kubernetes microservices
+github_url: https://github.com/tilt-dev/tilt
+website_url: https://tilt.dev
+docs_url: https://docs.tilt.dev
+install_command: brew install tilt
+category: Dev Tools
+tags: [kubernetes, devops, microservices, inner-loop, live-reload]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  An agent stack is several services (API, worker, vector DB, UI) that
+  nobody wants to docker-compose by hand every change. Tilt reads a
+  Tiltfile, rebuilds only what changed, live-updates containers, and
+  streams logs in one UI so local Kubernetes development matches how the
+  services run in staging.
+use_cases:
+  - Live-update a FastAPI agent backend and a Next.js UI on a local Kubernetes cluster
+  - Watch logs from embedding workers, Redis, and the API in one Tilt dashboard
+  - Share a Tiltfile so every engineer boots the same RAG demo stack with one command

--- a/tools/dev-tools/velero.yaml
+++ b/tools/dev-tools/velero.yaml
@@ -1,0 +1,22 @@
+name: Velero
+description: Kubernetes backup and disaster-recovery tool that snapshots cluster resources and persistent volumes, then restores them to the same or another cluster so ML teams can protect PVCs holding datasets, checkpoints, and feature stores.
+tagline: Backup and migrate Kubernetes apps and volumes
+github_url: https://github.com/vmware-tanzu/velero
+website_url: https://velero.io
+docs_url: https://velero.io/docs/
+install_command: brew install velero
+category: Dev Tools
+tags: [kubernetes, backup, disaster-recovery, volumes, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  etcd snapshots do not restore PVC-backed training data. Velero backups
+  Kubernetes objects plus volume snapshots to object storage, and can
+  restore a namespace or whole cluster after a failed upgrade, node loss,
+  or region move so datasets and model-serving state come back with the
+  workloads.
+use_cases:
+  - Nightly backup of namespaces that hold model-serving Deployments and dataset PVCs
+  - Migrate an ML workspace from a staging cluster to production with a Velero restore
+  - Recover a deleted feature-store PVC from an object-storage backup after an operator mistake


### PR DESCRIPTION
Add containerd, Cilium, Velero, Skaffold, and Tilt to the catalog.

Dev Tools batch:

- **containerd** (containerd/containerd, 21.2k, Apache-2.0) — CNCF container runtime
- **Cilium** (cilium/cilium, 25.0k, Apache-2.0) — eBPF networking and security for Kubernetes
- **Velero** (vmware-tanzu/velero, 10.3k, Apache-2.0) — Kubernetes backup and volume restore
- **Skaffold** (GoogleContainerTools/skaffold, 15.9k, Apache-2.0) — repeatable K8s inner-loop development
- **Tilt** (tilt-dev/tilt, 10.0k, Apache-2.0) — dev environment as code for K8s microservices

All files passed local `validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Cilium, containerd, Skaffold, Tilt, and Velero to the developer tools catalog.
  - Added descriptions, documentation links, categories, tags, licensing, pricing, installation details, and practical use cases for each tool.
  - Highlighted capabilities including Kubernetes networking, container management, development workflows, and backup and disaster recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->