### PR TITLE
Add Sidekiq, Watermill, Resque, Huey, Dramatiq to catalog

### DIFF
--- a/tools/dev-tools/dramatiq.yaml
+++ b/tools/dev-tools/dramatiq.yaml
@@ -1,0 +1,22 @@
+name: Dramatiq
+description: "Dramatiq is a fast, reliable background task library for Python 3 that uses RabbitMQ or Redis as a broker. It emphasizes simple worker processes, automatic retries, rate limits, and high throughput as a modern alternative to Celery for production job processing."
+tagline: Fast background tasks for Python 3
+github_url: https://github.com/Bogdanp/dramatiq
+website_url: https://dramatiq.io
+docs_url: https://dramatiq.io
+install_command: pip install dramatiq
+category: Dev Tools
+tags: [python, task-queue, rabbitmq, redis, background-jobs, workers]
+pricing: free
+is_open_source: true
+license: LGPL-3.0
+problem_solved: |
+  Python services that outgrow in-process threads need a distributed task queue that is simpler
+  and faster than Celery while still offering retries, rate limits, and broker durability.
+  Dramatiq uses RabbitMQ or Redis, multiprocess workers, and a small API so you can enqueue
+  inference, scraping, and batch transforms with predictable throughput and fewer moving parts
+  than a full Celery deployment.
+use_cases:
+  - "Process LLM inference, scraping, and embedding batches on RabbitMQ- or Redis-backed Dramatiq workers"
+  - "Apply per-actor rate limits and automatic retries when calling third-party AI APIs from background jobs"
+  - "Replace Celery in Python 3 services that want simpler workers and higher job throughput"

--- a/tools/dev-tools/huey.yaml
+++ b/tools/dev-tools/huey.yaml
@@ -1,0 +1,22 @@
+name: Huey
+description: "Huey is a lightweight Python task queue with a small API and optional Redis, Postgres, SQLite, filesystem, or in-memory storage. It supports retries, cron-style scheduling, pipelines, chords, locking, and Django integration without the operational weight of Celery."
+tagline: Lightweight Python task queue
+github_url: https://github.com/coleifer/huey
+website_url: https://huey.readthedocs.io/
+docs_url: https://huey.readthedocs.io/
+install_command: pip install huey
+category: Dev Tools
+tags: [python, task-queue, redis, django, background-jobs, scheduler]
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: |
+  Many Python AI apps need background tasks and periodic jobs but do not want Celery's broker
+  complexity, worker topology, and dependency surface. Huey provides a tiny API for enqueueing
+  functions, retries, crontab schedules, result storage, and pipelines, with Redis, Postgres,
+  SQLite, or even the filesystem as the backend. That lets small teams run embeddings, report
+  jobs, and nightly evals without standing up a full Celery cluster.
+use_cases:
+  - "Offload embedding generation and document parsing from Django request handlers with Redis or Postgres-backed Huey workers"
+  - "Schedule recurring model evals, cache warmups, and data syncs with Huey's crontab-style periodic tasks"
+  - "Chain pipeline steps (chunk, embed, index) with retries, locks, and result storage without adopting Celery"

--- a/tools/dev-tools/resque.yaml
+++ b/tools/dev-tools/resque.yaml
@@ -1,0 +1,22 @@
+name: Resque
+description: "Resque is a Redis-backed Ruby library for creating background jobs, placing them on multiple queues, and processing them later. It includes a Rake worker, a Sinatra monitoring UI, and persistent Redis queues so jobs survive process restarts."
+tagline: Redis-backed Ruby background jobs
+github_url: https://github.com/resque/resque
+website_url: http://resque.github.io/
+docs_url: https://github.com/resque/resque
+install_command: gem install resque
+category: Dev Tools
+tags: [ruby, redis, background-jobs, task-queue, workers, rails]
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: |
+  Ruby applications need a durable way to enqueue work that should not run in the web request:
+  image processing, dataset exports, webhook delivery, and model scoring. Homegrown thread
+  pools lose jobs on crash and give no visibility. Resque stores jobs as JSON in Redis, runs
+  isolated worker processes that can be restarted without losing the queue, and ships a
+  dashboard for failures, queue depth, and what workers are doing.
+use_cases:
+  - "Enqueue Ruby jobs for dataset exports, webhook delivery, and batch scoring so web processes stay responsive"
+  - "Run workers on multiple machines against shared Redis queues with priorities and failure tracking"
+  - "Inspect queues, busy workers, and failed jobs from Resque's Sinatra web UI in staging and production"

