### PR TITLE
Add mold, sqlc, grpcurl, gRPC-Gateway, Twirp to catalog

### DIFF
--- a/tools/dev-tools/grpc-gateway.yaml
+++ b/tools/dev-tools/grpc-gateway.yaml
@@ -1,0 +1,25 @@
+name: gRPC-Gateway
+description: Generates a reverse-proxy that translates JSON HTTP into gRPC using google.api.http annotations. Teams expose REST APIs from existing protobuf services without hand-writing HTTP handlers, which is useful for browsers talking to gRPC model backends.
+tagline: JSON HTTP proxy generated from gRPC services
+
+github_url: https://github.com/grpc-ecosystem/grpc-gateway
+website_url: https://grpc-ecosystem.github.io/grpc-gateway/
+docs_url: https://grpc-ecosystem.github.io/grpc-gateway/
+install_command: go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@latest
+
+category: Dev Tools
+tags: [grpc, rest, protobuf, api-gateway, openapi, golang, developer-tools]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Internal services often speak gRPC while browsers, mobile apps, and third-party clients
+  expect JSON over HTTP. Hand-writing both stacks duplicates proto contracts and drifts.
+  gRPC-Gateway generates a reverse proxy from the same .proto files, mapping RPCs to REST
+  paths so one schema serves both gRPC model backends and HTTP clients.
+
+use_cases:
+  - Expose a REST JSON API in front of a gRPC model-serving or feature-store backend
+  - Generate OpenAPI docs from protobuf annotations for external HTTP consumers
+  - Keep a single proto contract for internal RPC and public HTTP without dual handlers

