### PR TITLE
Add hadolint, asdf, runc to catalog

### DIFF
--- a/tools/dev-tools/asdf.yaml
+++ b/tools/dev-tools/asdf.yaml
@@ -1,0 +1,25 @@
+name: asdf
+description: Extendable version manager for runtimes and CLIs via plugins. asdf pins Node, Python, Terraform, kubectl, and more per project so ML repos share one shim instead of a stack of language-specific managers.
+tagline: One version manager for every runtime and CLI
+
+github_url: https://github.com/asdf-vm/asdf
+website_url: https://asdf-vm.com/
+docs_url: https://asdf-vm.com/guide/getting-started.html
+install_command: brew install asdf
+
+category: Dev Tools
+tags: [version-manager, cli, python, node, devops, tooling]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI projects mix Python, Node, Terraform, and kubectl versions that differ by repo.
+  nvm, pyenv, and tfenv each have their own shims. asdf uses a plugin list and a
+  .tool-versions file so a clone gets the same toolchain without guessing which manager to run.
+
+use_cases:
+  - Pin Python and Node together in a monorepo that trains models and ships a web UI
+  - Share .tool-versions so CI and laptops install the same kubectl and terraform
+  - Add a plugin for a custom CLI used by an ML platform without a new version manager
+  - Switch runtime versions per directory when jumping between research and serving repos

--- a/tools/dev-tools/hadolint.yaml
+++ b/tools/dev-tools/hadolint.yaml
@@ -1,0 +1,25 @@
+name: hadolint
+description: Dockerfile linter written in Haskell that validates best practices and inline bash. hadolint catches unpinned bases, extra layers, and shell pitfalls so ML images stay smaller and more reproducible before they hit a registry.
+tagline: Lint Dockerfiles before they bloat your images
+
+github_url: https://github.com/hadolint/hadolint
+website_url: https://github.com/hadolint/hadolint
+docs_url: https://github.com/hadolint/hadolint#readme
+install_command: brew install hadolint
+
+category: Dev Tools
+tags: [docker, linter, dockerfile, ci, haskell, devops]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  CUDA and Python Dockerfiles accumulate apt leftovers, latest tags, and brittle RUN shells
+  that only fail in production pulls. hadolint parses Dockerfiles plus bash and flags
+  DL3000-style issues in CI so serving images do not ship known packaging mistakes.
+
+use_cases:
+  - Fail CI when a training Dockerfile uses unpinned base images or apt without cleanup
+  - Lint inline bash in RUN instructions that install CUDA and Python wheels
+  - Enforce ignore rules per project so GPU images can waive a small set of checks
+  - Review generated Dockerfiles from ML platforms before they land in a registry

--- a/tools/dev-tools/runc.yaml
+++ b/tools/dev-tools/runc.yaml
@@ -1,0 +1,26 @@
+name: runc
+description: CLI for spawning and running containers according to the OCI runtime specification. runc is the low-level engine behind Docker, containerd, and Kubernetes, creating the namespaces, cgroups, and process tree that isolate ML workloads.
+tagline: OCI runtime that actually starts the container process
+
+github_url: https://github.com/opencontainers/runc
+website_url: https://www.opencontainers.org/
+docs_url: https://github.com/opencontainers/runc#readme
+install_command: brew install runc
+
+category: Dev Tools
+tags: [oci, containers, runtime, linux, kubernetes, isolation]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Higher-level tools start containers, but debugging failed GPU or cgroup setups needs the
+  runtime that creates namespaces and mounts. runc is the OCI reference runtime, so
+  containerd, Docker, and CRI-O all bottom out here when a training or serving pod will
+  not start.
+
+use_cases:
+  - Inspect or invoke the OCI runtime when a Kubernetes GPU pod fails at container start
+  - Build a custom low-level runtime stack for isolated model-serving sandboxes
+  - Reproduce containerd start errors by running a bundle directly with runc
+  - Validate that a rootfs and config.json meet the OCI runtime spec before production


### PR DESCRIPTION
## Add 3 tools to the catalog

Dockerfile linting, toolchain versioning, and the OCI container runtime.

| Tool | Category | Notes |
|------|----------|-------|
| hadolint | Dev Tools | Dockerfile linter (`hadolint/hadolint`, 12.4k★) |
| asdf | Dev Tools | Plugin-based version manager (`asdf-vm/asdf`, 25.6k★) |
| runc | Dev Tools | OCI container runtime (`opencontainers/runc`, 13.4k★) |

Local validation passed for all three YAML files.
