### PR TITLE
Add Oban, TerminusDB, OpenLineage, Marquez to catalog

### DIFF
--- a/tools/data/marquez.yaml
+++ b/tools/data/marquez.yaml
@@ -1,0 +1,21 @@
+name: Marquez
+description: "Marquez is an open-source metadata service for collecting, aggregating, and visualizing data lineage. It stores dataset provenance, job runtime, and access frequency, and is the reference implementation of the OpenLineage standard."
+tagline: OpenLineage metadata service and lineage UI
+github_url: https://github.com/MarquezProject/marquez
+website_url: https://marquezproject.ai
+docs_url: https://marquezproject.ai
+category: Data
+tags: [lineage, metadata, openlineage, data-pipelines, observability, lf-ai]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Collecting OpenLineage events is not enough if there is no store and UI to query who produced
+  a dataset, when a job last ran, and how often tables are read. Marquez is the reference
+  OpenLineage backend: it aggregates job and dataset metadata, keeps provenance, and visualizes
+  lineage so ML platform teams can see how features, training sets, and model artifacts flow
+  through the stack.
+use_cases:
+  - "Stand up an OpenLineage backend to collect Spark, Airflow, and dbt events for feature and training data provenance"
+  - "Visualize dataset lineage and job run history so teams can debug broken ML pipelines from source to model"
+  - "Centralize dataset lifecycle metadata (ownership, frequency, last run) for data platform and MLOps reviews"

--- a/tools/data/openlineage.yaml
+++ b/tools/data/openlineage.yaml
@@ -1,0 +1,22 @@
+name: OpenLineage
+description: "OpenLineage is an open standard for collecting job, run, and dataset lineage metadata as pipelines execute. Integrations for Spark, Airflow, dbt, and others emit a shared event model so lineage is not reinvented per platform."
+tagline: Open standard for data lineage metadata
+github_url: https://github.com/OpenLineage/OpenLineage
+website_url: https://openlineage.io
+docs_url: https://openlineage.io/docs
+install_command: pip install openlineage-python
+category: Data
+tags: [lineage, metadata, spark, airflow, dbt, data-pipelines, lf-ai]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Data and ML platforms each invent their own lineage model, so Spark, Airflow, and dbt jobs
+  cannot share a consistent picture of which datasets a training run consumed or produced.
+  OpenLineage defines run, job, and dataset entities plus extensible facets, with integrations
+  that emit events as jobs execute. Downstream catalogs and quality tools can then reconstruct
+  provenance for feature tables, embeddings, and model training without custom collectors.
+use_cases:
+  - "Instrument Spark, Airflow, and dbt jobs so feature tables and training datasets share one lineage event model"
+  - "Send OpenLineage events from Python pipelines with pip install openlineage-python to a Marquez or DataHub backend"
+  - "Trace which raw sources fed an embedding index or model checkpoint when a production metric drifts"

--- a/tools/data/terminusdb.yaml
+++ b/tools/data/terminusdb.yaml
@@ -1,0 +1,21 @@
+name: TerminusDB
+description: "TerminusDB is a distributed collaborative database with git-like versioning for structured data. It stores JSON documents in a knowledge graph, supports GraphQL and WOQL datalog queries, time-travel, and push/pull/clone between nodes."
+tagline: Git-for-data knowledge graph database
+github_url: https://github.com/terminusdb/terminusdb
+website_url: https://terminusdb.org
+docs_url: https://terminusdb.org/docs
+category: Data
+tags: [knowledge-graph, versioning, graphql, datalog, json, collaboration]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  AI teams that need a system of record for evolving structured knowledge struggle with
+  databases that overwrite history and graphs that cannot be branched or reviewed like code.
+  TerminusDB versions every commit, diffs states as patches, and supports clone/push/pull so
+  schemas and documents can be reviewed, time-traveled, and reasoned over with GraphQL or
+  WOQL datalog instead of ad-hoc JSON files.
+use_cases:
+  - "Version knowledge graphs for RAG and agent memory with git-like commits, diffs, and time-travel queries"
+  - "Collaborate on schemas and JSON documents across teams using clone, push, and pull between TerminusDB nodes"
+  - "Query linked documents with GraphQL or WOQL datalog, including path queries and temporal interval reasoning"

--- a/tools/dev-tools/oban.yaml
+++ b/tools/dev-tools/oban.yaml
@@ -1,0 +1,21 @@
+name: Oban
+description: "Oban is a robust job processing library for Elixir backed by PostgreSQL, MySQL, or SQLite3. It provides retries, uniqueness, cron, observability, and queue isolation in the database, with optional Oban Pro for extra commercial features."
+tagline: Database-backed job processing for Elixir
+github_url: https://github.com/oban-bg/oban
+website_url: https://oban.pro
+docs_url: https://oban.hexdocs.pm
+category: Dev Tools
+tags: [elixir, background-jobs, postgresql, task-queue, workers, phoenix]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Elixir and Phoenix apps need durable background jobs that survive node restarts without
+  standing up Redis or RabbitMQ just for a queue. Homegrown Task.async work is lost on crash
+  and has no uniqueness, cron, or dashboard. Oban stores jobs in PostgreSQL, MySQL, or SQLite,
+  so retries, uniqueness, scheduled work, and observability live next to application data and
+  can run inference, emails, and pipeline steps reliably on BEAM.
+use_cases:
+  - "Enqueue LLM API calls, embeddings, and report generation from Phoenix so request processes stay free"
+  - "Run cron-style model evals and data syncs with unique jobs so duplicate workers do not double-fire"
+  - "Inspect failed jobs, queue latency, and worker activity from Oban's database-backed observability"


### PR DESCRIPTION
## Add job processing and data lineage tools

Adds four production tools used in Elixir backends and ML data platforms:

| Tool | Category | Stars | License |
|------|----------|-------|---------|
| Oban | Dev Tools | 4.0k | Apache-2.0 (freemium Pro) |
| TerminusDB | Data | 3.4k | Apache-2.0 |
| OpenLineage | Data | 2.6k | Apache-2.0 |
| Marquez | Data | 2.3k | Apache-2.0 |

Local validation: `npx tsx scripts/validate-tool.ts` passed for all four files.
