### PR TITLE
Add Flannel, MetalLB, cert-manager, Kustomize, Falco to catalog

### DIFF
--- a/tools/dev-tools/cert-manager.yaml
+++ b/tools/dev-tools/cert-manager.yaml
@@ -1,0 +1,25 @@
+name: cert-manager
+description: Kubernetes controller that issues and renews TLS certificates from Let's Encrypt, private CAs, and vault-backed issuers. cert-manager keeps HTTPS on inference gateways and internal APIs valid without manual cert rotation.
+tagline: Automated TLS certificates for Kubernetes
+
+github_url: https://github.com/cert-manager/cert-manager
+website_url: https://cert-manager.io
+docs_url: https://cert-manager.io/docs/
+
+category: Dev Tools
+tags: [kubernetes, tls, certificates, security, ingress, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  TLS certs for model gateways expire, and copying PEMs into Secrets by
+  hand does not scale. cert-manager watches Certificate resources, talks
+  to ACME or an internal CA, and rotates Secrets so inference and agent
+  HTTPS endpoints stay valid.
+
+use_cases:
+  - Issue Let's Encrypt certs for a public LLM API Ingress automatically
+  - Rotate internal TLS for vector DB and embedding services from a private CA
+  - Keep mTLS secrets fresh for service-to-service agent traffic
+  - Standardize certificate issuance across GPU clusters with ClusterIssuers

--- a/tools/dev-tools/flannel.yaml
+++ b/tools/dev-tools/flannel.yaml
@@ -1,0 +1,25 @@
+name: Flannel
+description: Simple overlay network CNI for Kubernetes. Flannel assigns a subnet per node and routes pod traffic with VXLAN or host-gw so GPU clusters get working east-west networking without a full service mesh.
+tagline: Simple Kubernetes overlay networking CNI
+
+github_url: https://github.com/flannel-io/flannel
+website_url: https://github.com/flannel-io/flannel
+docs_url: https://github.com/flannel-io/flannel#flannel
+
+category: Dev Tools
+tags: [kubernetes, cni, networking, overlay, vxlan, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Pods on different nodes cannot talk until a CNI assigns addresses and
+  routes them. Flannel is a small overlay CNI that gives each node a subnet
+  and forwards traffic with VXLAN or host-gw, so ML clusters get working
+  pod networking without Calico-scale policy machinery.
+
+use_cases:
+  - Provide pod networking on a GPU Kubernetes cluster with a small CNI
+  - Use host-gw Flannel on a flat L2 lab so training jobs skip VXLAN overhead
+  - Boot kind, k3s, or kubeadm clusters that need a default overlay network
+  - Isolate east-west ML traffic to overlay subnets without a service mesh

--- a/tools/dev-tools/kustomize.yaml
+++ b/tools/dev-tools/kustomize.yaml
@@ -1,0 +1,27 @@
+name: Kustomize
+description: Template-free tool for customizing Kubernetes YAML. Kustomize overlays patches and replicas onto a base manifest so the same LLM serving stack can be deployed to dev, staging, and GPU production without Helm templates.
+tagline: Template-free Kubernetes YAML customization
+
+github_url: https://github.com/kubernetes-sigs/kustomize
+website_url: https://kustomize.io
+docs_url: https://kubectl.docs.kubernetes.io/references/kustomize/
+
+install_command: brew install kustomize
+
+category: Dev Tools
+tags: [kubernetes, yaml, gitops, overlays, kubectl, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Copying Deployment YAML per environment drifts, and Helm charts are heavy
+  for small patches. Kustomize keeps a base manifest and applies overlays
+  for replicas, images, and node selectors so one LLM stack definition
+  serves laptop, staging, and GPU clusters.
+
+use_cases:
+  - Overlay GPU nodeSelectors onto a base inference Deployment for production
+  - Patch image tags per environment without templating a Helm chart
+  - Generate ConfigMaps from files for prompt and model-config YAML
+  - Keep a GitOps repo with bases plus overlays for agent and RAG services

--- a/tools/dev-tools/metallb.yaml
+++ b/tools/dev-tools/metallb.yaml
@@ -1,0 +1,25 @@
+name: MetalLB
+description: Load-balancer implementation for bare-metal Kubernetes clusters. MetalLB announces Service IPs with BGP or ARP so on-prem GPU clusters can expose inference APIs without a cloud load balancer.
+tagline: Bare-metal load balancer for Kubernetes Services
+
+github_url: https://github.com/metallb/metallb
+website_url: https://metallb.io
+docs_url: https://metallb.io/installation/
+
+category: Dev Tools
+tags: [kubernetes, load-balancer, bare-metal, bgp, networking, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  LoadBalancer Services stay pending on bare metal because there is no cloud
+  LB controller. MetalLB assigns IPs from a pool and advertises them with
+  BGP or ARP so on-prem GPU clusters can expose inference, embedding, and
+  agent APIs the same way they would on AWS or GCP.
+
+use_cases:
+  - Expose an LLM inference Service with a LoadBalancer IP on a homelab cluster
+  - Announce GPU-node Services over BGP into the datacenter fabric
+  - Give on-prem vector DB and feature-store APIs stable external IPs
+  - Replace a manual HAProxy VIP with MetalLB for Kubernetes Services

--- a/tools/monitoring/falco.yaml
+++ b/tools/monitoring/falco.yaml
@@ -1,0 +1,25 @@
+name: Falco
+description: Cloud-native runtime security tool that detects unexpected behavior in containers and Kubernetes using kernel syscalls. Falco alerts on crypto miners, unexpected shells, and sensitive file access on GPU nodes running training and inference.
+tagline: Runtime security detection for Kubernetes and containers
+
+github_url: https://github.com/falcosecurity/falco
+website_url: https://falco.org
+docs_url: https://falco.org/docs/
+
+category: Monitoring
+tags: [security, kubernetes, runtime, containers, observability, cncf, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Image scans miss attacks that start after a pod is running. Falco watches
+  syscalls and Kubernetes audit events against rules so a GPU node running
+  training or inference alerts on unexpected shells, miners, and reads of
+  secrets or model files.
+
+use_cases:
+  - Alert when an inference container spawns an unexpected shell
+  - Detect crypto miners on GPU nodes that should only run training jobs
+  - Watch Kubernetes audit events for unexpected Secret or ConfigMap access
+  - Stream Falco alerts into an ML ops incident channel for runtime threats


### PR DESCRIPTION
## Add 5 tools to the catalog

- **Flannel** (Dev Tools) — simple Kubernetes overlay CNI
- **MetalLB** (Dev Tools) — bare-metal load balancer for Kubernetes Services
- **cert-manager** (Dev Tools) — automated TLS certificates for Kubernetes
- **Kustomize** (Dev Tools) — template-free Kubernetes YAML customization
- **Falco** (Monitoring) — runtime security detection for containers and Kubernetes

All files passed local `validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for cert-manager, Flannel, Kustomize, MetalLB, and Falco.
  * Included descriptions, documentation links, licensing and pricing details, and relevant use cases.
  * Added guidance covering Kubernetes networking, TLS certificates, deployments, service exposure, and runtime security monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->