### PR TITLE
Add minikube, k0s, stern, kubectx, dive to catalog

### DIFF
--- a/tools/dev-tools/dive.yaml
+++ b/tools/dev-tools/dive.yaml
@@ -1,0 +1,25 @@
+name: dive
+description: Explore each layer in a Docker or OCI image. dive shows wasted space, file diffs between layers, and an efficiency score so you can shrink ML base images and catch secrets or caches that bloat serving containers.
+tagline: Inspect Docker image layers and find wasted space
+
+github_url: https://github.com/wagoodman/dive
+website_url: https://github.com/wagoodman/dive
+docs_url: https://github.com/wagoodman/dive#readme
+install_command: brew install dive
+
+category: Dev Tools
+tags: [docker, oci, images, cli, devops, optimization]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  ML images balloon when pip caches, CUDA leftovers, and copy-paste Dockerfiles land in
+  early layers. docker history is too coarse to see which files survived. dive walks each
+  layer interactively so you can cut image size and keep model-serving pull times down.
+
+use_cases:
+  - Find pip cache and apt leftovers that inflate CUDA serving images
+  - Compare layers after a Dockerfile change to confirm a multi-stage build actually dropped compilers
+  - Hunt accidentally copied .env files or model checkpoints inside an image
+  - Score image efficiency in CI before pushing a training or inference image

--- a/tools/dev-tools/k0s.yaml
+++ b/tools/dev-tools/k0s.yaml
@@ -1,0 +1,25 @@
+name: k0s
+description: Zero-friction Kubernetes distribution that ships as a single binary with no host dependencies beyond the kernel. k0s runs control plane and workers with vanilla upstream Kubernetes, suited to air-gapped, edge, and single-node AI clusters.
+tagline: Single-binary Kubernetes with zero host friction
+
+github_url: https://github.com/k0sproject/k0s
+website_url: https://k0sproject.io
+docs_url: https://docs.k0sproject.io
+
+category: Dev Tools
+tags: [kubernetes, distribution, edge, single-binary, cncf, cluster]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  kubeadm and managed Kubernetes pull in container runtimes, extra packages, and cloud APIs
+  that are painful on edge boxes and air-gapped GPU machines. k0s installs as one binary,
+  brings upstream Kubernetes, and can run control plane plus workers on the same host for
+  compact inference clusters.
+
+use_cases:
+  - Stand up a single-node Kubernetes cluster on a GPU box for local model serving
+  - Deploy upstream Kubernetes in air-gapped labs without kubeadm host package sprawl
+  - Run compact edge clusters that still speak standard kubectl and Helm
+  - Replace heavier distributions when you only need vanilla Kubernetes APIs

--- a/tools/dev-tools/kubectx.yaml
+++ b/tools/dev-tools/kubectx.yaml
@@ -1,0 +1,25 @@
+name: kubectx
+description: Faster switching between kubectl contexts and namespaces. kubectx and kubens replace long config commands so platform engineers can hop between staging, prod, and local minikube clusters without editing kubeconfig by hand.
+tagline: Switch kubectl context and namespace in one command
+
+github_url: https://github.com/ahmetb/kubectx
+website_url: https://kubectx.dev
+docs_url: https://github.com/ahmetb/kubectx#readme
+install_command: brew install kubectx
+
+category: Dev Tools
+tags: [kubernetes, kubectl, cli, context, devops, productivity]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Teams juggle many kubeconfigs for local clusters, staging, and production. A wrong
+  kubectl apply lands in the wrong cluster. kubectx and kubens make context and namespace
+  switches explicit and tab-completable so ML platform work stays on the intended cluster.
+
+use_cases:
+  - Jump from minikube to a staging GKE context before applying a model-serving chart
+  - Switch namespaces between training jobs and inference without editing kubeconfig
+  - Tab-complete cluster names when debugging across several AI platform environments
+  - Pair with kubectl plugins so context mistakes are less likely in production

--- a/tools/dev-tools/minikube.yaml
+++ b/tools/dev-tools/minikube.yaml
@@ -1,0 +1,25 @@
+name: minikube
+description: Local Kubernetes cluster in a VM, container, or bare metal on macOS, Linux, and Windows. minikube is the Kubernetes SIG tool for running a single-node cluster with addons for ingress, metrics, and GPU so you can develop ML serving stacks without a remote cluster.
+tagline: Run Kubernetes locally for development and addons
+
+github_url: https://github.com/kubernetes/minikube
+website_url: https://minikube.sigs.k8s.io/
+docs_url: https://minikube.sigs.k8s.io/docs/
+install_command: brew install minikube
+
+category: Dev Tools
+tags: [kubernetes, local-dev, cluster, devops, gpu, addons]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Testing Helm charts, operators, and model-serving Deployments usually needs a real kube-apiserver,
+  not Docker Compose. minikube boots a local cluster with kubectl access and optional GPU or
+  ingress addons so CI and laptops can exercise Kubernetes APIs without a cloud account.
+
+use_cases:
+  - Run a local Kubernetes cluster to test inference Deployments and Services before cloud deploy
+  - Enable the GPU addon to iterate on CUDA-backed serving pods from a workstation
+  - Try ingress, metrics-server, and registry addons without provisioning a shared cluster
+  - Teach Kubernetes APIs for ML platform work with a disposable single-node environment

--- a/tools/dev-tools/stern.yaml
+++ b/tools/dev-tools/stern.yaml
@@ -1,0 +1,26 @@
+name: stern
+description: Multi-pod and container log tailing for Kubernetes. stern lets you follow logs across replica sets with color, filters, and container selectors so you can debug distributed AI services without juggling one kubectl logs process per pod.
+tagline: Tail logs from multiple Kubernetes pods at once
+
+github_url: https://github.com/stern/stern
+website_url: https://github.com/stern/stern
+docs_url: https://github.com/stern/stern#readme
+install_command: brew install stern
+
+category: Dev Tools
+tags: [kubernetes, logging, cli, debugging, devops, observability]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  kubectl logs follows one pod, so a rolling Deployment or a multi-container inference
+  service requires many terminals. stern tails matching pods and containers in one stream
+  with timestamps and color, which is the difference between spotting a crash loop and
+  missing it in a replica you were not watching.
+
+use_cases:
+  - Follow logs from every replica of a model-serving Deployment during a rollout
+  - Filter worker and sidecar containers when debugging a RAG API that spans several pods
+  - Watch crash-looping jobs across a namespace without starting a log stack
+  - Color-code pod streams while reproducing a flaky training-operator failure


### PR DESCRIPTION
## Add 5 tools to the catalog

Local Kubernetes and container-image tooling.

| Tool | Category | Notes |
|------|----------|-------|
| minikube | Dev Tools | Run Kubernetes locally (`kubernetes/minikube`, 32k★) |
| k0s | Dev Tools | Single-binary Kubernetes (`k0sproject/k0s`, 6.5k★) |
| stern | Dev Tools | Multi-pod log tailing (`stern/stern`, 4.9k★) |
| kubectx | Dev Tools | Switch kubectl context and namespace (`ahmetb/kubectx`, 20k★) |
| dive | Dev Tools | Explore Docker/OCI image layers (`wagoodman/dive`, 54.5k★) |

k0s has no Homebrew core formula; install command omitted.

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five Dev Tools catalog entries: Dive, k0s, kubectx, Minikube, and Stern.
  * Added searchable metadata, documentation links, installation details, licensing, pricing, and practical use cases.
  * Highlighted workflows including container image inspection, Kubernetes context switching, local cluster testing, edge deployments, and multi-pod log monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->