### PR TITLE
Add k3d, NSQ, Longhorn, Buildah, nerdctl to catalog

### DIFF
--- a/tools/data/longhorn.yaml
+++ b/tools/data/longhorn.yaml
@@ -1,0 +1,26 @@
+name: Longhorn
+description: Cloud-native distributed block storage built on and for Kubernetes. Longhorn adds replicated persistent volumes with snapshots, backups, and a UI so GPU jobs and vector databases can keep durable disks without a SAN.
+tagline: Kubernetes-native distributed block storage
+
+github_url: https://github.com/longhorn/longhorn
+website_url: https://longhorn.io
+docs_url: https://longhorn.io/docs
+
+category: Data
+tags: [kubernetes, block-storage, persistent-volumes, storage, cncf, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  GPU jobs, vector databases, and model caches need persistent disks on
+  Kubernetes, but cloud volumes are expensive and a SAN is operationally
+  heavy. Longhorn runs replicated block storage as pods on the cluster
+  itself, with snapshots, backups to S3, and a UI, so PVs survive node
+  failure without a separate storage appliance.
+
+use_cases:
+  - Give vector databases and feature stores replicated PersistentVolumes on Kubernetes
+  - Snapshot and back up model-cache disks to S3 from a Longhorn volume
+  - Run GPU training jobs that need durable local-like block storage across nodes
+  - Recover inference stateful sets after a node dies without a SAN

--- a/tools/data/nsq.yaml
+++ b/tools/data/nsq.yaml
@@ -1,0 +1,28 @@
+name: NSQ
+description: Realtime distributed messaging platform in Go. NSQ is a decentralized, fault-tolerant pub-sub system with nsqd, nsqlookupd, and nsqadmin, used to fan out events, jobs, and telemetry across ML and data pipelines.
+tagline: Decentralized realtime messaging for data pipelines
+
+github_url: https://github.com/nsqio/nsq
+website_url: https://nsq.io
+docs_url: https://nsq.io/overview/quick_start.html
+
+install_command: brew install nsq
+
+category: Data
+tags: [messaging, pub-sub, streaming, go, realtime, data-pipeline, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Centralized brokers become a bottleneck and a single point of failure when
+  you fan out jobs, logs, and inference events. NSQ is a decentralized
+  messaging platform: producers talk to nsqd, consumers discover topics via
+  nsqlookupd, and the topology scales by adding nodes instead of a shared
+  cluster quorum.
+
+use_cases:
+  - Fan out training-job events and dataset-ready notifications across workers
+  - Stream inference telemetry and feature updates without a single broker bottleneck
+  - Buffer scrape and ETL work behind nsqd so producers stay decoupled from consumers
+  - Operate a lightweight pub-sub backbone for ML services that do not need Kafka

--- a/tools/dev-tools/buildah.yaml
+++ b/tools/dev-tools/buildah.yaml
@@ -1,0 +1,27 @@
+name: Buildah
+description: Daemonless tool for building OCI container images without a Docker daemon. Buildah constructs images from Dockerfiles or scripted commits, used to bake CUDA training and inference images in CI and rootless environments.
+tagline: Daemonless OCI image builds without Docker
+
+github_url: https://github.com/containers/buildah
+website_url: https://buildah.io
+docs_url: https://github.com/containers/buildah/blob/main/docs/tutorials/01-intro.md
+
+install_command: dnf install buildah
+
+category: Dev Tools
+tags: [containers, oci, images, ci, rootless, podman, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building images with Docker needs a privileged daemon, which CI and
+  shared GPU boxes often forbid. Buildah builds OCI images from Dockerfiles
+  or scripted container commits without a daemon, as a regular user, so
+  training and inference images can be produced in locked-down pipelines.
+
+use_cases:
+  - Build CUDA training images in CI without a Docker daemon
+  - Script layered OCI images with buildah from, commit, and config instead of a Dockerfile
+  - Produce rootless inference images on shared machines where dockerd is banned
+  - Pair with Podman to build and run the same OCI images in air-gapped ML labs

--- a/tools/dev-tools/k3d.yaml
+++ b/tools/dev-tools/k3d.yaml
@@ -1,0 +1,27 @@
+name: k3d
+description: Little helper that runs CNCF k3s inside Docker. Spins up multi-node Kubernetes clusters as containers so you can test Helm charts, operators, and ML serving stacks locally without a VM or cloud cluster.
+tagline: Run k3s Kubernetes clusters inside Docker
+
+github_url: https://github.com/k3d-io/k3d
+website_url: https://k3d.io
+docs_url: https://k3d.io/stable/
+
+install_command: brew install k3d
+
+category: Dev Tools
+tags: [kubernetes, k3s, docker, local, ci, mlops, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Full Kubernetes clusters are slow to provision for local iteration, and even
+  k3s still wants a VM or a dedicated node. k3d wraps k3s in Docker so you get
+  a certified Kubernetes API as containers on a laptop or CI runner, then throw
+  the cluster away when the job finishes.
+
+use_cases:
+  - Spin up a multi-node k3s cluster in Docker to test Helm charts for LLM serving
+  - Run CI jobs that apply Kubernetes manifests without a cloud account
+  - Develop operators and CRDs against a disposable local Kubernetes API
+  - Workshop GPU and agent stacks on a laptop that already has Docker

--- a/tools/dev-tools/nerdctl.yaml
+++ b/tools/dev-tools/nerdctl.yaml
@@ -1,0 +1,27 @@
+name: nerdctl
+description: Docker-compatible CLI for containerd with Compose, rootless mode, and advanced image features. nerdctl lets you build, run, and compose containers against a containerd socket the same way Docker talks to dockerd.
+tagline: Docker-compatible CLI for containerd
+
+github_url: https://github.com/containerd/nerdctl
+website_url: https://github.com/containerd/nerdctl
+docs_url: https://github.com/containerd/nerdctl/blob/main/docs/command-reference.md
+
+install_command: brew install nerdctl
+
+category: Dev Tools
+tags: [containers, containerd, docker, compose, rootless, cli, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Kubernetes nodes and many ML clusters run containerd, not Docker, so the
+  Docker CLI cannot talk to the runtime. nerdctl is a Docker-compatible CLI
+  for containerd, including compose, rootless, and modern image formats, so
+  you can debug training and inference containers on the same engine K8s uses.
+
+use_cases:
+  - Debug GPU inference containers on a Kubernetes node that only has containerd
+  - Run docker-compose style stacks against containerd with nerdctl compose
+  - Build and run images rootless without a Docker daemon
+  - Inspect and manage containerd namespaces used by k3s, k3d, or kind clusters


### PR DESCRIPTION
## Add 5 tools to the catalog

- **k3d** (Dev Tools) — run CNCF k3s clusters inside Docker for local and CI Kubernetes
- **NSQ** (Data) — decentralized realtime pub-sub messaging platform
- **Longhorn** (Data) — Kubernetes-native distributed block storage
- **Buildah** (Dev Tools) — daemonless OCI image builds without Docker
- **nerdctl** (Dev Tools) — Docker-compatible CLI for containerd

All files passed local `validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Longhorn, NSQ, Buildah, k3d, and nerdctl.
  * Included descriptions, installation guidance, documentation links, licensing, pricing, categories, tags, and practical use cases.
  * Added coverage for storage, messaging, container image building, Kubernetes development, and containerd workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->