### PR TITLE
Add ORAS, Lima, Colima, CubeFS, zot to catalog

### DIFF
--- a/tools/data/cubefs.yaml
+++ b/tools/data/cubefs.yaml
@@ -1,0 +1,25 @@
+name: CubeFS
+description: Cloud-native distributed storage that unifies file, object, and blob access for large datasets. CubeFS is a CNCF project used to store training data, model artifacts, and logs with multi-tenant isolation and POSIX plus S3-compatible APIs.
+tagline: Cloud-native file, object, and blob storage for AI data
+
+github_url: https://github.com/cubefs/cubefs
+website_url: https://cubefs.io
+docs_url: https://cubefs.io/docs/
+
+category: Data
+tags: [storage, distributed, s3, posix, cncf, datasets]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI clusters need shared storage that can look like a POSIX filesystem to trainers and like
+  S3 to data pipelines, without running separate NAS and object stacks. CubeFS provides
+  multi-tenant file, object, and blob volumes on commodity disks so training jobs, feature
+  stores, and model registries share one scalable backend.
+
+use_cases:
+  - Mount POSIX volumes for distributed training jobs that stream large datasets from shared disks
+  - Expose S3-compatible buckets for feature stores, checkpoints, and experiment artifacts
+  - Isolate team datasets with multi-tenant volumes while sharing the same storage cluster
+  - Back Kubernetes persistent volumes for model serving and batch inference workloads

--- a/tools/dev-tools/colima.yaml
+++ b/tools/dev-tools/colima.yaml
@@ -1,0 +1,25 @@
+name: Colima
+description: Container runtimes on macOS and Linux with minimal setup. Colima wraps Lima to provide Docker and containerd APIs, a docker context, volume mounts, and optional Kubernetes so you can run Compose stacks without Docker Desktop.
+tagline: Docker and Kubernetes on macOS without Docker Desktop
+
+github_url: https://github.com/abiosoft/colima
+website_url: https://colima.run
+docs_url: https://github.com/abiosoft/colima#readme
+install_command: brew install colima
+
+category: Dev Tools
+tags: [containers, docker, kubernetes, macos, lima, local-dev]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Docker Desktop on macOS is licensed for many companies and often overkill for local Compose
+  and Kubernetes work. Colima starts a Lima VM, exposes the Docker API, and optionally k3s so
+  existing docker and kubectl workflows keep working with an open-source runtime.
+
+use_cases:
+  - Run docker compose stacks for local RAG apps, vector DBs, and model servers on a Mac
+  - Point the Docker CLI at Colima instead of Docker Desktop for CI-like local builds
+  - Enable Colima Kubernetes to test Helm charts and inference services before cluster deploy
+  - Mount project directories into containers for iterative ML service development

--- a/tools/dev-tools/lima.yaml
+++ b/tools/dev-tools/lima.yaml
@@ -1,0 +1,26 @@
+name: Lima
+description: Linux virtual machines on macOS, Linux, and Windows with a focus on running containers. Lima provides automatic file sharing, port forwarding, and first-class containerd support so you can develop Linux workloads without Docker Desktop.
+tagline: Linux VMs for running containers on your laptop
+
+github_url: https://github.com/lima-vm/lima
+website_url: https://lima-vm.io/
+docs_url: https://lima-vm.io/docs/
+install_command: brew install lima
+
+category: Dev Tools
+tags: [virtualization, containers, macos, linux, devops, local-dev]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI engineers on macOS need a Linux environment for containerd, GPU-adjacent tooling, and
+  Kubernetes-like local stacks, but Docker Desktop is heavy, licensed, and opinionated.
+  Lima boots a lightweight Linux VM with shared filesystems and port forwarding so nerdctl,
+  k3s, and other Linux container tools run locally with minimal setup.
+
+use_cases:
+  - Run containerd and nerdctl on a Mac to build and test Linux container images locally
+  - Spin up a k3s or k8s cluster inside a Lima VM for local ML serving experiments
+  - Share project directories into a Linux guest so training scripts see the same files as the host
+  - Replace Docker Desktop with an Apache-2.0 VM layer that Colima and other tools already use

