### PR TITLE
Add crun, Kata Containers, Karpenter, Terragrunt, cookiecutter to catalog

### DIFF
--- a/tools/dev-tools/cookiecutter.yaml
+++ b/tools/dev-tools/cookiecutter.yaml
@@ -1,0 +1,26 @@
+name: cookiecutter
+description: Command-line tool that creates projects from templates. cookiecutter prompts for values and renders a directory of files so ML repos, Python packages, and serving services start from a reviewed skeleton instead of copy-paste.
+tagline: Project templates that generate a repo from prompts
+
+github_url: https://github.com/cookiecutter/cookiecutter
+website_url: https://cookiecutter.readthedocs.io
+docs_url: https://cookiecutter.readthedocs.io
+install_command: pip install cookiecutter
+
+category: Dev Tools
+tags: [templates, scaffolding, python, cli, project-generator]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  New training or serving repos start as a copy of last quarter's project, then
+  miss CI, license, and packaging files. cookiecutter renders a template with
+  prompts so every package gets the same layout, tests, and docs stubs without
+  manual file copying.
+
+use_cases:
+  - Scaffold a new Python training package from a team template
+  - Generate a FastAPI model-serving service with CI and Dockerfile included
+  - Standardize data-science repo layout across research teams
+  - Publish an internal cookiecutter so agents and humans start from the same skeleton

--- a/tools/dev-tools/crun.yaml
+++ b/tools/dev-tools/crun.yaml
@@ -1,0 +1,25 @@
+name: crun
+description: Fast, lightweight OCI container runtime written in C. crun is a drop-in alternative to runc that uses less memory, so dense GPU nodes can start more training and serving containers without paying runc's per-container overhead.
+tagline: Lightweight C OCI runtime as a runc alternative
+
+github_url: https://github.com/containers/crun
+docs_url: https://github.com/containers/crun#readme
+install_command: brew install crun
+
+category: Dev Tools
+tags: [oci, containers, runtime, linux, podman, isolation]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  runc works, but each container process costs more memory than a C runtime needs.
+  On packed inference nodes that tax adds up. crun implements the OCI runtime spec
+  with a smaller footprint so Podman, CRI-O, and Kubernetes can start more sandboxes
+  per host.
+
+use_cases:
+  - Swap runc for a lighter OCI runtime on dense model-serving nodes
+  - Run Podman or CRI-O with crun to cut per-container memory
+  - Start OCI bundles directly when debugging a failed GPU container
+  - Compare runc vs crun start time for short-lived training sidecars

--- a/tools/dev-tools/karpenter.yaml
+++ b/tools/dev-tools/karpenter.yaml
@@ -1,0 +1,25 @@
+name: Karpenter
+description: Kubernetes node autoscaler that launches right-sized instances in seconds. Karpenter watches unschedulable pods and provisions matching nodes, so GPU training and bursty inference scale without a static node group for every instance type.
+tagline: Just-in-time Kubernetes nodes for bursty ML workloads
+
+github_url: https://github.com/kubernetes-sigs/karpenter
+website_url: https://karpenter.sh
+docs_url: https://karpenter.sh/docs/
+
+category: Dev Tools
+tags: [kubernetes, autoscaling, gpu, cloud, provisioning, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Cluster Autoscaler and fixed node groups lag when a training Job needs a
+  specific GPU type now. Karpenter reads pending pod constraints and launches
+  fitting instances in seconds, then drains them when the queue is empty so you
+  stop paying for idle accelerators.
+
+use_cases:
+  - Scale GPU nodes when training Jobs go pending, then drain them when idle
+  - Mix CPU inference and GPU training on one cluster without pre-baked node groups
+  - Bin-pack bursty agent or batch workloads onto cheaper spot capacity
+  - Cut idle node cost versus keeping always-on GPU autoscaling groups

--- a/tools/dev-tools/kata-containers.yaml
+++ b/tools/dev-tools/kata-containers.yaml
@@ -1,0 +1,25 @@
+name: Kata Containers
+description: Lightweight VMs that feel like containers. Kata runs each pod in a hardware-isolated virtual machine with a guest kernel, so untrusted or multi-tenant ML workloads get VM isolation while still using Kubernetes and OCI tooling.
+tagline: Container workflow with VM-level isolation
+
+github_url: https://github.com/kata-containers/kata-containers
+website_url: https://katacontainers.io
+docs_url: https://github.com/kata-containers/kata-containers/tree/main/docs
+
+category: Dev Tools
+tags: [containers, virtualization, isolation, kubernetes, security, oci]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Containers share a host kernel. For untrusted notebooks, customer models, or
+  multi-tenant inference that is not enough. Kata boots a slim VM per pod so you
+  keep kubectl and OCI images but get hardware isolation closer to Firecracker
+  than to runc.
+
+use_cases:
+  - Run untrusted training jobs in VM-isolated Kubernetes pods
+  - Isolate multi-tenant inference so tenants do not share a kernel
+  - Use a Kata runtime class next to runc for only the sensitive workloads
+  - Meet stronger isolation requirements without abandoning container images

--- a/tools/dev-tools/terragrunt.yaml
+++ b/tools/dev-tools/terragrunt.yaml
@@ -1,0 +1,26 @@
+name: Terragrunt
+description: Thin orchestration layer that scales OpenTofu and Terraform. Terragrunt keeps DRY configurations, remote state, and dependency order so ML platform stacks (GPU node groups, registries, warehouses) stay consistent across accounts.
+tagline: Scale Terraform and OpenTofu without copy-paste modules
+
+github_url: https://github.com/gruntwork-io/terragrunt
+website_url: https://terragrunt.com
+docs_url: https://terragrunt.com/docs
+install_command: brew install terragrunt
+
+category: Dev Tools
+tags: [terraform, opentofu, iac, devops, orchestration, cloud]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Copying Terraform roots per environment drifts state backends, provider
+  versions, and module pins. Terragrunt wraps OpenTofu/Terraform with keepers
+  for remote state, dependencies, and generated backends so a GPU VPC and a
+  serving cluster stay one pattern, not twenty forks.
+
+use_cases:
+  - Keep DRY Terraform for GPU clusters across staging and production accounts
+  - Order applies so a feature store depends on the VPC and IAM modules
+  - Generate remote-state backends instead of duplicating backend blocks
+  - Run the same OpenTofu stack in many regions with environment overlays


### PR DESCRIPTION
## Summary
Adds 5 Dev Tools catalog entries for container isolation, Kubernetes autoscaling, IaC, and project scaffolding:

- **crun** — lightweight C OCI runtime as a runc alternative (GPL-2.0, 4.1k★)
- **Kata Containers** — VM-isolated pods that still use Kubernetes and OCI images (Apache-2.0, 8.6k★)
- **Karpenter** — just-in-time Kubernetes node autoscaler for GPU and bursty workloads (Apache-2.0, 2.1k★)
- **Terragrunt** — DRY orchestration layer for OpenTofu and Terraform (MIT, 9.8k★)
- **cookiecutter** — project templates that scaffold repos from prompts (BSD-3-Clause, 25k★)

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Cookiecutter, crun, Karpenter, Kata Containers, and Terragrunt.
  * Included descriptions, installation details, documentation links, licensing, categories, tags, and practical use cases for each tool.
  * Added guidance covering package scaffolding, container runtimes, Kubernetes autoscaling, workload isolation, and infrastructure orchestration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->