### PR TITLE
Add Trivy, Harbor, BuildKit, Kyverno to catalog

### DIFF
--- a/tools/dev-tools/buildkit.yaml
+++ b/tools/dev-tools/buildkit.yaml
@@ -1,0 +1,27 @@
+name: BuildKit
+description: Concurrent, cache-efficient builder toolkit used by Docker Buildx. BuildKit parallelizes Dockerfile stages, mounts secrets, and caches layers so CUDA and Python ML images build faster in CI without leaking credentials.
+tagline: Concurrent cache-efficient container image builder
+
+github_url: https://github.com/moby/buildkit
+website_url: https://github.com/moby/buildkit
+docs_url: https://docs.docker.com/build/buildkit/
+
+install_command: brew install buildkit
+
+category: Dev Tools
+tags: [containers, docker, ci, images, cache, build, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Classic Docker builds are serial, cache poorly across CI runners, and
+  bake secrets into layers. BuildKit runs independent stages in parallel,
+  supports cache mounts and secret mounts, and is the engine behind
+  docker buildx so ML images compile faster without leaking keys.
+
+use_cases:
+  - Speed up CUDA image CI with parallel stages and registry cache
+  - Mount pip and apt caches so Python ML images rebuild without redownloading
+  - Inject Hugging Face tokens as BuildKit secrets instead of ENV layers
+  - Build multi-arch inference images with docker buildx and BuildKit

--- a/tools/dev-tools/harbor.yaml
+++ b/tools/dev-tools/harbor.yaml
@@ -1,0 +1,25 @@
+name: Harbor
+description: Cloud-native container registry that stores, signs, and scans images. Harbor adds RBAC, replication, and vulnerability scanning so ML teams can host private CUDA and model images instead of pushing everything to Docker Hub.
+tagline: Cloud-native registry with scan, sign, and RBAC
+
+github_url: https://github.com/goharbor/harbor
+website_url: https://goharbor.io
+docs_url: https://goharbor.io/docs/
+
+category: Dev Tools
+tags: [registry, containers, security, kubernetes, cncf, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Public registries rate-limit large CUDA pulls and offer little control
+  over who can push a model image. Harbor is a private registry with RBAC,
+  replication, signing, and scanning so GPU clusters pull trusted images
+  from inside the network.
+
+use_cases:
+  - Host private CUDA and inference images for an air-gapped GPU cluster
+  - Scan pushed model-serving images for CVEs before they are pullable
+  - Replicate images from a central Harbor to edge training sites
+  - Enforce RBAC so only CI can push tags used by production inference

--- a/tools/dev-tools/kyverno.yaml
+++ b/tools/dev-tools/kyverno.yaml
@@ -1,0 +1,25 @@
+name: Kyverno
+description: Kubernetes-native policy engine that validates, mutates, and generates resources with YAML policies. Kyverno blocks privileged GPU pods, injects node selectors, and generates NetworkPolicies without writing Rego.
+tagline: YAML policy as code for Kubernetes
+
+github_url: https://github.com/kyverno/kyverno
+website_url: https://kyverno.io
+docs_url: https://kyverno.io/docs/
+
+category: Dev Tools
+tags: [kubernetes, policy, security, admission, gitops, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Admission control with Rego is a specialist skill, so GPU clusters ship
+  with open privileged pods. Kyverno expresses validate, mutate, and
+  generate rules as Kubernetes YAML so platform teams can require
+  non-root inference, inject GPU nodeSelectors, and generate NetworkPolicies.
+
+use_cases:
+  - Block privileged containers on GPU nodes used for training
+  - Mutate inference Deployments to add the correct GPU nodeSelector
+  - Generate default NetworkPolicies for new ML namespaces
+  - Require resource limits on agent and vector DB workloads

--- a/tools/dev-tools/trivy.yaml
+++ b/tools/dev-tools/trivy.yaml
@@ -1,0 +1,27 @@
+name: Trivy
+description: All-in-one security scanner for container images, filesystems, git repos, Kubernetes, and clouds. Trivy finds CVEs, misconfigurations, secrets, and SBOMs so ML images and cluster YAML get scanned before they reach GPU nodes.
+tagline: Vulnerability and misconfig scanner for images and K8s
+
+github_url: https://github.com/aquasecurity/trivy
+website_url: https://trivy.dev
+docs_url: https://trivy.dev/latest/docs/
+
+install_command: brew install trivy
+
+category: Dev Tools
+tags: [security, containers, sbom, cve, kubernetes, scanning, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  CUDA and Python images ship with stale OS packages and leaked keys, and
+  cluster YAML often has open RBAC. Trivy scans images, filesystems, repos,
+  and Kubernetes for CVEs, secrets, and misconfigurations in one CLI so
+  training images fail CI before they hit a GPU node.
+
+use_cases:
+  - Scan CUDA training images for OS and Python CVEs in CI
+  - Detect secrets and API keys committed in an ML repo
+  - Audit Kubernetes RBAC and pod security for an inference cluster
+  - Generate SBOMs for model-serving images before a production release


### PR DESCRIPTION
## Add 4 tools to the catalog

- **Trivy** (Dev Tools) — vulnerability and misconfig scanner for images and Kubernetes
- **Harbor** (Dev Tools) — cloud-native registry with scan, sign, and RBAC
- **BuildKit** (Dev Tools) — concurrent cache-efficient container image builder
- **Kyverno** (Dev Tools) — YAML policy as code for Kubernetes

All files passed local `validate-tool.ts`.
