### PR TITLE
Add Firecracker, gVisor, vcluster, helmfile, CUE to catalog

### DIFF
--- a/tools/dev-tools/cue.yaml
+++ b/tools/dev-tools/cue.yaml
@@ -1,0 +1,26 @@
+name: CUE
+description: Configuration language that validates and unifies JSON, YAML, and OpenAPI data. CUE catches schema drift in Helm values, model-serving configs, and pipeline manifests before they reach a cluster, replacing ad hoc templates with types and constraints.
+tagline: Validate and unify JSON, YAML, and OpenAPI configs
+
+github_url: https://github.com/cue-lang/cue
+website_url: https://cuelang.org
+docs_url: https://cuelang.org/docs/
+install_command: brew install cue
+
+category: Dev Tools
+tags: [configuration, validation, yaml, json, schema, golang]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  YAML and JSON configs for training jobs and serving stacks have no types, so
+  invalid values ship to production. CUE is a constraint language that unifies
+  schemas and data, so you can validate, default, and generate configs from one
+  source instead of duplicating OpenAPI, Helm values, and ad hoc scripts.
+
+use_cases:
+  - Validate Helm values and Kubernetes manifests against a single CUE schema
+  - Generate OpenAPI or JSON Schema from CUE types for model-serving APIs
+  - Unify overlapping YAML configs across staging and production without copy-paste
+  - Catch missing required fields in pipeline configs before CI applies them

--- a/tools/dev-tools/firecracker.yaml
+++ b/tools/dev-tools/firecracker.yaml
@@ -1,0 +1,25 @@
+name: Firecracker
+description: Secure and fast microVMs for serverless computing. Firecracker uses KVM to run lightweight virtual machines with a minimal device model, giving each function or container a hardware-isolated kernel so multi-tenant ML inference can share hosts without sharing a kernel.
+tagline: MicroVMs that isolate serverless and inference workloads
+
+github_url: https://github.com/firecracker-microvm/firecracker
+website_url: https://firecracker-microvm.github.io/
+docs_url: https://github.com/firecracker-microvm/firecracker/blob/main/docs/getting-started.md
+
+category: Dev Tools
+tags: [microvm, kvm, serverless, isolation, rust, containers]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Containers share a host kernel, so a breakout in one tenant can reach every model
+  on the box. Firecracker boots a slim virtual machine in tens of milliseconds with
+  a tiny device model, giving each inference or function its own kernel while still
+  packing thousands of tenants onto one machine.
+
+use_cases:
+  - Isolate multi-tenant model inference so one customer cannot reach another kernel
+  - Run Lambda-style serverless functions with hardware virtualization instead of containers
+  - Sandbox untrusted agent or user code that must execute binaries on a shared host
+  - Pack more GPU-adjacent CPU tenants per machine than full VMs allow

--- a/tools/dev-tools/gvisor.yaml
+++ b/tools/dev-tools/gvisor.yaml
@@ -1,0 +1,25 @@
+name: gVisor
+description: Application kernel for containers that intercepts syscalls in user space. gVisor (runsc) sits between the container and the host kernel so untrusted code, including model-serving workloads, cannot talk to the real kernel even if it escapes the container namespace.
+tagline: User-space kernel that sandboxes container syscalls
+
+github_url: https://github.com/google/gvisor
+website_url: https://gvisor.dev
+docs_url: https://gvisor.dev/docs/
+
+category: Dev Tools
+tags: [sandbox, containers, security, kubernetes, runtime, isolation]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  OCI runtimes like runc still let containers issue syscalls to the host kernel.
+  gVisor implements a large Linux syscall surface in user space (Sentry) so a
+  compromised training job or untrusted notebook cannot reach host devices, files,
+  or other tenants through kernel bugs.
+
+use_cases:
+  - Run untrusted notebooks or agent-generated code in a syscall-sandboxed container
+  - Use the runsc runtime class on Kubernetes for multi-tenant model serving
+  - Reduce blast radius when evaluating third-party ML images you do not control
+  - Isolate CI jobs that build or test code from untrusted pull requests

