### PR TITLE
Add QEMU, Vagrant, vegeta, Distrobox, xh to catalog

### DIFF
--- a/tools/dev-tools/distrobox.yaml
+++ b/tools/dev-tools/distrobox.yaml
@@ -1,0 +1,26 @@
+name: Distrobox
+description: Run any Linux distribution inside a container tightly integrated with the host so home directory, USB devices, and graphical apps work as if they were native. ML engineers can keep a Fedora or Ubuntu toolbox on immutable hosts without dual-boot or a full VM.
+tagline: Any Linux distro in your terminal, tightly integrated with the host
+
+github_url: https://github.com/89luca89/distrobox
+website_url: https://distrobox.it/
+docs_url: https://distrobox.it/
+install_command: brew install distrobox
+
+category: Dev Tools
+tags: [containers, linux, podman, docker, local-dev, devops]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Immutable Linux hosts, Silverblue, and locked-down workstations block apt or dnf
+  installs that ML toolchains need. Distrobox creates a pet container of any distro,
+  shares the home directory, and lets you install CUDA toolkits, Python builds, or
+  distro-specific packages without dual-boot, a VM, or polluting the host.
+
+use_cases:
+  - Create an Ubuntu toolbox on Fedora Silverblue to install CUDA and PyTorch packages the host image lacks
+  - Keep per-project distros so a TensorFlow Ubuntu env never collides with a JAX Fedora env
+  - Run GUI ML tools from the container with host display, audio, and USB device access
+  - Export a containerized CLI onto the host PATH so teammates use the same pinned toolchain

--- a/tools/dev-tools/qemu.yaml
+++ b/tools/dev-tools/qemu.yaml
@@ -1,0 +1,27 @@
+name: QEMU
+description: Open-source machine emulator and virtualizer that runs operating systems and binaries for one architecture on another, or virtualizes guests near native speed with KVM, HVF, or WHPX. AI teams use it to test Linux stacks, emulate ARM and RISC-V boards, and reproduce CI environments without dedicated hardware.
+tagline: Emulate any machine, virtualize Linux for local AI stacks
+
+github_url: https://github.com/qemu/qemu
+website_url: https://www.qemu.org
+docs_url: https://www.qemu.org/docs/master/
+install_command: brew install qemu
+
+category: Dev Tools
+tags: [virtualization, emulator, kvm, linux, devops, local-dev]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  ML engineers need to run Linux guests, ARM or RISC-V images, and CI-like environments
+  on laptops that are not those architectures. Full cloud VMs are slow to iterate and
+  dedicated boards are scarce. QEMU emulates or virtualizes those machines locally so
+  training scripts, container runtimes, and firmware images can be tested before they
+  hit production hardware.
+
+use_cases:
+  - Boot a Linux VM on a Mac to run containerd, CUDA-adjacent tooling, or distro-specific ML packages
+  - Emulate ARM or RISC-V boards to test edge inference binaries without physical hardware
+  - Reproduce CI runner environments locally when a training image only fails on a specific kernel
+  - Snapshot and clone guests so experiments start from a known machine state

--- a/tools/dev-tools/vagrant.yaml
+++ b/tools/dev-tools/vagrant.yaml
@@ -1,0 +1,26 @@
+name: Vagrant
+description: Tool for building and sharing portable development environments from a Vagrantfile. It provisions VMs via VirtualBox, VMware, Hyper-V, Docker, or cloud providers so ML teams get identical Linux boxes, databases, and services from a single command.
+tagline: Shareable VMs for identical ML development boxes
+
+github_url: https://github.com/hashicorp/vagrant
+website_url: https://www.vagrantup.com
+docs_url: https://developer.hashicorp.com/vagrant/docs
+install_command: brew install --cask vagrant
+
+category: Dev Tools
+tags: [virtualization, local-dev, devops, vms, provisioning]
+pricing: free
+is_open_source: true
+license: BUSL-1.1
+
+problem_solved: |
+  AI teams waste days recreating local stacks: a specific Ubuntu, CUDA toolkit, database,
+  and message broker that only exist in one engineer's notes. Vagrant encodes that box
+  in a Vagrantfile so every teammate, CI job, and workshop attendee boots the same
+  environment with vagrant up instead of a wiki of install steps.
+
+use_cases:
+  - Check in a Vagrantfile that provisions Ubuntu plus Python, CUDA drivers, and Redis for a training lab
+  - Share a demo box with a vector database and API so workshop attendees skip machine setup
+  - Spin throwaway VMs for reproducing customer environment bugs without polluting the host
+  - Combine Vagrant with Ansible or shell provisioners to keep ML workshop images versioned

