### PR TITLE
Add Calico, CoreDNS, Rook to catalog

### DIFF
--- a/tools/data/rook.yaml
+++ b/tools/data/rook.yaml
@@ -1,0 +1,26 @@
+name: Rook
+description: Storage orchestration operator for Kubernetes. Rook deploys and manages Ceph and other storage systems as Kubernetes-native services so GPU clusters get self-healing block, object, and file storage without a separate SAN team.
+tagline: Kubernetes-native storage orchestration for Ceph
+
+github_url: https://github.com/rook/rook
+website_url: https://rook.io
+docs_url: https://rook.io/docs/rook/latest/
+
+category: Data
+tags: [kubernetes, storage, ceph, operator, object-storage, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Running Ceph by hand for training datasets and model artifacts is a
+  full-time storage job. Rook is a Kubernetes operator that deploys,
+  heals, and upgrades Ceph (and related storage) as cluster services, so
+  GPU nodes get block, object, and file storage through the same API as
+  the rest of the platform.
+
+use_cases:
+  - Deploy Ceph on Kubernetes for S3-compatible storage of datasets and checkpoints
+  - Provision block volumes for vector databases via Rook-managed Ceph RBD
+  - Give a GPU cluster POSIX file storage through Rook CephFS without a SAN
+  - Self-heal storage daemons when a Kubernetes node running Ceph OSDs fails

--- a/tools/dev-tools/calico.yaml
+++ b/tools/dev-tools/calico.yaml
@@ -1,0 +1,25 @@
+name: Calico
+description: Cloud native networking and network security for Kubernetes. Calico provides CNI, network policy, and optional eBPF or iptables dataplanes so GPU clusters can isolate inference services and lock down east-west traffic.
+tagline: Kubernetes CNI and network policy for cluster security
+
+github_url: https://github.com/projectcalico/calico
+website_url: https://www.tigera.io/project-calico/
+docs_url: https://docs.tigera.io/calico/latest/about/
+
+category: Dev Tools
+tags: [kubernetes, cni, networking, security, network-policy, mlops, open-source]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Default Kubernetes networking is allow-all, so every pod can reach every
+  model server and vector DB. Calico is a CNI plus network-policy engine
+  (iptables or eBPF) that isolates namespaces and workloads so inference
+  APIs and training jobs only accept the traffic you explicitly allow.
+
+use_cases:
+  - Enforce NetworkPolicy so only the API gateway can reach a model-serving namespace
+  - Run Calico as the cluster CNI for GPU nodes that need stable pod networking
+  - Isolate training, feature-store, and inference namespaces on a shared cluster
+  - Use Calico eBPF dataplane for high-QPS east-west traffic without kube-proxy

--- a/tools/dev-tools/coredns.yaml
+++ b/tools/dev-tools/coredns.yaml
@@ -1,0 +1,27 @@
+name: CoreDNS
+description: Plugin-chaining DNS server used as the default cluster DNS in Kubernetes. CoreDNS answers service discovery queries and can add custom plugins so ML platforms resolve internal model, vector DB, and agent endpoints.
+tagline: Plugin-based DNS server for Kubernetes service discovery
+
+github_url: https://github.com/coredns/coredns
+website_url: https://coredns.io
+docs_url: https://coredns.io/manual/toc/
+
+install_command: brew install coredns
+
+category: Dev Tools
+tags: [dns, kubernetes, service-discovery, cncf, networking, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Containers and agents need stable names for model servers, vector DBs, and
+  internal APIs. CoreDNS is the default Kubernetes cluster DNS: a plugin
+  chain that answers Service and Pod queries and can be extended for custom
+  zones, so ML platforms do not hard-code IPs.
+
+use_cases:
+  - Resolve Kubernetes Service names for inference, embedding, and vector DB pods
+  - Add CoreDNS plugins for custom internal zones used by agent runtimes
+  - Run cluster DNS in CI kind or k3d clusters that boot ML stacks
+  - Replace a static hosts file with plugin-based DNS for local model endpoints


### PR DESCRIPTION
## Add 3 tools to the catalog

- **Calico** (Dev Tools) — Kubernetes CNI and network policy
- **CoreDNS** (Dev Tools) — plugin-based DNS server for cluster service discovery
- **Rook** (Data) — Kubernetes-native storage orchestration for Ceph

All files passed local `validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Rook to the tools catalog with storage orchestration details and use cases.
  * Added Calico with Kubernetes networking, policy, and eBPF capabilities.
  * Added CoreDNS with installation information, DNS features, and common use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->