### PR TITLE
Add Grype, cosign, Spegel to catalog

### DIFF
--- a/tools/dev-tools/cosign.yaml
+++ b/tools/dev-tools/cosign.yaml
@@ -1,0 +1,32 @@
+name: cosign
+description: >-
+  Sigstore tool for signing and verifying containers and binaries. Cosign
+  attaches signatures, SBOMs, and attestations to OCI images so ML teams can
+  prove a model server or training image came from trusted CI before it runs
+  on a GPU node.
+tagline: Sign and verify containers and binaries with Sigstore
+
+github_url: https://github.com/sigstore/cosign
+website_url: https://www.sigstore.dev
+docs_url: https://docs.sigstore.dev/cosign/system_config/installation/
+install_command: brew install cosign
+
+category: Dev Tools
+tags: [security, signing, containers, supply-chain, sigstore, oci, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  GPU clusters pull unsigned model-serving images and custom CUDA bases,
+  so a swapped tag or poisoned layer can run as production inference.
+  Cosign signs OCI artifacts and verifies signatures, SBOMs, and
+  attestations at deploy time, using keyless Sigstore identities or keys,
+  so only CI-built images are allowed onto training and serving nodes.
+
+use_cases:
+  - Sign model-serving and training images in CI so Kubernetes only pulls verified tags
+  - Verify image signatures in admission control before a GPU workload starts
+  - Attach SBOM and SLSA attestations to ML container builds for supply-chain audits
+  - Keyless-sign binaries and images with Sigstore without managing long-lived keys
+  - Enforce provenance on custom CUDA or PyTorch base images used across the org

--- a/tools/dev-tools/grype.yaml
+++ b/tools/dev-tools/grype.yaml
@@ -1,0 +1,33 @@
+name: Grype
+description: >-
+  Vulnerability scanner for container images, filesystems, and SBOMs. Grype
+  matches packages against vulnerability databases so ML images, CUDA bases,
+  and Python wheels get CVE findings before they reach a GPU cluster or
+  registry, with JSON output that CI can gate on.
+tagline: Scan container images and filesystems for CVEs
+
+github_url: https://github.com/anchore/grype
+website_url: https://anchore.com/opensource/grype/
+docs_url: https://github.com/anchore/grype
+install_command: brew install grype
+
+category: Dev Tools
+tags: [security, vulnerability-scanner, containers, sbom, ci-cd, devops, kubernetes]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  ML container images pull CUDA, PyTorch, and dozens of Python wheels, so
+  CVE debt lands in GPU clusters without anyone scanning the layers. Grype
+  inspects images, directories, and SBOMs, matches packages to known
+  vulnerabilities, and fails CI when severity thresholds are crossed, so
+  teams catch unpatched libraries before a training job or inference
+  service ships.
+
+use_cases:
+  - Scan GPU training and inference images for CVEs before pushing to a registry
+  - Gate pull requests when a Python or CUDA base image introduces a high-severity CVE
+  - Scan an SBOM from Syft to inventory vulnerabilities across an ML service
+  - Audit a local model-serving filesystem or unpacked container rootfs in CI
+  - Produce JSON vulnerability reports for Kubernetes admission or nightly image jobs

--- a/tools/dev-tools/spegel.yaml
+++ b/tools/dev-tools/spegel.yaml
@@ -1,0 +1,32 @@
+name: Spegel
+description: >-
+  Stateless cluster-local OCI registry mirror. Spegel peers Kubernetes nodes
+  so image pulls are served from the node that already has the layers,
+  cutting registry traffic and speeding GPU job startup when many workers
+  need the same PyTorch or CUDA image.
+tagline: Stateless cluster-local OCI registry mirror
+
+github_url: https://github.com/spegel-org/spegel
+website_url: https://spegel.dev
+docs_url: https://spegel.dev/docs/getting-started/
+
+category: Dev Tools
+tags: [kubernetes, registry, oci, containers, p2p, mlops, gpu]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: >-
+  Training and inference clusters pull the same multi-gigabyte CUDA and
+  PyTorch images onto every node from a remote registry, saturating
+  bandwidth and delaying job start. Spegel runs as a DaemonSet that
+  advertises local image layers and serves them to other nodes, so after
+  the first pull the rest of the cluster mirrors from peers instead of
+  the origin registry.
+
+use_cases:
+  - Mirror CUDA and PyTorch images across GPU nodes so workers start without re-pulling from a remote registry
+  - Cut registry bandwidth when autoscaling inference replicas that share a base image
+  - Speed ephemeral training job startup on Kubernetes by serving layers from peer nodes
+  - Keep clusters usable when the upstream registry is slow or rate-limited
+  - Deploy a DaemonSet registry mirror without standing up a full Harbor or registry replica


### PR DESCRIPTION
## Summary
Add three container supply-chain tools to the Agentic AI For Good catalog:

- **Grype**: vulnerability scanner for container images, filesystems, and SBOMs (anchore/grype, 12.8k stars)
- **cosign**: Sigstore signing and verification for containers and binaries (sigstore/cosign, 6.3k stars)
- **Spegel**: stateless cluster-local OCI registry mirror (spegel-org/spegel, 3.8k stars)

All files passed local `validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cosign to the developer-tools catalog for signing and verifying container images and binaries.
  * Added Grype for scanning containers, filesystems, SBOMs, CI pipelines, and Kubernetes environments for vulnerabilities.
  * Added Spegel, a cluster-local OCI registry mirror that helps speed image delivery and reduce registry bandwidth usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->