### PR TITLE
Add Axum, Fairlearn, FastHTML, HTMX, Fastify to catalog

### DIFF
--- a/tools/data/fairlearn.yaml
+++ b/tools/data/fairlearn.yaml
@@ -1,0 +1,25 @@
+name: Fairlearn
+description: A Python library to assess and mitigate fairness issues in machine learning models. It measures group disparities, applies mitigation algorithms, and reports fairness metrics so production ML systems can be audited before they harm users.
+tagline: Assess and mitigate ML fairness issues
+
+github_url: https://github.com/fairlearn/fairlearn
+website_url: https://fairlearn.org
+docs_url: https://fairlearn.org/main/user_guide/
+install_command: pip install fairlearn
+
+category: Data
+tags: [python, fairness, responsible-ai, metrics, mitigation, machine-learning]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Production models can treat groups differently even when accuracy looks
+  fine. Fairlearn measures disparity with group fairness metrics, applies
+  mitigation algorithms at train or post-process time, and produces reports
+  so teams can audit models before they ship harmful decisions.
+
+use_cases:
+  - Measure group fairness metrics on a classification or ranking model
+  - Apply reduction or post-processing mitigations to reduce disparity
+  - Generate fairness reports for model review and compliance workflows

--- a/tools/dev-tools/axum.yaml
+++ b/tools/dev-tools/axum.yaml
@@ -1,0 +1,25 @@
+name: Axum
+description: HTTP routing and request-handling library for Rust built on Tokio and Tower. Teams use it to serve LLM APIs, embedding endpoints, and agent webhooks as typed, modular Rust services without a heavyweight framework.
+tagline: Ergonomic Rust web framework for typed HTTP APIs
+
+github_url: https://github.com/tokio-rs/axum
+website_url: https://github.com/tokio-rs/axum
+docs_url: https://docs.rs/axum
+install_command: cargo add axum
+
+category: Dev Tools
+tags: [rust, web-framework, tokio, tower, http, api, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Serving LLM inference, embeddings, and agent webhooks in Rust often means
+  assembling Tokio, hyper, and Tower by hand. Axum sits on that stack with
+  extractors, typed routing, and middleware so teams ship production HTTP
+  services without a heavyweight framework or untyped request handling.
+
+use_cases:
+  - Serve a typed Rust LLM or embedding HTTP API on Tokio
+  - Expose agent webhook and tool-calling endpoints with Tower middleware
+  - Build low-latency inference gateways that share extractors and routers

--- a/tools/dev-tools/fasthtml.yaml
+++ b/tools/dev-tools/fasthtml.yaml
@@ -1,0 +1,25 @@
+name: FastHTML
+description: Python web framework that maps HTML and HTTP 1:1 with HTMX interactivity built in. Build AI dashboards, chat UIs, and internal tools as compact Python without a separate JavaScript frontend stack.
+tagline: Fastest way to create an HTML app in Python
+
+github_url: https://github.com/AnswerDotAI/fasthtml
+website_url: https://www.fastht.ml/docs/
+docs_url: https://www.fastht.ml/docs/
+install_command: pip install python-fasthtml
+
+category: Dev Tools
+tags: [python, web-framework, htmx, html, dashboards, developer-tools]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Python AI teams often split a FastAPI backend from a React frontend just
+  to ship a chat UI or eval dashboard. FastHTML renders HTML in Python and
+  uses HTMX for partial updates, so interactive tools stay one Python app
+  without a separate JavaScript stack.
+
+use_cases:
+  - Build an LLM chat or eval dashboard entirely in Python
+  - Ship internal AI tools with HTMX partials instead of a SPA
+  - Prototype HTML UIs that call models without a frontend framework

--- a/tools/dev-tools/fastify.yaml
+++ b/tools/dev-tools/fastify.yaml
@@ -1,0 +1,25 @@
+name: Fastify
+description: Fast, low-overhead Node.js web framework with a plugin architecture and JSON schema validation. Used to serve LLM APIs, embedding gateways, and agent webhooks with lower latency than Express.
+tagline: Fast and low overhead web framework for Node.js
+
+github_url: https://github.com/fastify/fastify
+website_url: https://www.fastify.dev
+docs_url: https://fastify.dev/docs/latest/
+install_command: npm install fastify
+
+category: Dev Tools
+tags: [javascript, typescript, nodejs, web-framework, api, plugins, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Express is easy but slow and loosely typed for high-QPS LLM gateways.
+  Fastify adds schema-based validation, a plugin system, and lower overhead
+  so Node teams serve inference APIs, embedding endpoints, and agent
+  webhooks with better latency and safer request handling.
+
+use_cases:
+  - Serve a Node.js LLM or embedding HTTP API with JSON schema validation
+  - Build an agent webhook gateway with Fastify plugins and hooks
+  - Replace Express on high-QPS inference proxies to cut overhead

--- a/tools/dev-tools/htmx.yaml
+++ b/tools/dev-tools/htmx.yaml
@@ -1,0 +1,25 @@
+name: HTMX
+description: HTML-first library that adds AJAX, WebSockets, and SSE via attributes so pages update without writing JavaScript. AI teams use it for chat UIs, streaming token output, and internal tools that stay simple HTML.
+tagline: High power tools for HTML
+
+github_url: https://github.com/bigskysoftware/htmx
+website_url: https://htmx.org
+docs_url: https://htmx.org/docs/
+install_command: npm install htmx.org
+
+category: Dev Tools
+tags: [javascript, html, ajax, sse, websockets, hypermedia, developer-tools]
+pricing: free
+is_open_source: true
+license: 0BSD
+
+problem_solved: |
+  Interactive AI UIs often require a full JavaScript SPA just to swap HTML
+  after a model call or stream tokens. HTMX adds AJAX, SSE, and WebSockets
+  as HTML attributes so chat boxes, dashboards, and internal tools update
+  in place without a frontend framework.
+
+use_cases:
+  - Stream LLM tokens into a page with Server-Sent Events attributes
+  - Swap chat or search results with HTML partials instead of a SPA
+  - Add WebSocket updates to internal AI tools without custom JS


### PR DESCRIPTION
## Add Axum, Fairlearn, FastHTML, HTMX, Fastify to catalog

Five catalog entries for web frameworks and ML fairness tooling used in AI stacks.

- **Axum** (Dev Tools) — Rust HTTP framework on Tokio/Tower for typed LLM APIs
- **Fairlearn** (Data) — Python library to measure and mitigate ML fairness issues
- **FastHTML** (Dev Tools) — Python HTML/HTMX framework for AI dashboards without a JS SPA
- **HTMX** (Dev Tools) — HTML-first AJAX/SSE/WebSocket attributes for chat UIs
- **Fastify** (Dev Tools) — Low-overhead Node.js framework for LLM gateways

Local validation passed (`npx tsx scripts/validate-tool.ts`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Fairlearn, Axum, FastHTML, Fastify, and HTMX.
  * Included descriptions, documentation links, installation instructions, licensing details, classifications, and practical use cases for each tool.
  * Expanded discoverability of tools supporting machine learning fairness, web development, APIs, streaming, and real-time applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->