--- a/tools/dev-tools/grpcurl.yaml
+++ b/tools/dev-tools/grpcurl.yaml
@@ -1,0 +1,25 @@
+name: grpcurl
+description: A command-line client for gRPC servers, analogous to curl for HTTP. It lists services via server reflection, invokes RPCs, and inspects protobuf payloads, making it the standard tool for debugging model-serving and microservice gRPC APIs.
+tagline: Like cURL, but for gRPC
+
+github_url: https://github.com/fullstorydev/grpcurl
+website_url: https://github.com/fullstorydev/grpcurl
+docs_url: https://github.com/fullstorydev/grpcurl/blob/master/README.md
+install_command: brew install grpcurl
+
+category: Dev Tools
+tags: [grpc, cli, protobuf, debugging, api, microservices, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  gRPC traffic is binary protobuf over HTTP/2, so curl and browser tools cannot inspect
+  or call it. grpcurl talks to gRPC servers from the terminal, using reflection or proto
+  files to list methods and send requests. That makes model-serving endpoints, embedding
+  APIs, and internal RPC services as easy to probe as a REST URL.
+
+use_cases:
+  - Invoke inference or embedding RPCs against a gRPC model server from the terminal
+  - List services and methods on a reflected gRPC endpoint during local debugging
+  - Script health checks and smoke tests for protobuf APIs in CI without writing a client

--- a/tools/dev-tools/mold.yaml
+++ b/tools/dev-tools/mold.yaml
@@ -1,0 +1,25 @@
+name: mold
+description: A drop-in replacement for Unix linkers that links large C++ and Rust programs far faster than GNU ld, gold, or lld. Used to cut CI and local rebuild times for ML frameworks, inference engines, and native extensions.
+tagline: A modern linker that makes large native builds finish faster
+
+github_url: https://github.com/rui314/mold
+website_url: https://github.com/rui314/mold
+docs_url: https://github.com/rui314/mold/blob/main/docs/mold.md
+install_command: brew install mold
+
+category: Dev Tools
+tags: [linker, rust, cpp, build, ci, performance, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Linking is often the slowest step when compiling large C++ or Rust codebases such as
+  PyTorch, TensorFlow, or custom CUDA kernels. mold is a drop-in ld replacement that
+  parallelizes linking and typically finishes several times faster than GNU ld or gold,
+  shrinking CI cycles and local rebuilds without changing compiler flags beyond -fuse-ld=mold.
+
+use_cases:
+  - Speed up CI linking of large ML frameworks and native Python extensions
+  - Cut local rebuild times for Rust inference servers and C++ CUDA kernels
+  - Drop in as -fuse-ld=mold in CMake, Bazel, or cargo without rewriting the build

--- a/tools/dev-tools/sqlc.yaml
+++ b/tools/dev-tools/sqlc.yaml
@@ -1,0 +1,25 @@
+name: sqlc
+description: Compiles SQL queries into type-safe Go, Python, Kotlin, and TypeScript so database access stays in SQL instead of an ORM. You write queries, it generates models and methods, catching schema mismatches at compile time.
+tagline: Generate type-safe code from SQL
+
+github_url: https://github.com/sqlc-dev/sqlc
+website_url: https://sqlc.dev
+docs_url: https://docs.sqlc.dev
+install_command: brew install sqlc
+
+category: Dev Tools
+tags: [sql, codegen, go, postgresql, mysql, type-safe, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  ORMs hide SQL and still fail at runtime when a column is renamed or a query is wrong.
+  sqlc keeps queries in plain SQL against your schema, then generates typed client code
+  so broken queries fail at compile time. Feature stores, experiment trackers, and
+  training-metadata databases get predictable, reviewable SQL without stringly-typed access.
+
+use_cases:
+  - Generate typed Go or Python accessors for feature-store and experiment-tracking databases
+  - Keep production SQL in reviewable .sql files instead of ORM query builders
+  - Catch schema drift in CI by regenerating code and failing the build on type errors

--- a/tools/dev-tools/twirp.yaml
+++ b/tools/dev-tools/twirp.yaml
@@ -1,0 +1,25 @@
+name: Twirp
+description: A simple RPC framework from Twitch that generates HTTP JSON and protobuf clients and servers from .proto service definitions. Smaller than gRPC, it uses standard HTTP and is easy to debug with curl while remaining strongly typed.
+tagline: Simple protobuf RPC over plain HTTP
+
+github_url: https://github.com/twitchtv/twirp
+website_url: https://twitchtv.github.io/twirp/docs/intro.html
+docs_url: https://twitchtv.github.io/twirp/docs/intro.html
+install_command: go install github.com/twitchtv/twirp/protoc-gen-twirp@latest
+
+category: Dev Tools
+tags: [rpc, protobuf, http, golang, microservices, codegen, developer-tools]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Full gRPC stacks bring HTTP/2, custom load balancers, and tooling that many teams do not
+  need for internal APIs. Twirp generates typed clients and servers from protobuf, then
+  speaks regular HTTP with JSON or binary protobuf. Services stay schema-first and easy
+  to call with curl, while avoiding gRPC operational complexity.
+
+use_cases:
+  - Define internal microservice APIs in protobuf and generate Go servers over HTTP
+  - Call typed RPC endpoints with curl or JSON clients during debugging
+  - Ship a smaller RPC stack than gRPC for services that only need HTTP plus protobuf


### PR DESCRIPTION
## Summary
Adds five developer infrastructure tools used daily in AI/ML build and service stacks:

- **mold** (rui314/mold, 16.9k★, MIT) — modern Unix linker that speeds up large C++/Rust builds
- **sqlc** (sqlc-dev/sqlc, 18.2k★, MIT) — generate type-safe code from SQL
- **grpcurl** (fullstorydev/grpcurl, 12.8k★, MIT) — curl-like CLI for gRPC servers
- **gRPC-Gateway** (grpc-ecosystem/grpc-gateway, 20.0k★, BSD-3-Clause) — JSON/HTTP reverse-proxy generated from gRPC
- **Twirp** (twitchtv/twirp, 7.5k★, Apache-2.0) — simple protobuf RPC over plain HTTP

All entries validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added developer-tool catalog entries for gRPC-Gateway, grpcurl, mold, sqlc, and Twirp.
  * Each entry includes descriptions, installation guidance, links to documentation, categories, tags, licensing, and representative use cases.
  * Added discoverability information highlighting capabilities such as gRPC communication, code generation, build performance, and RPC frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->