--- a/tools/dev-tools/sidekiq.yaml
+++ b/tools/dev-tools/sidekiq.yaml
@@ -1,0 +1,22 @@
+name: Sidekiq
+description: "Sidekiq is a multithreaded Redis-backed background job processor for Ruby. It runs many jobs concurrently in one process, ships a web UI for queues and failures, and integrates with Rails Active Job. Open-source Sidekiq is LGPL; Pro and Enterprise add commercial features."
+tagline: Multithreaded background jobs for Ruby
+github_url: https://github.com/sidekiq/sidekiq
+website_url: https://sidekiq.org
+docs_url: https://github.com/sidekiq/sidekiq/wiki
+install_command: gem install sidekiq
+category: Dev Tools
+tags: [ruby, background-jobs, redis, rails, task-queue, workers]
+pricing: freemium
+is_open_source: true
+license: LGPL-3.0
+problem_solved: |
+  Ruby web apps cannot run slow work (emails, embeddings, batch inference, report generation)
+  inside the request cycle without blocking users and exhausting process workers. Process-per-job
+  queues waste memory; ad-hoc threads have no retries, visibility, or persistence. Sidekiq uses
+  Redis as a durable queue and threads to run many jobs in one process, with retries, a web UI,
+  and Active Job integration so background work is reliable under load.
+use_cases:
+  - "Queue LLM API calls, embedding jobs, and document processing from a Rails app so request threads stay free"
+  - "Send transactional email, webhooks, and notifications asynchronously with automatic retries on failure"
+  - "Monitor failed jobs, queue latency, and worker busy-ness from Sidekiq's web UI in production"

--- a/tools/dev-tools/watermill.yaml
+++ b/tools/dev-tools/watermill.yaml
@@ -1,0 +1,22 @@
+name: Watermill
+description: "Watermill is a Go library for building event-driven applications on message streams. It offers a unified Pub/Sub API over Kafka, RabbitMQ, NATS, PostgreSQL, HTTP, and more so you can implement event sourcing, CQRS, sagas, and stream processing without locking into one broker."
+tagline: Event-driven applications in Go
+github_url: https://github.com/ThreeDotsLabs/watermill
+website_url: https://watermill.io
+docs_url: https://watermill.io
+install_command: go get github.com/ThreeDotsLabs/watermill
+category: Dev Tools
+tags: [go, event-driven, pubsub, kafka, rabbitmq, cqrs, messaging]
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: |
+  Go services that need event-driven architecture often glue together broker-specific SDKs,
+  losing a consistent handler model, middleware, and testing story when switching Kafka for
+  RabbitMQ or PostgreSQL. Watermill gives a single Publish/Subscribe and Router API across
+  backends, with middlewares for retries, poison queues, and metrics, so AI pipelines can
+  fan out jobs, build read models, and run sagas without rewriting the messaging layer.
+use_cases:
+  - "Fan out embedding and inference jobs as events on Kafka or NATS with a shared Go handler API"
+  - "Build CQRS read models and sagas for agent workflows that must survive at-least-once delivery"
+  - "Prototype event-driven services on PostgreSQL or HTTP, then swap to Kafka without changing handlers"


### PR DESCRIPTION
## Add background job / messaging tools to the catalog

Adds five production task-queue and event-driven libraries used in AI/ML backends:

| Tool | Category | Stars | License |
|------|----------|-------|---------|
| Sidekiq | Dev Tools | 13.5k | LGPL-3.0 (freemium Pro/Enterprise) |
| Watermill | Dev Tools | 9.9k | MIT |
| Resque | Dev Tools | 9.5k | MIT |
| Huey | Dev Tools | 6.0k | MIT |
| Dramatiq | Dev Tools | 5.3k | LGPL-3.0 |

Local validation: `npx tsx scripts/validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Dramatiq, Huey, Resque, Sidekiq, and Watermill.
  * Included descriptions, documentation links, installation guidance, licensing details, categories, tags, and common use cases.
  * Expanded coverage of background-job processing, task queues, scheduled work, event-driven applications, and pipeline workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->