### PR TITLE
Add OpenMetadata, tokei, PlantUML, Miller to catalog

### DIFF
--- a/tools/data/miller.yaml
+++ b/tools/data/miller.yaml
@@ -1,0 +1,26 @@
+name: Miller
+description: Command-line tool for name-indexed data such as CSV, TSV, and tabular JSON, with awk-like verbs for cut, join, sort, and stats. Data and ML pipelines reshape evaluation tables without loading pandas.
+tagline: awk, sed, cut, join, and sort for CSV and tabular JSON
+
+github_url: https://github.com/johnkerl/miller
+website_url: https://miller.readthedocs.io
+docs_url: https://miller.readthedocs.io
+install_command: brew install miller
+
+category: Data
+tags: [csv, tsv, cli, data-wrangling, golang]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+problem_solved: |
+  Eval sets and feature dumps arrive as huge CSV or JSON lines that are painful
+  to inspect in pandas and awkward in awk. Miller streams name-indexed records
+  so you can filter, join, and summarize tables in a pipeline without a Python
+  process or loading the file into memory.
+
+use_cases:
+  - Filter and summarize LLM eval CSVs in CI without a pandas script
+  - Join prediction TSV with ground-truth CSV by a named key
+  - Convert nested JSON logs into flat tables for a metrics dashboard
+  - Compute group-by stats on streaming feature dumps from a training job

--- a/tools/data/openmetadata.yaml
+++ b/tools/data/openmetadata.yaml
@@ -1,0 +1,25 @@
+name: OpenMetadata
+description: Open-source metadata platform for data discovery, lineage, quality, and governance across warehouses, pipelines, and ML assets. Teams catalog datasets, models, and pipelines in one place instead of tribal wiki knowledge.
+tagline: Open metadata catalog for data and ML assets
+
+github_url: https://github.com/open-metadata/OpenMetadata
+website_url: https://open-metadata.org
+docs_url: https://docs.open-metadata.org
+
+category: Data
+tags: [metadata, lineage, data-catalog, governance, data-quality]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Feature tables, training datasets, and pipeline jobs scatter across warehouses
+  with no shared catalog, so teams cannot answer who owns a table or what
+  trained a model. OpenMetadata ingests metadata and lineage so discovery,
+  ownership, and quality checks live in one service instead of Slack threads.
+
+use_cases:
+  - Catalog warehouse tables and ML feature datasets with owners and descriptions
+  - Trace lineage from a source table through dbt or Airflow into a training job
+  - Surface data quality tests next to the datasets an embedding pipeline consumes
+  - Let analysts search for approved datasets instead of copying tribal SQL

--- a/tools/dev-tools/plantuml.yaml
+++ b/tools/dev-tools/plantuml.yaml
@@ -1,0 +1,26 @@
+name: PlantUML
+description: Text-based diagramming tool that turns a simple language into UML, sequence, component, and architecture diagrams. Teams keep design docs in git and render images in CI instead of drawing boxes in a GUI.
+tagline: UML and sequence diagrams from plain text
+
+github_url: https://github.com/plantuml/plantuml
+website_url: https://plantuml.com
+docs_url: https://plantuml.com/guide
+install_command: brew install plantuml
+
+category: Dev Tools
+tags: [diagrams, uml, documentation, java, architecture]
+pricing: free
+is_open_source: true
+license: LGPL-3.0
+
+problem_solved: |
+  Sequence diagrams of agent tool calls and class diagrams of training code
+  rot in slide decks. PlantUML stores the diagram as text next to the code,
+  so PRs can review the design and CI can emit PNG or SVG whenever the
+  description changes.
+
+use_cases:
+  - Document agent tool-calling sequences as text that CI renders to SVG
+  - Keep component diagrams of a RAG stack versioned beside the services
+  - Generate class diagrams from Java or C++ model-serving code during review
+  - Embed PlantUML in Markdown so architecture docs stay compilable

--- a/tools/dev-tools/tokei.yaml
+++ b/tools/dev-tools/tokei.yaml
@@ -1,0 +1,26 @@
+name: tokei
+description: Fast code statistics tool written in Rust that counts lines, comments, and blanks across hundreds of languages. AI teams use it to size repos, ignore generated files, and report language mix in CI.
+tagline: Count your code, quickly, across hundreds of languages
+
+github_url: https://github.com/XAMPPRocky/tokei
+website_url: https://github.com/XAMPPRocky/tokei
+docs_url: https://github.com/XAMPPRocky/tokei
+install_command: brew install tokei
+
+category: Dev Tools
+tags: [cli, rust, metrics, code-stats, ci]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  cloc is slow on large monorepos and generated protobuf or notebook dumps
+  inflate line counts. tokei walks trees quickly, respects gitignore, and
+  reports per-language totals so reviews and dashboards reflect real source
+  instead of vendored noise.
+
+use_cases:
+  - Report language mix of an ML monorepo in CI without checking in cloc XML
+  - Ignore generated protobuf and notebook output when sizing a training codebase
+  - Compare lines of Python versus CUDA before a refactor of a kernel-heavy repo
+  - Feed compact JSON stats into an internal engineering dashboard


### PR DESCRIPTION
## Summary

Adds 4 catalog entries:

- **OpenMetadata** (Data) — metadata platform for discovery, lineage, and governance
- **tokei** (Dev Tools) — fast code statistics across hundreds of languages
- **PlantUML** (Dev Tools) — UML and sequence diagrams from plain text
- **Miller** (Data) — awk-like CLI for CSV, TSV, and tabular JSON

Each YAML was validated locally with `npx tsx scripts/validate-tool.ts`.
