### PR TITLE
Add OpenFaaS, Knative, Contour, GoReleaser, external-dns to catalog

### DIFF
--- a/tools/dev-tools/contour.yaml
+++ b/tools/dev-tools/contour.yaml
@@ -1,0 +1,32 @@
+name: Contour
+description: >-
+  Kubernetes ingress controller built on Envoy. Contour watches Ingress and
+  HTTPProxy resources and programs Envoy for HTTP/HTTPS routing, TLS, and
+  traffic shifting so ML APIs, notebooks, and model gateways can sit behind a
+  single programmable edge without hand-editing Envoy YAML.
+tagline: Envoy-powered Kubernetes ingress controller
+
+github_url: https://github.com/projectcontour/contour
+website_url: https://projectcontour.io
+docs_url: https://projectcontour.io/docs/
+
+category: Dev Tools
+tags: [kubernetes, ingress, envoy, reverse-proxy, tls, traffic-management, cncf]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Exposing model servers, vector DBs, and internal ML apps on Kubernetes
+  usually means either limited Ingress objects or hand-maintained Envoy
+  configs that drift. Contour sits as a control plane in front of Envoy,
+  translating Kubernetes HTTPProxy and Ingress into live routes with TLS,
+  retries, and weighted routing so inference traffic can be shifted across
+  versions without restarting the data plane by hand.
+
+use_cases:
+  - Route HTTPS traffic to model serving, embedding, and notebook services on Kubernetes
+  - Shift a percentage of inference requests to a canary model deployment via HTTPProxy weights
+  - Terminate TLS for internal ML APIs and apply retries and timeouts at the Envoy edge
+  - Expose multiple RAG or agent backends on one cluster IP with host and path routing
+  - Replace ad-hoc Envoy ConfigMaps with Kubernetes-native HTTPProxy objects for ML gateways

--- a/tools/dev-tools/external-dns.yaml
+++ b/tools/dev-tools/external-dns.yaml
@@ -1,0 +1,31 @@
+name: external-dns
+description: >-
+  Kubernetes controller that keeps DNS records in sync with Services, Ingress,
+  and Gateway resources. It creates and updates records in Route 53, Cloudflare,
+  Google Cloud DNS, and other providers so model APIs and notebooks get stable
+  hostnames without manual DNS tickets.
+tagline: Sync Kubernetes resources to external DNS providers
+
+github_url: https://github.com/kubernetes-sigs/external-dns
+website_url: https://kubernetes-sigs.github.io/external-dns/
+docs_url: https://kubernetes-sigs.github.io/external-dns/
+
+category: Dev Tools
+tags: [kubernetes, dns, ingress, devops, networking, cloud, cncf]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Every new model endpoint, notebook, or staging inference service on
+  Kubernetes needs a DNS name, and updating Route 53 or Cloudflare by hand
+  lags deploys and leaves stale records after teardown. external-dns watches
+  annotated Services and Ingress objects and writes the matching records so
+  hostnames appear when workloads come up and disappear when they go away.
+
+use_cases:
+  - Auto-create DNS records for Ingress-backed model serving and RAG APIs
+  - Keep staging and canary inference hostnames in sync as Kubernetes services come and go
+  - Point custom domains at GPU notebook or labeling UIs without filing DNS tickets
+  - Clean up stale DNS records when ephemeral ML experiment namespaces are deleted
+  - Sync Gateway or Service hostnames to Route 53, Cloudflare, or Google Cloud DNS

--- a/tools/dev-tools/goreleaser.yaml
+++ b/tools/dev-tools/goreleaser.yaml
@@ -1,0 +1,33 @@
+name: GoReleaser
+description: >-
+  Release automation for Go, Rust, Zig, and other compiled projects. GoReleaser
+  builds binaries, archives, checksums, Homebrew formulas, Docker images, and
+  GitHub Releases from one config so ML CLIs, inference servers, and agent
+  runtimes ship consistently across platforms without custom release scripts.
+tagline: Release engineering, simplified
+
+github_url: https://github.com/goreleaser/goreleaser
+website_url: https://goreleaser.com
+docs_url: https://goreleaser.com
+install_command: brew install goreleaser
+
+category: Dev Tools
+tags: [go, release, ci-cd, packaging, docker, homebrew, devops]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: >-
+  Shipping an ML CLI or Go inference binary across macOS, Linux, and Windows
+  means repeating build flags, archive layouts, checksums, Homebrew taps, and
+  container tags in every CI job. GoReleaser collapses that into a single
+  YAML-driven pipeline that produces signed artifacts, changelogs, and
+  GitHub Releases so teams stop maintaining one-off release scripts that
+  break whenever a GOOS or Docker tag changes.
+
+use_cases:
+  - Publish multi-arch binaries for an ML CLI or agent runtime on every GitHub tag
+  - Build and push Docker images for Go model servers alongside GitHub Release archives
+  - Generate Homebrew formulas and checksums so internal AI tools install with brew
+  - Sign and upload release artifacts from CI without maintaining custom goreleaser-like scripts
+  - Ship Windows, Linux, and macOS builds of a vector-search or embedding CLI from one config