--- a/tools/dev-tools/oras.yaml
+++ b/tools/dev-tools/oras.yaml
@@ -1,0 +1,26 @@
+name: ORAS
+description: OCI Registry As Storage CLI and libraries for pushing, pulling, and attaching artifacts to any OCI-compliant registry. ORAS treats Helm charts, SBOMs, WASM modules, and ML model files as first-class registry content alongside container images.
+tagline: Push any artifact to an OCI registry, not just container images
+
+github_url: https://github.com/oras-project/oras
+website_url: https://oras.land
+docs_url: https://oras.land/docs/
+install_command: brew install oras
+
+category: Dev Tools
+tags: [oci, containers, registry, artifacts, devops, mlops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  ML and platform teams already run OCI registries for container images, but model weights,
+  SBOMs, Helm charts, and WASM modules live in separate stores with different auth, versioning,
+  and promotion rules. ORAS uses the OCI distribution spec so any artifact can be stored,
+  tagged, signed, and promoted through the same registry you already operate.
+
+use_cases:
+  - Push versioned ML model weights and config bundles to an OCI registry next to serving images
+  - Attach SBOMs and signatures to container images as OCI referrers for supply-chain scans
+  - Store Helm charts and WASM modules in the same registry used for Kubernetes deployments
+  - Copy artifacts between air-gapped and cloud registries without converting formats

--- a/tools/dev-tools/zot.yaml
+++ b/tools/dev-tools/zot.yaml
@@ -1,0 +1,25 @@
+name: zot
+description: Vendor-neutral OCI-native container image and artifact registry built on the OCI Distribution Specification. zot is a scale-out, production-ready registry for images, Helm charts, and ORAS artifacts without vendor lock-in to Docker Hub or cloud registries.
+tagline: Vendor-neutral OCI registry for images and artifacts
+
+github_url: https://github.com/project-zot/zot
+website_url: https://zotregistry.dev
+docs_url: https://zotregistry.dev/latest/
+
+category: Dev Tools
+tags: [oci, registry, containers, artifacts, cncf, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Teams that want an OCI registry they can self-host often get a Docker Hub clone or a cloud
+  vendor product with extra APIs. zot implements only the OCI distribution spec, so images,
+  Helm charts, and ORAS artifacts store the same way in air-gapped, edge, and production
+  clusters without a vendor control plane.
+
+use_cases:
+  - Self-host an OCI registry for ML serving images and ORAS-pushed model artifacts
+  - Mirror upstream images into an air-gapped cluster that still speaks standard OCI APIs
+  - Store Helm charts and SBOMs next to container images in one spec-compliant registry
+  - Run a lightweight registry at the edge for offline model and image distribution


### PR DESCRIPTION
## Add 5 tools to the catalog

Container and storage infrastructure used in local ML development and artifact distribution.

| Tool | Category | Notes |
|------|----------|-------|
| ORAS | Dev Tools | OCI Registry As Storage CLI (`oras-project/oras`, 2.4k★) |
| Lima | Dev Tools | Linux VMs for containers (`lima-vm/lima`, 21.8k★) |
| Colima | Dev Tools | Docker/Kubernetes on macOS without Docker Desktop (`abiosoft/colima`, 30.6k★) |
| CubeFS | Data | CNCF distributed file/object/blob storage (`cubefs/cubefs`, 5.6k★) |
| zot | Dev Tools | Vendor-neutral OCI-native registry (`project-zot/zot`, 2.7k★) |

zot has no Homebrew formula for the registry (brew `zot` is an unrelated coding agent). Install command omitted; the product is a Go/OCI registry.

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for CubeFS, Colima, Lima, ORAS, and zot.
  - Included descriptions, categories, tags, licensing and pricing details, installation guidance, links, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->