### PR TITLE
Add Pants, Youki to catalog

### DIFF
--- a/tools/dev-tools/pants.yaml
+++ b/tools/dev-tools/pants.yaml
@@ -1,0 +1,25 @@
+name: Pants
+description: Fast, scalable build system for Python, JVM, Go, and shell monorepos. Pants infers dependencies, caches test and lint results, and runs only what changed so large ML codebases skip full rebuilds on every commit.
+tagline: Monorepo build system with inferred Python dependencies
+
+github_url: https://github.com/pantsbuild/pants
+website_url: https://www.pantsbuild.org
+docs_url: https://www.pantsbuild.org/stable/docs
+install_command: pip install pantsbuild.pants
+
+category: Dev Tools
+tags: [build-system, python, monorepo, caching, ci, jvm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Make, Bazel-lite scripts, and ad hoc tox jobs do not scale when an ML repo mixes
+  Python packages, generated protobufs, and tests. Pants infers imports, sandboxes
+  runs, and caches by content so CI only re-tests what a change actually touches.
+
+use_cases:
+  - Run only the Python tests affected by a model-training code change
+  - Cache lint, format, and type-check results across local and CI workers
+  - Manage a monorepo that mixes Python training code with JVM feature services
+  - Infer third-party requirements from imports instead of hand-maintained lists

--- a/tools/dev-tools/youki.yaml
+++ b/tools/dev-tools/youki.yaml
@@ -1,0 +1,25 @@
+name: Youki
+description: OCI container runtime written in Rust as a memory-safe alternative to runc. Youki implements the runtime spec so containerd and Kubernetes can start training and serving containers with lower memory use and fewer memory-safety bugs in the process that creates namespaces.
+tagline: Rust OCI runtime as a runc alternative
+
+github_url: https://github.com/youki-dev/youki
+website_url: https://youki-dev.github.io/youki/
+docs_url: https://youki-dev.github.io/youki/
+
+category: Dev Tools
+tags: [oci, containers, runtime, rust, kubernetes, isolation]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  runc is C-based and is the process that creates every container on a node.
+  A memory bug there is a host-level incident. Youki is a Rust OCI runtime that
+  speaks the same spec, so you can swap the low-level engine without changing
+  Docker or Kubernetes APIs.
+
+use_cases:
+  - Replace runc with a memory-safe OCI runtime on GPU training nodes
+  - Run containerd with youki for lower-memory dense inference packing
+  - Experiment with a Rust runtime while keeping OCI config.json bundles
+  - Reduce the C attack surface of the process that creates namespaces and cgroups


### PR DESCRIPTION
## Summary
Adds 2 Dev Tools catalog entries (remainder of the container/build batch after PR #413):

- **Pants** — monorepo build system with inferred Python dependencies and content-addressed caching (Apache-2.0, 3.8k★)
- **Youki** — OCI container runtime written in Rust as a memory-safe runc alternative (Apache-2.0, 7.5k★)

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for both files.
