### PR TITLE
Add KEDA, SQLMesh, Pandera, Hono to catalog

### DIFF
--- a/tools/data/pandera.yaml
+++ b/tools/data/pandera.yaml
@@ -1,0 +1,25 @@
+name: Pandera
+description: A statistical data-testing library for pandas, Polars, Spark, and other DataFrame APIs. You declare schemas and checks, then validate training tables at runtime so silent type and distribution bugs fail before they reach a model.
+tagline: Statistical typing and validation for DataFrames
+
+github_url: https://github.com/unionai-oss/pandera
+website_url: https://www.union.ai/pandera
+docs_url: https://pandera.readthedocs.io
+install_command: pip install pandera
+
+category: Data
+tags: [pandas, validation, schema, data-quality, python, dataframes, data]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Training jobs often fail late or silently when a column type, null rate, or category
+  set drifts. Pandera lets you declare DataFrame schemas with statistical checks and
+  run them in pandas, Polars, or Spark pipelines. Bad batches raise before they poison
+  a feature store or a fit.
+
+use_cases:
+  - Validate pandas or Polars training tables against a schema before model fit
+  - Catch null spikes and category drift in feature-engineering pipelines
+  - Share DataFrame contracts between data engineering and ML training code

--- a/tools/data/sqlmesh.yaml
+++ b/tools/data/sqlmesh.yaml
@@ -1,0 +1,25 @@
+name: SQLMesh
+description: A data transformation framework that is backwards compatible with dbt. It adds virtual environments, table diffs, and incremental models so warehouse pipelines that feed ML features can be developed and promoted without rebuilding production tables.
+tagline: Scalable data transformations, compatible with dbt
+
+github_url: https://github.com/TobikoData/sqlmesh
+website_url: https://sqlmesh.readthedocs.io/en/stable/
+docs_url: https://sqlmesh.readthedocs.io/en/stable/
+install_command: pip install sqlmesh
+
+category: Data
+tags: [sql, dbt, data-transformation, warehouse, python, analytics, data]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  dbt projects often rebuild or mis-increment production tables when a model change is
+  tested. SQLMesh plans changes against virtual environments, diffs tables, and applies
+  incremental updates so feature pipelines can be validated before they touch prod.
+  Existing dbt models can be imported instead of rewritten.
+
+use_cases:
+  - Develop warehouse models for ML features in isolated virtual environments
+  - Diff table changes before promoting a transformation to production
+  - Run incremental SQL models that stay compatible with existing dbt projects

--- a/tools/dev-tools/hono.yaml
+++ b/tools/dev-tools/hono.yaml
@@ -1,0 +1,25 @@
+name: Hono
+description: A small web framework built on Web Standards that runs on Cloudflare Workers, Deno, Bun, Node.js, and more. It is used to serve lightweight AI API gateways and edge inference wrappers without locking into a single JavaScript runtime.
+tagline: Web framework built on Web Standards
+
+github_url: https://github.com/honojs/hono
+website_url: https://hono.dev
+docs_url: https://hono.dev/docs/
+install_command: npm install hono
+
+category: Dev Tools
+tags: [javascript, typescript, web-framework, edge, cloudflare, bun, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Express and Next.js API routes are heavy or Node-only when you want an edge LLM
+  proxy. Hono uses standard Request/Response APIs and deploys to Workers, Deno, Bun,
+  and Node with the same code. Teams ship token-thin AI gateways and webhook receivers
+  at the edge without a runtime-specific framework.
+
+use_cases:
+  - Serve an edge LLM proxy or embedding API on Cloudflare Workers
+  - Share one TypeScript HTTP app across Node, Bun, and Deno
+  - Build lightweight webhook and agent-tool HTTP endpoints with typed middleware

--- a/tools/dev-tools/keda.yaml
+++ b/tools/dev-tools/keda.yaml
@@ -1,0 +1,24 @@
+name: KEDA
+description: Kubernetes Event-driven Autoscaling. It scales Deployments, Jobs, and custom resources from event sources such as Kafka, Redis, Prometheus, and cloud queues, including scale-to-zero for idle inference workers.
+tagline: Event-driven autoscaling for Kubernetes workloads
+
+github_url: https://github.com/kedacore/keda
+website_url: https://keda.sh
+docs_url: https://keda.sh/docs/
+
+category: Dev Tools
+tags: [kubernetes, autoscaling, events, kafka, redis, inference, developer-tools]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  HPA scales on CPU and memory, which is a poor signal for queue-backed ML workers.
+  KEDA adds event-driven scalers so Kafka lag, Redis list length, or Prometheus metrics
+  drive replica counts, including scale to zero when the queue is empty. Inference
+  consumers and embedding workers then cost nothing while idle and catch up when events arrive.
+
+use_cases:
+  - Scale Kafka or Redis consumers that run embedding and feature-compute jobs
+  - Scale GPU inference Deployments to zero when request queues are empty
+  - Drive Kubernetes Jobs from cloud queue depth for batch scoring pipelines


### PR DESCRIPTION
## Summary
Adds four remaining tools from the replenishment batch:

- **KEDA** (kedacore/keda, 10.5k★, Apache-2.0) — event-driven autoscaling for Kubernetes
- **SQLMesh** (TobikoData/sqlmesh, 3.3k★, Apache-2.0) — data transformation framework compatible with dbt
- **Pandera** (unionai-oss/pandera, 4.4k★, MIT) — statistical DataFrame validation
- **Hono** (honojs/hono, 32.1k★, MIT) — Web Standards HTTP framework for edge and Node

All entries validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Pandera, SQLMesh, Hono, and KEDA.
  * Included descriptions, tags, licensing and pricing details, links, installation commands, problem statements, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->