### PR TITLE
Add OXC, watchexec, gitui, Jujutsu, DataFusion to catalog

### DIFF
--- a/tools/data/datafusion.yaml
+++ b/tools/data/datafusion.yaml
@@ -1,0 +1,25 @@
+name: DataFusion
+description: Apache DataFusion is an extensible SQL query engine written in Rust, built on Apache Arrow. Python and Rust APIs let teams run analytical SQL on Parquet and object storage without standing up a cluster, which fits local and embedded ML feature queries.
+tagline: Embeddable Arrow-native SQL query engine
+
+github_url: https://github.com/apache/datafusion
+website_url: https://datafusion.apache.org/
+docs_url: https://datafusion.apache.org/user-guide/introduction.html
+install_command: pip install datafusion
+
+category: Data
+tags: [sql, arrow, rust, python, query-engine, parquet, analytics]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Ad hoc SQL over Parquet lakes usually means Spark or DuckDB, and embedding a planner
+  in a Rust or Python service is hard. DataFusion is a library query engine on Arrow that
+  you embed in your process, extend with custom functions, and point at files. Feature
+  extraction and dataset inspection can run in-process without a separate cluster.
+
+use_cases:
+  - Query Parquet training datasets with SQL from Python without Spark
+  - Embed an Arrow SQL engine inside a Rust feature-store or inference service
+  - Extend SQL with custom UDFs for domain-specific ML feature transforms

--- a/tools/dev-tools/gitui.yaml
+++ b/tools/dev-tools/gitui.yaml
@@ -1,0 +1,25 @@
+name: gitui
+description: A fast terminal UI for Git written in Rust. It offers staging, committing, blame, stash, and log browsing in a keyboard-driven TUI, which is useful in remote GPU boxes and SSH sessions where a graphical Git client is not available.
+tagline: Blazing-fast terminal UI for Git
+
+github_url: https://github.com/extrawurst/gitui
+website_url: https://github.com/extrawurst/gitui
+docs_url: https://github.com/extrawurst/gitui/blob/master/README.md
+install_command: brew install gitui
+
+category: Dev Tools
+tags: [git, tui, rust, terminal, developer-tools, vcs]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  GPU training boxes and headless servers have Git but no GUI, and raw git status/diff
+  is slow to navigate in large ML repos with many generated files. gitui gives a keyboard
+  TUI for staging hunks, inspecting logs, and managing stashes over SSH, so experiment
+  branches can be reviewed without copying the repo to a laptop.
+
+use_cases:
+  - Stage and commit experiment code on a remote GPU box over SSH
+  - Browse blame and log in large ML repositories from the terminal
+  - Manage stashes and branches without a graphical Git client

--- a/tools/dev-tools/jujutsu.yaml
+++ b/tools/dev-tools/jujutsu.yaml
@@ -1,0 +1,25 @@
+name: Jujutsu
+description: A Git-compatible version control system with a simpler mental model than Git. Working-copy commits are automatic, conflicts are first-class, and the jj CLI interoperates with Git remotes, which helps ML teams manage long-lived experiment branches.
+tagline: Git-compatible VCS with a simpler workflow
+
+github_url: https://github.com/jj-vcs/jj
+website_url: https://jj-vcs.github.io/jj/
+docs_url: https://jj-vcs.github.io/jj/latest/
+install_command: brew install jj
+
+category: Dev Tools
+tags: [git, vcs, version-control, cli, rust, developer-tools]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Git's index, rebase, and detached HEAD confuse people iterating on experiments, and
+  rewriting history is easy to get wrong. Jujutsu records every working-copy change as a
+  commit, treats conflicts as data, and still pushes to GitHub remotes. Teams keep Git
+  interoperability while getting undo-friendly history for model and data pipeline work.
+
+use_cases:
+  - Track experiment branches with automatic working-copy commits instead of constant git add
+  - Collaborate on GitHub remotes using jj while teammates stay on git
+  - Resolve conflicts as first-class state instead of stopping the whole rebase

--- a/tools/dev-tools/oxc.yaml
+++ b/tools/dev-tools/oxc.yaml
@@ -1,0 +1,25 @@
+name: OXC
+description: A high-performance JavaScript and TypeScript toolchain written in Rust, covering parser, linter, formatter, resolver, and minifier. oxlint is the drop-in ESLint-class linter used to keep large frontend and agent-UI codebases fast in CI.
+tagline: Rust-powered JavaScript toolchain, including oxlint
+
+github_url: https://github.com/oxc-project/oxc
+website_url: https://oxc.rs
+docs_url: https://oxc.rs
+install_command: npm install -g oxlint
+
+category: Dev Tools
+tags: [javascript, typescript, linter, rust, parser, formatter, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  ESLint and related JS tooling are slow on large monorepos, so CI lint jobs dominate
+  agent-dashboard and web-app pipelines. OXC reimplements parser, linter, and formatter
+  in Rust. oxlint runs orders of magnitude faster than ESLint on the same rules, catching
+  issues in TypeScript frontends without waiting minutes per pull request.
+
+use_cases:
+  - Lint large TypeScript monorepos in CI in seconds instead of minutes
+  - Parse and transform JS/TS in custom build tools without a slow Babel pipeline
+  - Replace ESLint on agent console and ML dashboard frontends for faster local feedback

--- a/tools/dev-tools/watchexec.yaml
+++ b/tools/dev-tools/watchexec.yaml
@@ -1,0 +1,25 @@
+name: watchexec
+description: A cross-platform CLI that runs a command whenever files change. Used as a lightweight file watcher for rebuilds, tests, codegen, and local model-serving loops without tying the workflow to a specific language toolchain.
+tagline: Run a command whenever files change
+
+github_url: https://github.com/watchexec/watchexec
+website_url: https://watchexec.github.io/
+docs_url: https://watchexec.github.io/
+install_command: brew install watchexec
+
+category: Dev Tools
+tags: [file-watcher, cli, rust, developer-tools, productivity, rebuild]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Language-specific watchers (nodemon, cargo-watch) do not cover mixed ML repos with
+  Python, Rust, and configs. watchexec watches a directory and re-runs any command on
+  change, with ignore files, filters, and debounce. Training scripts, codegen, and local
+  servers restart from one tool instead of a pile of per-language watchers.
+
+use_cases:
+  - Rerun pytest or ruff when Python training or eval code changes
+  - Rebuild native extensions or restart a local inference server on file save
+  - Watch prompt templates and YAML catalogs and trigger validation on each edit


### PR DESCRIPTION
## Summary
Adds five developer and data-infrastructure tools:

- **OXC** (oxc-project/oxc, 22.6k★, MIT) — Rust JavaScript/TypeScript toolchain including oxlint
- **watchexec** (watchexec/watchexec, 7.2k★, Apache-2.0) — run a command on file changes
- **gitui** (extrawurst/gitui, 22.5k★, MIT) — fast terminal UI for Git
- **Jujutsu** (jj-vcs/jj, 31.3k★, Apache-2.0) — Git-compatible VCS with a simpler workflow
- **DataFusion** (apache/datafusion, 9.3k★, Apache-2.0) — embeddable Arrow-native SQL query engine

All entries validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for DataFusion, GitUI, Jujutsu, OXC, and Watchexec.
  * Included descriptions, installation details, links, licensing, categories, tags, and practical use cases for each tool.
  * Added guidance covering SQL analytics, Git workflows, JavaScript tooling, file watching, and remote development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->