--- a/tools/dev-tools/helmfile.yaml
+++ b/tools/dev-tools/helmfile.yaml
@@ -1,0 +1,26 @@
+name: helmfile
+description: Declaratively deploy Kubernetes manifests, Kustomize configs, and Helm charts as versioned releases. helmfile composes many charts into one environment file so ML platform stacks stay reproducible across clusters and GitOps tools like Argo CD.
+tagline: Compose Helm releases into one declarative environment
+
+github_url: https://github.com/helmfile/helmfile
+website_url: https://helmfile.readthedocs.io
+docs_url: https://helmfile.readthedocs.io
+install_command: brew install helmfile
+
+category: Dev Tools
+tags: [helm, kubernetes, gitops, deployment, kustomize, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Real ML platforms install dozens of charts (ingress, GPU operators, monitoring,
+  serving). Running helm install by hand drifts across environments. helmfile
+  lists every release, value overlay, and dependency so a cluster can be applied
+  or diffed as one file.
+
+use_cases:
+  - Declare GPU operator, serving, and observability charts as one environment
+  - Diff and apply the same stack to staging and production with value overlays
+  - Generate an all-in-one manifest for Argo CD from existing Helm charts
+  - Pin chart versions so training-cluster bootstraps stay reproducible

--- a/tools/dev-tools/vcluster.yaml
+++ b/tools/dev-tools/vcluster.yaml
@@ -1,0 +1,26 @@
+name: vcluster
+description: Creates virtual Kubernetes clusters inside a host cluster. Each vCluster gets its own API server, CRDs, and RBAC so teams can run isolated training, Ray, or inference environments on shared hardware without provisioning a full cluster per tenant.
+tagline: Virtual Kubernetes clusters on shared host clusters
+
+github_url: https://github.com/loft-sh/vcluster
+website_url: https://www.vcluster.com
+docs_url: https://www.vcluster.com/docs
+install_command: brew install vcluster
+
+category: Dev Tools
+tags: [kubernetes, multi-tenant, virtual-cluster, platform, isolation, gitops]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Sharing one Kubernetes cluster means fighting over CRDs, cluster-scoped RBAC, and
+  noisy neighbors. Giving every team a real cluster wastes control-plane cost.
+  vCluster nests a full API server in a namespace so ML teams get isolation
+  without another cloud account.
+
+use_cases:
+  - Give each ML team a virtual cluster with its own CRDs for training operators
+  - Spin up ephemeral clusters for Ray, Slurm, or inference stacks on shared nodes
+  - Test Helm charts and operators that need cluster-scoped resources without a new EKS account
+  - Offer tenant Kubernetes to internal platform users while keeping one host cluster


### PR DESCRIPTION
## Summary
Adds 5 Dev Tools catalog entries for container isolation, virtual Kubernetes, Helm composition, and config validation:

- **Firecracker** — KVM microVMs for multi-tenant serverless and inference isolation (Apache-2.0, 36k★)
- **gVisor** — user-space application kernel (runsc) that sandboxes container syscalls (Apache-2.0, 19k★)
- **vcluster** — virtual Kubernetes clusters with their own API server on a shared host cluster (Apache-2.0, 11k★)
- **helmfile** — declarative composition of Helm charts, Kustomize, and manifests (MIT, 5k★)
- **CUE** — constraint language to validate and unify JSON, YAML, and OpenAPI configs (Apache-2.0, 6k★)

Kaniko was in the tracker batch but is skipped: `GoogleContainerTools/kaniko` is archived.

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five developer tools to the catalog: CUE, Firecracker, gVisor, Helmfile, and vcluster.
  * Added descriptions, project links, installation or documentation details, licensing, pricing, categories, and tags for each tool.
  * Documented practical use cases including configuration validation, workload isolation, sandboxing, Kubernetes environments, Helm management, and multi-tenant infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->