### PR TITLE
Add dasel, Testcontainers, Liquibase to catalog

### DIFF
--- a/tools/dev-tools/dasel.yaml
+++ b/tools/dev-tools/dasel.yaml
@@ -1,0 +1,26 @@
+name: dasel
+description: CLI and library for querying, transforming, and modifying JSON, YAML, TOML, XML, INI, HCL, KDL, and CSV with one selector syntax. AI pipelines can reshape configs, prompts, and evaluation fixtures without writing a parser per format.
+tagline: One selector syntax for JSON, YAML, TOML, XML, and CSV
+
+github_url: https://github.com/TomWright/dasel
+website_url: https://daseldocs.tomwright.me
+docs_url: https://daseldocs.tomwright.me
+install_command: brew install dasel
+
+category: Dev Tools
+tags: [cli, json, yaml, toml, data-transform, golang]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  ML pipelines mix JSON API payloads, YAML configs, TOML tool settings, and CSV
+  eval sets. jq handles JSON, yq handles YAML, and everything else needs a one-off
+  script. dasel uses one selector language across those formats so agents and CI
+  jobs can read or patch structured files without a parser per type.
+
+use_cases:
+  - Extract nested fields from mixed JSON and YAML model configs in a single CI step
+  - Convert evaluation CSV into YAML fixtures for prompt regression tests
+  - Patch TOML or HCL deploy configs from a shell script without a language runtime
+  - Let an agent rewrite a YAML prompt pack and emit JSON for an API in one command

--- a/tools/dev-tools/liquibase.yaml
+++ b/tools/dev-tools/liquibase.yaml
@@ -1,0 +1,26 @@
+name: Liquibase
+description: Database schema change management tool that versions SQL and changelog files so every environment applies the same migrations. ML platforms use it to evolve feature-store tables, eval schemas, and app databases without untracked ALTER scripts.
+tagline: Versioned database migrations for every environment
+
+github_url: https://github.com/liquibase/liquibase
+website_url: https://www.liquibase.org
+docs_url: https://docs.liquibase.com
+install_command: brew install liquibase
+
+category: Dev Tools
+tags: [database, migrations, sql, java, devops, ci-cd]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Feature stores, eval tables, and application schemas drift when each engineer
+  runs ad-hoc ALTER statements. Liquibase tracks changes as ordered changelogs
+  that apply the same way in local Docker, CI, and production, with rollback
+  and drift detection so ML data planes stay reviewable.
+
+use_cases:
+  - Version feature-store table changes alongside the training code that depends on them
+  - Apply the same Postgres changelog in testcontainers CI and production deploys
+  - Generate SQL diffs when promoting an eval schema from staging to prod
+  - Roll back a failed migration that broke an embedding metadata table

--- a/tools/dev-tools/testcontainers.yaml
+++ b/tools/dev-tools/testcontainers.yaml
@@ -1,0 +1,28 @@
+name: Testcontainers
+description: Library that spins up throwaway Docker containers of databases, brokers, browsers, and anything else that runs in Docker for integration tests. ML teams get real Postgres, Redis, Kafka, or vector DB instances in CI without shared staging boxes.
+tagline: Throwaway Docker containers for real integration tests
+
+github_url: https://github.com/testcontainers/testcontainers-java
+website_url: https://testcontainers.org
+docs_url: https://testcontainers.org
+install_command: |
+  pip install testcontainers
+  npm install testcontainers
+
+category: Dev Tools
+tags: [testing, docker, integration-tests, java, python, nodejs]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI services depend on Postgres, Redis, Kafka, and vector databases that mocks
+  never quite match. Shared staging clusters flake and collide across jobs.
+  Testcontainers starts a real container per test, waits until it is ready, and
+  tears it down so integration tests hit the same software production uses.
+
+use_cases:
+  - Run pytest against a real Postgres and Redis container when testing a RAG ingest path
+  - Spin up Kafka or RabbitMQ in CI to verify agent event pipelines without a shared broker
+  - Start a local vector database container for embedding retrieval tests
+  - Drive a Selenium browser container against an AI web app in JUnit or Node tests


### PR DESCRIPTION
## Summary

Adds 3 Dev Tools entries to the Agentic AI For Good catalog:

- **dasel** — query and transform JSON, YAML, TOML, XML, and CSV with one selector syntax
- **Testcontainers** — throwaway Docker containers for real integration tests
- **Liquibase** — versioned database schema change management

Each YAML was validated locally with `npx tsx scripts/validate-tool.ts`.