--- a/tools/dev-tools/knative.yaml
+++ b/tools/dev-tools/knative.yaml
@@ -1,0 +1,32 @@
+name: Knative
+description: >-
+  Kubernetes-based serverless platform that runs request-driven workloads with
+  scale-to-zero, traffic splitting, and revisioned deployments. Knative Serving
+  is widely used to host model APIs and event-driven ML jobs that should only
+  consume compute while they are handling traffic.
+tagline: Scale-to-zero serverless compute on Kubernetes
+
+github_url: https://github.com/knative/serving
+website_url: https://knative.dev
+docs_url: https://knative.dev/docs/serving/
+
+category: Dev Tools
+tags: [kubernetes, serverless, scale-to-zero, serving, mlops, traffic-splitting, cncf]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Model servers and inference APIs on Kubernetes typically stay at least one
+  replica hot, burning GPU and CPU even with no traffic, and rollouts require
+  custom ingress and canary wiring. Knative Serving gives each service a URL,
+  concurrency-based autoscaling including scale-to-zero, and first-class
+  revisions so teams can split traffic across model versions without writing
+  their own autoscaler or ingress controller.
+
+use_cases:
+  - Host model inference APIs that scale to zero overnight and scale out on burst traffic
+  - Canary a new model revision by splitting a percentage of requests to the new Knative revision
+  - Serve embedding or RAG backends as request-driven Knative services with concurrency limits
+  - Run event-driven preprocessing jobs that start from zero when a CloudEvent arrives
+  - Replace custom HPA plus ingress glue with Knative routes for GPU-backed model endpoints

--- a/tools/dev-tools/openfaas.yaml
+++ b/tools/dev-tools/openfaas.yaml
@@ -1,0 +1,32 @@
+name: OpenFaaS
+description: >-
+  Serverless functions platform for Kubernetes and VMs. Write functions in any
+  language, package them as containers, and deploy with a CLI or REST API.
+  Autoscaling includes scale-to-zero, so inference endpoints and event-driven
+  ML jobs only consume cluster resources when they have work.
+tagline: Serverless functions made simple on Kubernetes
+
+github_url: https://github.com/openfaas/faas
+website_url: https://www.openfaas.com
+docs_url: https://docs.openfaas.com
+
+category: Dev Tools
+tags: [serverless, kubernetes, functions, faas, containers, mlops, scale-to-zero]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: >-
+  Serving ML models and glue jobs as always-on services wastes cluster capacity
+  and turns every endpoint into an ops burden. OpenFaaS lets teams wrap any
+  container as a function with a single HTTP contract, then scale replicas up
+  from zero on demand and back down when idle. Templates, secrets, and a
+  watchdog process keep language choice and GPU images intact while giving
+  inference, webhooks, and batch triggers a uniform deploy path.
+
+use_cases:
+  - Deploy GPU or CPU model-serving functions that scale to zero between inference requests
+  - Wrap preprocessing, embedding, and postprocessing steps as independent functions in an ML pipeline
+  - Expose webhook handlers that trigger dataset ingest or retraining jobs without a standing service
+  - Package Python, Go, or custom container functions with one CLI for mixed-language AI backends
+  - Run event-driven batch scoring on Kubernetes with autoscaling based on queue depth or HTTP load


### PR DESCRIPTION
## Summary
Add five Kubernetes/release engineering tools to the Agentic AI For Good catalog:

- **OpenFaaS**: serverless functions on Kubernetes with scale-to-zero (openfaas/faas, 26k stars)
- **Knative**: request-driven Serving with revisions and traffic splitting (knative/serving, 6k stars)
- **Contour**: Envoy-powered Kubernetes ingress controller (projectcontour/contour, 3.9k stars)
- **GoReleaser**: multi-platform release automation (goreleaser/goreleaser, 16k stars)
- **external-dns**: sync Kubernetes Services/Ingress to DNS providers (kubernetes-sigs/external-dns, 9k stars)

All files passed local `validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Contour, ExternalDNS, GoReleaser, Knative, and OpenFaaS.
  * Included descriptions, capabilities, use cases, licensing, pricing, installation details, and project links for each tool.
  * Expanded visibility into Kubernetes networking, DNS, serverless platforms, release automation, and ML-focused workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->