### PR TITLE
Add Dagger, Earthly to catalog

### DIFF
--- a/tools/dev-tools/dagger.yaml
+++ b/tools/dev-tools/dagger.yaml
@@ -1,0 +1,22 @@
+name: Dagger
+description: Portable automation engine that builds, tests, and ships any codebase as a DAG of containers. Pipelines run the same locally, in CI, or in Dagger Cloud, so ML teams stop rewriting Docker-plus-Make glue for every provider.
+tagline: Container pipelines that run the same locally and in CI
+github_url: https://github.com/dagger/dagger
+website_url: https://dagger.io
+docs_url: https://docs.dagger.io
+install_command: brew install dagger/tap/dagger
+category: Dev Tools
+tags: [ci-cd, containers, pipelines, devops, sdk]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Training image builds and eval jobs are copy-pasted across GitHub Actions,
+  GitLab, and laptops, then drift. Dagger encodes those steps as typed
+  functions that run in containers, so the same pipeline builds a CUDA
+  image, runs tests, and pushes a model API whether you invoke it from a
+  laptop or from CI.
+use_cases:
+  - Encode CUDA image builds and pytest suites as Dagger functions shared by laptop and CI
+  - Replace brittle YAML CI with a typed pipeline that publishes a FastAPI inference image
+  - Run the same eval job graph locally against a GPU box and in GitHub Actions

--- a/tools/dev-tools/earthly.yaml
+++ b/tools/dev-tools/earthly.yaml
@@ -1,0 +1,22 @@
+name: Earthly
+description: Build framework that combines Dockerfile and Makefile ideas into Earthfiles. Each target is cached, parallelizable, and repeatable in containers so teams can build training images and CLIs the same way on a laptop and in CI.
+tagline: Dockerfile-plus-Makefile builds that cache and repeat
+github_url: https://github.com/earthly/earthly
+website_url: https://earthly.dev
+docs_url: https://docs.earthly.dev
+install_command: brew install earthly
+category: Dev Tools
+tags: [ci-cd, containers, builds, makefile, dockerfile, devops]
+pricing: freemium
+is_open_source: true
+license: MPL-2.0
+problem_solved: |
+  Dockerfiles cannot express multi-target graphs well, and Makefiles do not
+  isolate dependencies. Earthly runs each target in a container with
+  BuildKit caching, so compiling a tokenizer, baking a CUDA image, and
+  running tests share a cache and produce the same artifact in CI as on a
+  developer machine.
+use_cases:
+  - Build a CUDA training image and a CPU eval image from one Earthfile with shared cache
+  - Run lint, unit tests, and container publish as Earthly targets in GitHub Actions
+  - Reproduce a teammate's model-server image locally with the same Earthfile target


### PR DESCRIPTION
Add Dagger and Earthly to the catalog.

Dev Tools remainder:

- **Dagger** (dagger/dagger, 16.2k, Apache-2.0) — portable container pipelines
- **Earthly** (earthly/earthly, 12.0k, MPL-2.0) — Dockerfile-plus-Makefile builds

Kaniko and MinIO were skipped because their GitHub repos are archived.

Passed local `validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Dagger and Earthly to the developer tools catalog.
  - Included descriptions, documentation and repository links, installation instructions, licensing details, pricing models, and relevant tags.
  - Added example use cases for container image builds, CI workflows, test execution, and local build reproduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->