### PR TITLE
Add River, Taskiq, Karafka to catalog

### DIFF
--- a/tools/data/karafka.yaml
+++ b/tools/data/karafka.yaml
@@ -1,0 +1,25 @@
+name: Karafka
+description: A Ruby and Rails framework for multi-threaded Kafka consumers and producers, with a web UI, ActiveJob backend, and dead-letter queues. Built on librdkafka, it processes event streams that feed feature stores and ML pipelines.
+tagline: Efficient Kafka processing for Ruby and Rails
+
+github_url: https://github.com/karafka/karafka
+website_url: https://karafka.io
+docs_url: https://karafka.io/docs
+install_command: gem install karafka
+
+category: Data
+tags: [kafka, ruby, rails, streaming, event-processing, consumers, data]
+pricing: freemium
+is_open_source: true
+license: LGPL-3.0
+
+problem_solved: |
+  Ruby teams that need Kafka often glue rdkafka bindings and thread pools by hand, then lose
+  observability and retry semantics. Karafka gives a Rails-native consumer DSL, multi-threaded
+  processing, dead-letter queues, and a web UI on top of librdkafka. Event streams that land
+  in feature stores or training pipelines can be consumed without a custom Kafka runtime.
+
+use_cases:
+  - Consume Kafka topics in Rails to persist events into feature stores or warehouses
+  - Run multi-threaded consumers for high-throughput ML event pipelines in Ruby
+  - Use the Karafka web UI to monitor lag, retries, and dead-letter queues in production

--- a/tools/dev-tools/river.yaml
+++ b/tools/dev-tools/river.yaml
@@ -1,0 +1,26 @@
+name: River
+description: A Postgres-backed job queue for Go that enqueues work in the same database transaction as application data. Jobs become visible only after commit, so embedding pipelines and training workers never lose or duplicate work after a rollback.
+tagline: Fast, reliable background jobs in Go on Postgres
+
+github_url: https://github.com/riverqueue/river
+website_url: https://riverqueue.com
+docs_url: https://riverqueue.com/docs
+install_command: go get github.com/riverqueue/river
+
+category: Dev Tools
+tags: [go, postgres, job-queue, background-jobs, workers, developer-tools]
+pricing: freemium
+is_open_source: true
+license: MPL-2.0
+
+problem_solved: |
+  Redis job queues split application writes from enqueueing, so a committed user record can
+  miss its follow-up job, or a rolled-back write can still fire work. River stores jobs in
+  Postgres and inserts them in the same transaction as your data. If the transaction commits,
+  the job runs; if it rolls back, the job never existed. That model fits Go ML services that
+  already run on Postgres.
+
+use_cases:
+  - Enqueue embedding or notification jobs atomically with the source database write
+  - Run cron and retryable workers for Go model-serving apps without a Redis dependency
+  - Inspect failing jobs in River UI during incidents without adding another datastore

--- a/tools/dev-tools/taskiq.yaml
+++ b/tools/dev-tools/taskiq.yaml
@@ -1,0 +1,25 @@
+name: Taskiq
+description: An async-first Python distributed task queue inspired by Celery and Dramatiq. It runs sync and async functions, integrates with FastAPI and AioHTTP, and brokers work over Redis, NATS, RabbitMQ, or Kafka.
+tagline: Distributed Python task queue with first-class async
+
+github_url: https://github.com/taskiq-python/taskiq
+website_url: https://taskiq-python.github.io/
+docs_url: https://taskiq-python.github.io/
+install_command: pip install taskiq
+
+category: Dev Tools
+tags: [python, async, task-queue, celery, fastapi, redis, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Celery is sync-first and awkward inside FastAPI and other asyncio stacks used for LLM APIs.
+  Taskiq sends and runs both sync and async functions with type-hinted brokers, so workers
+  can await model calls, HTTP clients, and DB pools without wrapping them in sync executors.
+  Redis, NATS, RabbitMQ, and Kafka brokers cover the same backends ML teams already run.
+
+use_cases:
+  - Offload LLM inference, embedding, and webhook work from FastAPI request handlers
+  - Run typed async workers against Redis, NATS, RabbitMQ, or Kafka brokers
+  - Reuse FastAPI dependencies inside background tasks instead of rebuilding a Celery app


### PR DESCRIPTION
## Summary
Adds three job-queue and stream-processing tools:

- **River** (riverqueue/river, 5.6k★, MPL-2.0) — Postgres-backed background jobs for Go
- **Taskiq** (taskiq-python/taskiq, 2.3k★, MIT) — async-first Python distributed task queue
- **Karafka** (karafka/karafka, 2.3k★, LGPL-3.0) — Ruby/Rails Kafka processing framework

All entries validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Karafka to the framework catalog, with details for Ruby and Rails Kafka consumers and producers.
  * Added River to the development tools catalog, highlighting its Postgres-backed job queue capabilities.
  * Added Taskiq to the development tools catalog, covering async distributed task processing and supported message brokers.
  * Included installation guidance, links, licensing, pricing, tags, problem statements, and practical use cases for each entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->