### PR TITLE
Add tox, PDM, sops, HTTPie to catalog

### DIFF
--- a/tools/dev-tools/httpie.yaml
+++ b/tools/dev-tools/httpie.yaml
@@ -1,0 +1,26 @@
+name: HTTPie
+description: User-friendly command-line HTTP client with JSON defaults, color output, and sessions. HTTPie is the readable curl alternative for probing model APIs, webhooks, and vector-DB REST endpoints from a terminal.
+tagline: Human-friendly HTTP client for API debugging
+
+github_url: https://github.com/httpie/cli
+website_url: https://httpie.io
+docs_url: https://httpie.io/docs/cli
+install_command: pip install httpie
+
+category: Dev Tools
+tags: [http, cli, api, json, debugging, rest]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  curl flags for JSON headers, pretty printing, and sessions are easy to get
+  wrong when you are hitting an inference API at 1 a.m. HTTPie defaults to
+  JSON, shows colorized responses, and stores sessions so auth cookies and
+  tokens survive across requests.
+
+use_cases:
+  - POST a sample prompt to a local model server and read the JSON response
+  - Save a session with a Bearer token for a vector database REST API
+  - Download OpenAPI examples without assembling curl header flags
+  - Debug webhook payloads from an agent tool-calling flow

--- a/tools/dev-tools/pdm.yaml
+++ b/tools/dev-tools/pdm.yaml
@@ -1,0 +1,26 @@
+name: PDM
+description: Modern Python package and dependency manager that follows PEP 517, 582, and 621. PDM uses pyproject.toml as the single source of truth so ML libraries pin dependencies without a setup.py or a Conda env that drifts from the lockfile.
+tagline: PEP-compliant Python package and dependency manager
+
+github_url: https://github.com/pdm-project/pdm
+website_url: https://pdm-project.org
+docs_url: https://pdm-project.org/latest/
+install_command: pip install pdm
+
+category: Dev Tools
+tags: [python, packaging, dependencies, lockfile, pep621]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Poetry, pip-tools, and setup.py disagree on metadata and lockfiles. PDM
+  targets current PEPs so a training package can declare dependencies, extras,
+  and scripts in pyproject.toml and install them reproducibly without a
+  proprietary lock format.
+
+use_cases:
+  - Manage a Python ML library with pyproject.toml and a committed lockfile
+  - Install optional extras for GPU vs CPU inference from one project file
+  - Publish a package to PyPI using PEP 517 builds instead of setup.py
+  - Keep local and CI environments in sync without a Conda environment.yml

--- a/tools/dev-tools/sops.yaml
+++ b/tools/dev-tools/sops.yaml
@@ -1,0 +1,26 @@
+name: sops
+description: Editor for encrypted files that keeps secrets in Git. sops encrypts YAML, JSON, dotenv, and binary with age, PGP, or cloud KMS so API keys and model-endpoint credentials can live next to the manifests that use them.
+tagline: Encrypt secrets in Git with age, PGP, or cloud KMS
+
+github_url: https://github.com/getsops/sops
+website_url: https://getsops.io
+docs_url: https://getsops.io
+install_command: brew install sops
+
+category: Dev Tools
+tags: [secrets, encryption, gitops, kms, yaml, devops]
+pricing: free
+is_open_source: true
+license: MPL-2.0
+
+problem_solved: |
+  Helm values and .env files with API keys cannot sit in Git unencrypted, but
+  sealed-secret controllers are heavy for small teams. sops encrypts only the
+  secret values in YAML so diffs stay readable and CI decrypts with KMS or age
+  at apply time.
+
+use_cases:
+  - Store OpenAI and cloud keys in encrypted YAML next to Helm values
+  - Decrypt secrets in CI with AWS KMS or age before applying a serving stack
+  - Keep dotenv files for local agent configs in Git without plaintext keys
+  - Review secret-file diffs because only values are ciphertext, keys stay clear

--- a/tools/dev-tools/tox.yaml
+++ b/tools/dev-tools/tox.yaml
@@ -1,0 +1,26 @@
+name: tox
+description: Command-line CI frontend that runs tests and tools in isolated environments. tox creates virtualenvs per Python version and factor so ML libraries prove they work on 3.10 through 3.13 without polluting the developer machine.
+tagline: Isolated test environments across Python versions
+
+github_url: https://github.com/tox-dev/tox
+website_url: https://tox.wiki
+docs_url: https://tox.wiki
+install_command: pip install tox
+
+category: Dev Tools
+tags: [python, testing, ci, virtualenv, automation]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Running pytest in whatever venv is active hides version-specific breakage.
+  tox declares factors (py310, py311, lint) and rebuilds isolated environments
+  so a training library CI matrix is one config, not a pile of GitHub Actions
+  jobs copied by hand.
+
+use_cases:
+  - Run unit tests for a model SDK against multiple Python versions locally
+  - Gate PRs on lint plus tests without sharing a single developer virtualenv
+  - Reproduce a CI failure with the same tox factor the pipeline used
+  - Standardize packaging checks (build, import, pytest) for internal ML libs


### PR DESCRIPTION
## Summary
Adds 4 Dev Tools catalog entries (remainder after PR #415):

- **tox** — isolated test environments across Python versions (MIT, 3.9k★)
- **PDM** — PEP-compliant Python package and dependency manager (MIT, 8.7k★)
- **sops** — encrypt secrets in Git with age, PGP, or cloud KMS (MPL-2.0, 23k★)
- **HTTPie** — human-friendly HTTP client for API debugging (BSD-3-Clause, 38k★)

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all four files.
