### PR TITLE
Add Luigi, Beanstalkd, Connect RPC, Solid Queue to catalog

### DIFF
--- a/tools/data/luigi.yaml
+++ b/tools/data/luigi.yaml
@@ -1,0 +1,22 @@
+name: Luigi
+description: "Luigi is Spotify's Python package for building complex batch pipelines. It handles dependency resolution, workflow management, failure handling, visualization, and Hadoop integration so long-running jobs run in the right order."
+tagline: Python batch pipelines from Spotify
+github_url: https://github.com/spotify/luigi
+website_url: https://luigi.readthedocs.io
+docs_url: https://luigi.readthedocs.io/en/stable/
+install_command: pip install luigi
+category: Data
+tags: [python, pipelines, workflow, batch, hadoop, spotify, etl]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Batch ML and data jobs have dependencies: extract before transform, transform before
+  train. Cron plus shell scripts do not visualize the graph or retry only failed nodes.
+  Luigi models tasks and their outputs so Spotify-style pipelines resolve order, skip
+  finished work, and surface failures in a UI, which is still useful for feature ETL
+  and periodic model training without a heavier orchestrator.
+use_cases:
+  - "Build Python batch pipelines that extract, transform, and train models with explicit task dependencies"
+  - "Skip already-complete ETL nodes and retry only failed feature-generation tasks"
+  - "Visualize Hadoop or local batch workflows for dataset refreshes that feed RAG indexes"

--- a/tools/dev-tools/beanstalkd.yaml
+++ b/tools/dev-tools/beanstalkd.yaml
@@ -1,0 +1,21 @@
+name: Beanstalkd
+description: "Beanstalkd is a simple, fast work queue. Producers put jobs into tubes; workers reserve, delete, or bury them over a small text protocol. It is designed to cut web latency by moving slow work off the request path."
+tagline: Simple fast work queue
+github_url: https://github.com/beanstalkd/beanstalkd
+website_url: https://beanstalkd.github.io/
+docs_url: https://github.com/beanstalkd/beanstalkd/blob/master/doc/protocol.txt
+install_command: brew install beanstalkd
+category: Dev Tools
+tags: [work-queue, background-jobs, c, messaging, workers]
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: |
+  Small services need a dedicated queue that is simpler than Kafka or Redis-backed job
+  frameworks. Beanstalkd speaks a tiny protocol: put, reserve, delete, bury, with
+  priorities and delayed jobs. Web and AI APIs can dump embedding or webhook work onto
+  a tube and keep request latency low without operating a full broker cluster.
+use_cases:
+  - "Offload embedding generation and webhook delivery from web workers onto Beanstalkd tubes"
+  - "Delay and prioritize jobs with a minimal protocol instead of standing up Kafka or Redis"
+  - "Run a single-binary work queue on Linux or macOS for small ML batch workers"

--- a/tools/dev-tools/connect-rpc.yaml
+++ b/tools/dev-tools/connect-rpc.yaml
@@ -1,0 +1,22 @@
+name: Connect RPC
+description: "Connect is a slim library for browser- and gRPC-compatible HTTP APIs from Protocol Buffer schemas. Handlers and clients speak Connect, gRPC, and gRPC-Web over HTTP/1.1 or HTTP/2, including streaming, with curl-friendly JSON."
+tagline: Protobuf RPC that works in browsers and services
+github_url: https://github.com/connectrpc/connect-go
+website_url: https://connectrpc.com
+docs_url: https://connectrpc.com/docs/introduction
+install_command: go get connectrpc.com/connect
+category: Dev Tools
+tags: [rpc, protobuf, grpc, go, http, api, streaming]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  gRPC is awkward in browsers and behind HTTP/1.1 load balancers, while hand-rolled JSON
+  APIs lose protobuf contracts. Connect generates type-safe clients and handlers that
+  speak Connect, gRPC, and gRPC-Web so the same schema serves curl, browsers, and
+  microservices. AI gateways can expose inference and agent APIs without a separate
+  gRPC-Web proxy.
+use_cases:
+  - "Expose protobuf inference and agent APIs that work with curl, browsers, and gRPC clients"
+  - "Generate type-safe Go clients for internal model-serving services without a gRPC-Web proxy"
+  - "Support streaming completions over HTTP/1.1 and HTTP/2 from one Connect handler"

--- a/tools/dev-tools/solid-queue.yaml
+++ b/tools/dev-tools/solid-queue.yaml
@@ -1,0 +1,21 @@
+name: Solid Queue
+description: "Solid Queue is Rails' database-backed Active Job backend. It supports delayed jobs, concurrency controls, recurring jobs, queue pausing, and bulk enqueue on MySQL, PostgreSQL, or SQLite using FOR UPDATE SKIP LOCKED when available."
+tagline: Database-backed Active Job for Rails
+github_url: https://github.com/rails/solid_queue
+website_url: https://github.com/rails/solid_queue
+docs_url: https://github.com/rails/solid_queue
+install_command: gem install solid_queue
+category: Dev Tools
+tags: [ruby, rails, postgresql, mysql, sqlite, background-jobs, active-job]
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: |
+  Rails 8 defaults to database-backed jobs so teams do not need Redis for Active Job.
+  Solid Queue polls with SKIP LOCKED, handles recurring and delayed work, and stays
+  compatible with Active Job retries. AI features in Rails can enqueue inference and
+  mailers on the same SQL database the app already runs.
+use_cases:
+  - "Use Rails 8 default Active Job on Postgres, MySQL, or SQLite for LLM calls and emails"
+  - "Pause queues, set numeric priorities, and bulk-enqueue batch embedding jobs"
+  - "Run Solid Queue workers alongside Puma without adding Redis to the stack"


### PR DESCRIPTION
## Add Luigi, Beanstalkd, Connect RPC, Solid Queue

Adds four production pipeline, queue, RPC, and Rails job tools:

| Tool | Category | Stars | License |
|------|----------|-------|---------|
| Luigi | Data | 18.8k | Apache-2.0 |
| Beanstalkd | Dev Tools | 6.7k | MIT |
| Connect RPC | Dev Tools | 4.1k | Apache-2.0 |
| Solid Queue | Dev Tools | 2.5k | MIT |

Local validation: `npx tsx scripts/validate-tool.ts` passed for all four files.
