### PR TITLE
Add Telepresence, mirrord, Buck2 to catalog

### DIFF
--- a/tools/dev-tools/buck2.yaml
+++ b/tools/dev-tools/buck2.yaml
@@ -1,0 +1,25 @@
+name: Buck2
+description: Fast, correct build system from Meta and the successor to Buck. Buck2 uses a Rust engine and Starlark configuration for hermetic, incrementally cached builds of large monorepos spanning C++, Python, and ML tooling.
+tagline: Hermetic, incremental builds for large monorepos
+
+github_url: https://github.com/facebook/buck2
+website_url: https://buck2.build/
+docs_url: https://buck2.build/docs/getting_started/
+
+category: Dev Tools
+tags: [build-system, monorepo, rust, starlark, bazel, ci]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Large AI codebases mix CUDA kernels, Python packages, and native libs that Make and ad-hoc
+  scripts rebuild too often and Bazel can be heavy to adopt. Buck2 provides a hermetic graph
+  with remote execution and fine-grained incrementality so training stacks and inference
+  binaries rebuild only what changed.
+
+use_cases:
+  - Build mixed Python and C++ ML repos with cached, hermetic targets instead of ad-hoc scripts
+  - Share remote-execution cache across CI and developer machines for CUDA and native deps
+  - Define Starlark rules for packaging model-serving binaries alongside training tools
+  - Migrate from Buck1 or reduce full-repo rebuilds when only one library changed

--- a/tools/dev-tools/mirrord.yaml
+++ b/tools/dev-tools/mirrord.yaml
@@ -1,0 +1,26 @@
+name: mirrord
+description: Run any local process as if it were a pod in your Kubernetes cluster. mirrord steals or mirrors traffic and injects real env vars, DNS, and network so AI agents and developers can test against cluster dependencies without a container rebuild.
+tagline: Run local processes with the cluster's env, DNS, and traffic
+
+github_url: https://github.com/metalbear-co/mirrord
+website_url: https://metalbear.com/mirrord
+docs_url: https://metalbear.com/mirrord/docs/overview/quick-start/
+install_command: brew install metalbear-co/mirrord/mirrord
+
+category: Dev Tools
+tags: [kubernetes, local-dev, debugging, agents, devops, rust]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Local processes cannot see cluster ConfigMaps, Secrets, service DNS, or east-west traffic,
+  so teams containerize every change just to hit real dependencies. mirrord wraps a local
+  binary or an AI agent's runtime so it inherits the pod's environment and network, shrinking
+  the inner loop for services that talk to in-cluster models and data stores.
+
+use_cases:
+  - Debug a local API that must call in-cluster vector DBs and model servers by service DNS
+  - Let a coding agent run tests against cluster Secrets and ConfigMaps without deploying it
+  - Mirror production-like traffic to a local process while the cluster pod keeps serving
+  - Iterate on a microservice in an IDE with the same env vars the Kubernetes pod would have

--- a/tools/dev-tools/telepresence.yaml
+++ b/tools/dev-tools/telepresence.yaml
@@ -1,0 +1,25 @@
+name: Telepresence
+description: Local development against a remote Kubernetes or OpenShift cluster. Telepresence intercepts cluster traffic so you can run a service on your laptop with your own IDE and debugger while the rest of the mesh still talks to it as a cluster pod.
+tagline: Code locally as if your process were a pod in the cluster
+
+github_url: https://github.com/telepresenceio/telepresence
+website_url: https://www.telepresence.io
+docs_url: https://www.telepresence.io/docs/quick-start
+
+category: Dev Tools
+tags: [kubernetes, local-dev, debugging, intercept, devops, microservices]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Debugging a service that depends on cluster DNS, sidecars, and other in-cluster APIs usually
+  means rebuild, push, and wait for a rollout. Telepresence connects your workstation to the
+  cluster network and can replace or intercept a workload so local code gets real cluster
+  traffic, env, and DNS without a full deploy cycle.
+
+use_cases:
+  - Replace a cluster Deployment with a local process to debug with your IDE against live traffic
+  - Intercept one service port while the remote container keeps running for safer experiments
+  - Wiretap production-like traffic to a local ML inference stub without disturbing the workload
+  - Reach in-cluster vector DBs and model servers by DNS from a laptop during development


### PR DESCRIPTION
## Add 3 tools to the catalog

Kubernetes local-dev and hermetic build tooling.

| Tool | Category | Notes |
|------|----------|-------|
| Telepresence | Dev Tools | Local process as a cluster member (`telepresenceio/telepresence`, 7.3k★) |
| mirrord | Dev Tools | Steal/mirror cluster env and traffic to a local process (`metalbear-co/mirrord`, 5.3k★) |
| Buck2 | Dev Tools | Meta's successor to Buck (`facebook/buck2`, 4.4k★) |

Telepresence and Buck2 ship OS-specific binaries, so `install_command` is omitted. mirrord uses `brew install metalbear-co/mirrord/mirrord`.

Local validation passed for all three YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Buck2 to the developer tools catalog, including build, caching, migration, and rule-definition use cases.
  * Added mirrord with metadata covering local debugging and testing against Kubernetes environments.
  * Added Telepresence with information on cluster connectivity, traffic interception, and local development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->