### PR TITLE
Add Wasmer, Spin, Syft, WasmEdge to catalog

### DIFF
--- a/tools/dev-tools/spin.yaml
+++ b/tools/dev-tools/spin.yaml
@@ -1,0 +1,31 @@
+name: Spin
+description: >-
+  Open-source toolchain for building serverless apps with WebAssembly.
+  Spin compiles HTTP, Redis, and storage components to Wasm so ML glue
+  APIs, webhooks, and lightweight inference frontends start in
+  milliseconds without a full container stack.
+tagline: Serverless WebAssembly applications
+
+github_url: https://github.com/spinframework/spin
+website_url: https://spinframework.dev
+docs_url: https://spinframework.dev/docs
+
+category: Dev Tools
+tags: [webassembly, wasm, serverless, spin, wasi, edge, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Tiny HTTP handlers for model webhooks, embeddings, or routing still
+  ship as containers with multi-second cold starts and a large image.
+  Spin builds those handlers as Wasm components with WASI interfaces
+  for HTTP and key-value, so the same app runs locally and on a
+  Spin-compatible host with millisecond startup and a smaller sandbox.
+
+use_cases:
+  - Build a millisecond-start HTTP frontend in front of a model-serving backend
+  - Handle dataset or labeling webhooks as Wasm functions without a standing Node service
+  - Compose Redis and HTTP Spin components for a lightweight RAG routing API
+  - Develop locally with the Spin CLI and deploy the same Wasm artifact to a cluster
+  - Isolate untrusted request handlers in Wasm instead of a full sidecar container

--- a/tools/dev-tools/syft.yaml
+++ b/tools/dev-tools/syft.yaml
@@ -1,0 +1,32 @@
+name: Syft
+description: >-
+  CLI and library that generates Software Bills of Materials from
+  container images, filesystems, and archives. Syft inventories OS
+  packages and language deps so ML images can be scanned, signed, and
+  compared before they reach a GPU cluster.
+tagline: Generate SBOMs from containers and filesystems
+
+github_url: https://github.com/anchore/syft
+website_url: https://github.com/anchore/syft
+docs_url: https://github.com/anchore/syft
+install_command: brew install syft
+
+category: Dev Tools
+tags: [sbom, security, containers, supply-chain, grype, devops, ci-cd]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  CUDA and PyTorch images hide hundreds of OS and Python packages, so
+  teams cannot tell what they shipped or feed a scanner. Syft walks
+  images and directories, emits SPDX, CycloneDX, or Syft JSON SBOMs,
+  and pairs with Grype so vulnerability and license review starts from
+  an inventory instead of a black-box tag.
+
+use_cases:
+  - Generate an SBOM for a GPU training image and attach it to a release
+  - Inventory Python and OS packages in a model-serving container before deploy
+  - Feed Syft JSON into Grype to scan CVEs without re-unpacking the image
+  - Compare SBOMs across CUDA base image upgrades to see what packages changed
+  - Produce SPDX or CycloneDX for compliance on internal ML runtimes

--- a/tools/dev-tools/wasmedge.yaml
+++ b/tools/dev-tools/wasmedge.yaml
@@ -1,0 +1,32 @@
+name: WasmEdge
+description: >-
+  Lightweight WebAssembly runtime aimed at cloud-native and edge apps.
+  WasmEdge runs WASI, HTTP, and TensorFlow Lite plugins so inference
+  and stream processing can run in a sandbox on Kubernetes, edge
+  devices, and embedded hosts without a full OS container.
+tagline: Cloud-native WebAssembly runtime for edge and serverless
+
+github_url: https://github.com/WasmEdge/WasmEdge
+website_url: https://wasmedge.org
+docs_url: https://wasmedge.org/docs/
+
+category: Dev Tools
+tags: [webassembly, wasm, runtime, edge, serverless, kubernetes, tflite]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Running small inference or stream functions on edge nodes still
+  means a container runtime, a large image, and weak isolation for
+  plugins. WasmEdge executes Wasm with host extensions for networking
+  and TensorFlow Lite, so those functions run as sandboxed modules
+  under Kubernetes or on a device with a smaller footprint than OCI
+  pods.
+
+use_cases:
+  - Run TensorFlow Lite or lightweight inference as a Wasm module on edge devices
+  - Schedule Wasm functions on Kubernetes instead of full containers for glue APIs
+  - Embed WasmEdge in a service to load untrusted preprocessing plugins safely
+  - Process streaming events with WASI modules at the cluster edge
+  - Prototype portable ML helpers that run the same way on Linux servers and devices

--- a/tools/dev-tools/wasmer.yaml
+++ b/tools/dev-tools/wasmer.yaml
@@ -1,0 +1,32 @@
+name: Wasmer
+description: >-
+  Universal WebAssembly runtime that runs WASI modules as lightweight
+  containers. Wasmer embeds in hosts and ships a CLI so teams can package
+  inference helpers, agent tools, and edge functions as Wasm instead of
+  OS-level containers.
+tagline: Fast, secure WebAssembly containers
+
+github_url: https://github.com/wasmerio/wasmer
+website_url: https://wasmer.io
+docs_url: https://docs.wasmer.io
+install_command: brew install wasmer
+
+category: Dev Tools
+tags: [webassembly, wasm, runtime, wasi, containers, edge, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: >-
+  Shipping small tools next to an agent or model server usually means
+  another container image, another CVE surface, and slower cold start.
+  Wasmer runs WebAssembly with WASI so those tools become portable
+  modules with a sandbox, a registry of packages, and a CLI, without
+  standing up a full OCI runtime for every plugin.
+
+use_cases:
+  - Run sandboxed agent tools or data transforms as WASI modules instead of sidecar containers
+  - Embed a Wasm runtime in a Python or Rust model server to load user-supplied plugins
+  - Package edge inference helpers once and run them on laptops, servers, and edge hosts
+  - Publish and consume Wasm packages for reusable ML preprocessing steps
+  - Replace heavyweight micro-containers for glue jobs with faster Wasm startup


### PR DESCRIPTION
## Summary
Add four WebAssembly runtime and SBOM tools to the Agentic AI For Good catalog:

- **Wasmer**: universal WebAssembly runtime (wasmerio/wasmer, 21k stars)
- **Spin**: serverless WebAssembly apps (spinframework/spin, 6.5k stars)
- **Syft**: SBOM generator for containers and filesystems (anchore/syft, 9.5k stars)
- **WasmEdge**: cloud-native WebAssembly runtime (WasmEdge/WasmEdge, 10.8k stars)

All files passed local `validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Spin, Syft, WasmEdge, and Wasmer.
  * Added searchable metadata including descriptions, documentation links, installation details, licensing, pricing, categories, and tags.
  * Added practical use cases covering serverless WebAssembly, SBOM generation, portable machine learning, sandboxing, and lightweight application deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->