### PR TITLE
Add Textual, glow, D2, gum, vhs to catalog

### DIFF
--- a/tools/dev-tools/d2.yaml
+++ b/tools/dev-tools/d2.yaml
@@ -1,0 +1,26 @@
+name: D2
+description: Modern diagram scripting language that turns text into flowcharts, sequence diagrams, and architecture sketches. AI teams version system diagrams next to code instead of dragging boxes in a GUI.
+tagline: Text to diagrams for architecture that lives in git
+
+github_url: https://github.com/d2lang/d2
+website_url: https://d2lang.com
+docs_url: https://d2lang.com/tour/intro/
+install_command: brew install d2
+
+category: Dev Tools
+tags: [diagrams, documentation, golang, architecture, cli]
+pricing: free
+is_open_source: true
+license: MPL-2.0
+
+problem_solved: |
+  RAG pipelines and agent stacks change weekly, but architecture pictures rot
+  in slides. D2 compiles a readable script into SVG or PNG so teams keep
+  diagrams in git, review them in PRs, and regenerate docs when the graph of
+  services changes.
+
+use_cases:
+  - Version an agent plus vector-DB architecture diagram beside the Terraform that deploys it
+  - Generate sequence diagrams of tool-calling flows for onboarding docs
+  - Render CI-produced SVGs of data pipelines after each schema change
+  - Sketch multi-service inference graphs without a proprietary diagram SaaS

--- a/tools/dev-tools/glow.yaml
+++ b/tools/dev-tools/glow.yaml
@@ -1,0 +1,26 @@
+name: glow
+description: Terminal markdown reader from Charm that renders README files, changelogs, and local docs with style. AI teams use it to preview prompt markdown, eval reports, and agent runbooks without leaving the shell.
+tagline: Beautiful markdown in the terminal
+
+github_url: https://github.com/charmbracelet/glow
+website_url: https://github.com/charmbracelet/glow
+docs_url: https://github.com/charmbracelet/glow
+install_command: brew install glow
+
+category: Dev Tools
+tags: [markdown, cli, terminal, golang, documentation]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Prompt packs, experiment notes, and model cards live as markdown that looks
+  ugly in cat and noisy in a browser. glow paginates and styles those files
+  in the terminal so reviewers can read README-quality docs next to the code
+  that produced them.
+
+use_cases:
+  - Preview a model's README and changelog over SSH before merging a catalog PR
+  - Read local prompt markdown and eval reports without opening a GUI editor
+  - Browse a stash of agent runbooks from a pager with fuzzy find
+  - Render GitHub-flavored markdown in CI logs for human-readable job summaries

--- a/tools/dev-tools/gum.yaml
+++ b/tools/dev-tools/gum.yaml
@@ -1,0 +1,26 @@
+name: gum
+description: Charm toolkit for glamorous shell scripts with prompts, spinners, filters, and formatted output. Use it to wrap ML CLI workflows in interactive confirmations instead of brittle read loops.
+tagline: Glamorous interactive prompts for shell scripts
+
+github_url: https://github.com/charmbracelet/gum
+website_url: https://github.com/charmbracelet/gum
+docs_url: https://github.com/charmbracelet/gum
+install_command: brew install gum
+
+category: Dev Tools
+tags: [cli, shell, golang, prompts, scripting, terminal]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Internal ML scripts ask engineers to type y/n, pick a checkpoint, or choose
+  a GPU host with raw echo and read. Those prompts fail in CI and look broken
+  in tmux. gum gives filter, choose, confirm, and input widgets that scripts
+  can call so humans get a real UI and automation can skip it.
+
+use_cases:
+  - Prompt an engineer to pick a model checkpoint from a fuzzy list before deploy
+  - Confirm a destructive dataset wipe with a styled yes/no instead of a raw read
+  - Filter GPU hosts or experiment names in a shell wrapper around training jobs
+  - Format script output as a table or spinner while an embedding job runs

--- a/tools/dev-tools/textual.yaml
+++ b/tools/dev-tools/textual.yaml
@@ -1,0 +1,27 @@
+name: Textual
+description: Python framework for building rich terminal user interfaces with CSS-like styling, widgets, and async reactivity. ML teams use it for local dashboards, dataset browsers, and agent consoles that run over SSH without a browser.
+tagline: Modern TUI apps in Python, styled like the web
+
+github_url: https://github.com/Textualize/textual
+website_url: https://textual.textualize.io/
+docs_url: https://textual.textualize.io/guide/
+install_command: pip install textual
+
+category: Dev Tools
+tags: [python, tui, terminal, ui, cli, async]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI engineers live in terminals and SSH sessions where a React dashboard is
+  overkill and curses apps are painful to maintain. Textual lets you compose
+  widgets, CSS, and async workers into a real app that runs in the same shell
+  as training jobs, so operators get live logs, tables, and controls without
+  shipping a web frontend.
+
+use_cases:
+  - Build a local TUI to browse datasets, launch training jobs, and watch loss curves over SSH
+  - Ship an agent console with live tool-call logs and approval prompts in the terminal
+  - Prototype internal ML ops tools that work on jump hosts without opening ports
+  - Combine Textual with Rich renderables to inspect nested JSON model outputs interactively

--- a/tools/dev-tools/vhs.yaml
+++ b/tools/dev-tools/vhs.yaml
@@ -1,0 +1,26 @@
+name: vhs
+description: Charm CLI that records terminal sessions from a tape file into GIFs and videos. AI teams capture reproducible demos of CLIs, agents, and install flows for docs without a screen recorder.
+tagline: Record terminal demos as GIFs from a tape file
+
+github_url: https://github.com/charmbracelet/vhs
+website_url: https://github.com/charmbracelet/vhs
+docs_url: https://github.com/charmbracelet/vhs
+install_command: brew install vhs
+
+category: Dev Tools
+tags: [cli, demo, gif, documentation, golang, terminal]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  README GIFs of CLI tools go stale the moment flags change, and recording
+  them by hand is noisy. vhs runs a declarative tape of keypresses in a
+  headless terminal and writes a GIF so docs stay in git and regenerate in CI
+  whenever the demo script changes.
+
+use_cases:
+  - Record an agent CLI walkthrough GIF that CI regenerates on every README change
+  - Demo an inference server install flow without a laptop screen recording
+  - Capture typed examples of prompt-cli usage for workshop materials
+  - Keep catalog contribution docs visual with a tape-driven terminal recording


### PR DESCRIPTION
## Summary

Adds 5 Dev Tools entries to the Agentic AI For Good catalog:

- **Textual** — Python TUI framework for terminal dashboards and agent consoles
- **glow** — terminal markdown reader from Charm
- **D2** — text-to-diagram language for architecture that lives in git
- **gum** — glamorous interactive prompts for shell scripts
- **vhs** — record terminal demos as GIFs from a tape file

Each YAML was validated locally with `npx tsx scripts/validate-tool.ts`.
