### PR TITLE
Add GoodJob, Delayed Job, Faktory, Broadway, sccache to catalog

### DIFF
--- a/tools/data/broadway.yaml
+++ b/tools/data/broadway.yaml
@@ -1,0 +1,21 @@
+name: Broadway
+description: "Broadway is an Elixir library for concurrent multi-stage data ingestion and processing. It consumes from SQS, Kafka, Pub/Sub, RabbitMQ, and other producers with back-pressure, batching, acknowledgements, and fault-tolerant BEAM pipelines."
+tagline: Concurrent data ingestion pipelines in Elixir
+github_url: https://github.com/elixir-broadway/broadway
+website_url: https://elixir-broadway.org
+docs_url: https://hexdocs.pm/broadway
+category: Data
+tags: [elixir, data-pipelines, kafka, sqs, rabbitmq, streaming, ingestion]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Building concurrent ingestion topologies in Elixir with raw GenStage is error-prone:
+  back-pressure, batching, acks, and shutdown must be wired by hand. Broadway configures
+  producers, processors, and batchers so event streams from Kafka, SQS, or Pub/Sub become
+  long-lived pipelines for feature events, embeddings, and webhook fan-in without dropping
+  messages on crash.
+use_cases:
+  - "Ingest Kafka or SQS events into Elixir pipelines that batch embedding and feature writes"
+  - "Apply back-pressure and rate limits when calling LLM APIs from a Broadway processor"
+  - "Acknowledge messages only after downstream vector or warehouse writes succeed"

--- a/tools/dev-tools/delayed-job.yaml
+++ b/tools/dev-tools/delayed-job.yaml
@@ -1,0 +1,22 @@
+name: Delayed Job
+description: "Delayed Job is a database-backed asynchronous priority queue extracted from Shopify. It stores jobs as rows, supports priorities and retries, and runs a single-threaded worker so long-running Ruby tasks survive web process restarts."
+tagline: Database-backed background jobs from Shopify
+github_url: https://github.com/collectiveidea/delayed_job
+website_url: https://github.com/collectiveidea/delayed_job
+docs_url: https://github.com/collectiveidea/delayed_job
+install_command: gem install delayed_job
+category: Dev Tools
+tags: [ruby, rails, background-jobs, postgresql, task-queue, shopify]
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: |
+  Ruby apps need a durable queue for newsletters, image work, search reindexes, and batch
+  imports without introducing Redis. Delayed Job stores jobs in the application database,
+  so work is not lost when a web process dies, and operators can inspect, retry, and
+  prioritize rows with SQL. That is still a practical path for Rails AI features that
+  enqueue scoring and report generation on a single primary database.
+use_cases:
+  - "Enqueue newsletter sends, image resizing, and search reindexes as database rows in a Rails app"
+  - "Retry failed embedding or webhook jobs by inspecting the delayed_jobs table with SQL"
+  - "Run a Delayed Job worker alongside the web process so background AI tasks survive deploys"

--- a/tools/dev-tools/faktory.yaml
+++ b/tools/dev-tools/faktory.yaml
@@ -1,0 +1,21 @@
+name: Faktory
+description: "Faktory is a language-agnostic persistent background job server. Jobs are JSON hashes pushed to queues; workers in any language fetch, ACK, or FAIL them with reservation timeouts, retries, and a built-in web UI for monitoring."
+tagline: Language-agnostic persistent job server
+github_url: https://github.com/contribsys/faktory
+website_url: https://contribsys.com/faktory
+docs_url: https://github.com/contribsys/faktory/wiki
+category: Dev Tools
+tags: [background-jobs, task-queue, workers, redis, go, polyglot]
+pricing: freemium
+is_open_source: true
+license: GPL-3.0
+problem_solved: |
+  Polyglot stacks cannot share Sidekiq or Celery without rewriting workers in one language.
+  Faktory is a dedicated job server: producers push JSON jobs, workers in Ruby, Python, Go,
+  or other clients fetch them with timeouts and retries. That lets an AI platform enqueue
+  work from a Rails API and process embeddings in Python without a language-specific broker
+  protocol. Open-source Faktory is GPL; Faktory Pro adds commercial features.
+use_cases:
+  - "Enqueue jobs from a Rails or Go API and process embeddings or scraping in Python workers"
+  - "Run a shared job server across microservices so each language team does not operate its own queue"
+  - "Monitor queues, retries, and failed jobs from Faktory's web UI in production"