--- a/tools/dev-tools/vegeta.yaml
+++ b/tools/dev-tools/vegeta.yaml
@@ -1,0 +1,26 @@
+name: vegeta
+description: Go HTTP load testing tool and library that attacks endpoints at a constant request rate and reports latency, success ratio, and throughput. Use it to soak test model serving APIs, embedding endpoints, and RAG gateways before production traffic arrives.
+tagline: HTTP load testing for inference APIs that is over 9000
+
+github_url: https://github.com/tsenart/vegeta
+website_url: https://github.com/tsenart/vegeta
+docs_url: https://pkg.go.dev/github.com/tsenart/vegeta/v12
+install_command: brew install vegeta
+
+category: Dev Tools
+tags: [load-testing, http, benchmarking, golang, performance, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Model serving APIs look fine under a handful of curl calls and then collapse under
+  concurrent chat or embedding traffic. vegeta holds a constant request rate, records
+  latency histograms, and reports success ratios so teams can find saturation points
+  before users do.
+
+use_cases:
+  - Soak test an OpenAI-compatible inference endpoint at a fixed QPS and plot latency percentiles
+  - Compare embedding API throughput before and after a batching or cache change
+  - Load test a RAG gateway that fans out to retrieval and generation services
+  - Encode attack targets as a file so CI can regression-test API performance on every deploy

--- a/tools/dev-tools/xh.yaml
+++ b/tools/dev-tools/xh.yaml
@@ -1,0 +1,26 @@
+name: xh
+description: Friendly, fast HTTP client written in Rust and inspired by HTTPie, with HTTP/2, downloads, and JSON highlighting. It is a drop-in HTTPie replacement for hitting inference APIs, webhooks, and local model servers from the terminal.
+tagline: Fast HTTPie-style requests from the terminal, in Rust
+
+github_url: https://github.com/ducaale/xh
+website_url: https://github.com/ducaale/xh
+docs_url: https://github.com/ducaale/xh
+install_command: brew install xh
+
+category: Dev Tools
+tags: [http, cli, rust, api, developer-tools, json]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Hitting model APIs from the shell with curl is verbose, and HTTPie is slower than
+  teams want for tight request loops. xh keeps HTTPie's readable syntax, adds HTTP/2
+  and wget-like downloads, and stays fast enough to probe local inference servers
+  during development.
+
+use_cases:
+  - POST JSON to a local vLLM or Ollama endpoint and pretty-print the streaming response
+  - Download model artifacts or OpenAPI specs with wget-compatible flags
+  - Replay webhook payloads against an agent callback URL while iterating on auth headers
+  - Alias http to xh so existing HTTPie muscle memory works on a faster binary


### PR DESCRIPTION
## Summary

Adds 5 Dev Tools entries to the Agentic AI For Good catalog:

- **QEMU** — machine emulator and virtualizer for local Linux/ARM/RISC-V guests
- **Vagrant** — portable development environments from a Vagrantfile
- **vegeta** — HTTP load testing tool for constant-rate API attacks
- **Distrobox** — any Linux distro in a host-integrated container
- **xh** — fast HTTPie-style HTTP client written in Rust

Each YAML was validated locally with `npx tsx scripts/validate-tool.ts`.
