### PR TITLE
Add Open Policy Agent, Gatekeeper, Skopeo, CRI-O, wasmtime to catalog

### DIFF
--- a/tools/dev-tools/cri-o.yaml
+++ b/tools/dev-tools/cri-o.yaml
@@ -1,0 +1,31 @@
+name: CRI-O
+description: >-
+  OCI-based Kubernetes container runtime that implements the CRI. CRI-O
+  runs pods with containerd-compatible images and crun/runc so GPU
+  clusters can use a Kubernetes-focused runtime instead of a full Docker
+  stack, with cgroup and device support for NVIDIA workloads.
+tagline: Lightweight OCI runtime for Kubernetes
+
+github_url: https://github.com/cri-o/cri-o
+website_url: https://cri-o.io
+docs_url: https://github.com/cri-o/cri-o/blob/main/docs/crio.8.md
+
+category: Dev Tools
+tags: [kubernetes, cri, containers, oci, runtime, gpu, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Kubernetes needs a CRI runtime, and shipping Docker Engine on every
+  GPU node adds a daemon, extra APIs, and a larger attack surface.
+  CRI-O implements only what kubelet needs to pull OCI images and run
+  pods, including device plugins for GPUs, so training and inference
+  nodes stay Kubernetes-native without a full Docker install.
+
+use_cases:
+  - Run Kubernetes GPU nodes with an OCI CRI runtime instead of Docker Engine
+  - Pull and start PyTorch or CUDA pods through kubelet with runc or crun
+  - Standardize training cluster runtimes on CRI-O for OpenShift or vanilla Kubernetes
+  - Reduce node attack surface by dropping unused Docker APIs on inference workers
+  - Integrate NVIDIA device plugins with a CRI that supports host devices and cgroups

--- a/tools/dev-tools/gatekeeper.yaml
+++ b/tools/dev-tools/gatekeeper.yaml
@@ -1,0 +1,32 @@
+name: Gatekeeper
+description: >-
+  Kubernetes policy controller that runs Open Policy Agent as an admission
+  webhook. Gatekeeper enforces ConstraintTemplates so clusters can require
+  resource limits, block privileged GPU pods, and audit existing objects
+  without wrapping every controller in custom admission code.
+tagline: OPA admission control for Kubernetes
+
+github_url: https://github.com/open-policy-agent/gatekeeper
+website_url: https://open-policy-agent.github.io/gatekeeper/
+docs_url: https://open-policy-agent.github.io/gatekeeper/website/docs/
+
+category: Dev Tools
+tags: [kubernetes, policy, opa, admission, security, governance, mlops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  GPU clusters accumulate privileged pods, missing limits, and unlabeled
+  namespaces because admission is optional and Rego is hard to wire in.
+  Gatekeeper installs OPA as a validating and mutating webhook with
+  ConstraintTemplates, so platform teams express cluster rules as
+  Kubernetes objects and reject or audit workloads that violate GPU,
+  security, or labeling policy.
+
+use_cases:
+  - Block privileged or hostNetwork pods in GPU training namespaces
+  - Require resource limits and GPU requests on inference Deployments
+  - Audit existing cluster objects against policy without rejecting live workloads
+  - Mutate labels or nodeSelectors on ML jobs at admission time
+  - Share ConstraintTemplates so every cluster enforces the same model-serving rules

--- a/tools/dev-tools/open-policy-agent.yaml
+++ b/tools/dev-tools/open-policy-agent.yaml
@@ -1,0 +1,33 @@
+name: Open Policy Agent
+description: >-
+  General-purpose policy engine that evaluates Rego against JSON. OPA is used
+  as a sidecar or library to authorize API calls, admission requests, and
+  data access so ML platforms can encode who may deploy models, call GPUs,
+  or read datasets without baking rules into every service.
+tagline: Policy as code for APIs, Kubernetes, and data
+
+github_url: https://github.com/open-policy-agent/opa
+website_url: https://www.openpolicyagent.org
+docs_url: https://www.openpolicyagent.org/docs/latest/
+install_command: brew install opa
+
+category: Dev Tools
+tags: [policy, rego, authorization, kubernetes, security, admission, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Authorization for model APIs, GPU quotas, and dataset access is often
+  scattered across app code and ad-hoc scripts, so rules drift and audits
+  fail. Open Policy Agent centralizes those decisions in Rego policies
+  evaluated against JSON input, letting services ask a sidecar or library
+  whether a request is allowed instead of reimplementing access control
+  in every inference and training service.
+
+use_cases:
+  - Authorize who can invoke a model-serving API or start a GPU training job
+  - Evaluate Kubernetes admission requests against Rego policies for ML namespaces
+  - Gate dataset and feature-store reads with policy that inspects identity and labels
+  - Run OPA as a sidecar next to an agent or RAG API for request-time authorization
+  - Unit-test Rego policies in CI so GPU and data access rules do not silently change

--- a/tools/dev-tools/skopeo.yaml
+++ b/tools/dev-tools/skopeo.yaml
@@ -1,0 +1,33 @@
+name: Skopeo
+description: >-
+  CLI for inspecting, copying, and signing images across OCI registries
+  without a local Docker daemon. Skopeo copies model and CUDA images
+  between registries, inspects manifests, and syncs tags so ML pipelines
+  can promote artifacts without pulling full layers onto a build laptop.
+tagline: Copy and inspect images across OCI registries
+
+github_url: https://github.com/podman-container-tools/skopeo
+website_url: https://github.com/podman-container-tools/skopeo
+docs_url: https://github.com/podman-container-tools/skopeo/blob/main/docs/skopeo.1.md
+install_command: brew install skopeo
+
+category: Dev Tools
+tags: [containers, oci, registry, images, devops, ci-cd, podman]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Promoting a PyTorch or CUDA image between registries usually means
+  docker pull then docker push, which needs a daemon, disk for every
+  layer, and extra credentials. Skopeo copies, inspects, and deletes
+  remote images by talking to registries directly, so CI can move
+  model artifacts across Harbor, ECR, or GHCR without a local Docker
+  socket or a full layer cache.
+
+use_cases:
+  - Copy a signed model-serving image from CI into a production registry without docker pull
+  - Inspect OCI manifests and digests of CUDA base images before a training job
+  - Sync tags between Harbor and a cloud registry as part of an ML promotion pipeline
+  - Delete stale experiment image tags from a registry without a Docker daemon
+  - Verify remote image architecture and layers before scheduling GPU workloads

--- a/tools/dev-tools/wasmtime.yaml
+++ b/tools/dev-tools/wasmtime.yaml
@@ -1,0 +1,32 @@
+name: wasmtime
+description: >-
+  Bytecode Alliance WebAssembly runtime with Cranelift JIT. Wasmtime
+  embeds WASI and a C/Rust/Python API so teams can run sandboxed
+  inference plugins, data transforms, and agent tools as Wasm modules
+  instead of unsandboxed native code.
+tagline: Fast, standards-compliant WebAssembly runtime
+
+github_url: https://github.com/bytecodealliance/wasmtime
+website_url: https://wasmtime.dev
+docs_url: https://docs.wasmtime.dev
+install_command: brew install wasmtime
+
+category: Dev Tools
+tags: [webassembly, wasm, runtime, wasi, sandbox, rust, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Embedding untrusted preprocessing, tools, or model plugins next to an
+  agent means running native code with the host's privileges. Wasmtime
+  executes WebAssembly with WASI and fuel/limits so those plugins run
+  in a sandbox with explicit capabilities, while Cranelift keeps
+  startup and throughput viable for request-path transforms.
+
+use_cases:
+  - Run sandboxed preprocessing or tokenization plugins beside a model server
+  - Embed Wasm tools in an agent runtime so third-party functions cannot escape the host
+  - Execute WASI modules for data transforms in CI without shipping language-specific binaries
+  - Cap CPU via Wasmtime fuel so a runaway plugin cannot stall an inference process
+  - Prototype portable ML glue code once and run it on Linux, macOS, and embedding hosts


### PR DESCRIPTION
## Summary
Add five policy, container, and Wasm runtime tools to the Agentic AI For Good catalog:

- **Open Policy Agent**: general-purpose Rego policy engine (open-policy-agent/opa, 12.2k stars)
- **Gatekeeper**: Kubernetes admission controller built on OPA (open-policy-agent/gatekeeper, 4.3k stars)
- **Skopeo**: copy and inspect OCI images without a Docker daemon (podman-container-tools/skopeo, 11.2k stars)
- **CRI-O**: OCI CRI runtime for Kubernetes (cri-o/cri-o, 5.7k stars)
- **wasmtime**: Bytecode Alliance WebAssembly runtime (bytecodealliance/wasmtime, 18.6k stars)

All files passed local `validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for CRI-O, Gatekeeper, Open Policy Agent, Skopeo, and Wasmtime.
  * Included descriptions, installation details, links, licensing, pricing, categories, and relevant use cases.
  * Expanded discoverability of tools for Kubernetes, policy management, container images, WebAssembly, GPU, and ML workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->