--- a/tools/dev-tools/good-job.yaml
+++ b/tools/dev-tools/good-job.yaml
@@ -1,0 +1,21 @@
+name: GoodJob
+description: "GoodJob is a multithreaded, Postgres-based Active Job backend for Ruby on Rails. It uses advisory locks and LISTEN/NOTIFY for run-once safety and low latency, and includes cron, batches, concurrency controls, and a web dashboard without Redis."
+tagline: Postgres-backed Active Job for Rails
+github_url: https://github.com/bensheldon/good_job
+website_url: https://goodjob-demo.herokuapp.com
+docs_url: https://github.com/bensheldon/good_job
+install_command: gem install good_job
+category: Dev Tools
+tags: [ruby, rails, postgresql, background-jobs, active-job, workers]
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: |
+  Rails teams that want durable background jobs often add Redis just for Sidekiq, then operate
+  two data stores. Jobs in Redis can vanish on crash unless you pay for Sidekiq Pro. GoodJob
+  keeps Active Job in Postgres with multithreaded workers, advisory locks, and LISTEN/NOTIFY,
+  so emails, embeddings, and batch inference share the same ACID database as the app.
+use_cases:
+  - "Run Rails Active Job on Postgres for LLM calls, emails, and exports without operating Redis"
+  - "Schedule cron-like jobs and batches with concurrency limits from GoodJob's web dashboard"
+  - "Scale from in-process workers in development to a dedicated good_job CLI in production"

--- a/tools/dev-tools/sccache.yaml
+++ b/tools/dev-tools/sccache.yaml
@@ -1,0 +1,21 @@
+name: sccache
+description: "sccache is Mozilla's compiler cache, a ccache-like wrapper that skips redundant compiles for C/C++, Rust, CUDA, and HIP. It stores results locally or in S3, Redis, GitHub Actions cache, and other remotes, and can distribute compilation across machines."
+tagline: Shared compiler cache for C++, Rust, and CUDA
+github_url: https://github.com/mozilla/sccache
+website_url: https://github.com/mozilla/sccache
+docs_url: https://github.com/mozilla/sccache
+install_command: brew install sccache
+category: Dev Tools
+tags: [compiler, cache, rust, cuda, cplusplus, ci, mozilla]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  ML and systems codebases spend CI hours recompiling C++, CUDA, and Rust that did not change.
+  Local ccache does not share across machines or GitHub runners. sccache wraps the compiler,
+  caches object files locally or in S3/Redis/Actions cache, and optionally distributes builds,
+  so PyTorch extensions, CUDA kernels, and Rust tokenizers rebuild only when inputs change.
+use_cases:
+  - "Cache CUDA and C++ compiles for PyTorch extensions across CI jobs with S3 or GitHub Actions storage"
+  - "Speed up Rust tokenizer and inference crate builds by wrapping rustc with sccache"
+  - "Share a compiler cache across developer laptops and build farms without reconfiguring each compiler"


### PR DESCRIPTION
## Add job backends, Elixir ingestion, and compiler cache

Adds five production tools:

| Tool | Category | Stars | License |
|------|----------|-------|---------|
| GoodJob | Dev Tools | 3.0k | MIT |
| Delayed Job | Dev Tools | 4.8k | MIT |
| Faktory | Dev Tools | 6.1k | GPL-3.0 (freemium Pro) |
| Broadway | Data | 2.7k | Apache-2.0 |
| sccache | Dev Tools | 7.6k | Apache-2.0 |

Local validation: `npx tsx scripts/validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Broadway to the library catalog, including descriptions, links, licensing, pricing, tags, and practical use cases.
  - Added Delayed Job, Faktory, GoodJob, and sccache to the developer tools catalog.
  - New entries include installation details, documentation links, capabilities, licensing, pricing, and common use cases.
  - Improved catalog coverage for data ingestion, background job processing, and build acceleration tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->