### PR TITLE
Add Actix Web, NestJS, Express, PageIndex, RAPTOR to catalog

### DIFF
--- a/tools/dev-tools/actix-web.yaml
+++ b/tools/dev-tools/actix-web.yaml
@@ -1,0 +1,25 @@
+name: Actix Web
+description: Powerful, pragmatic, and extremely fast web framework for Rust. Teams use it to serve LLM APIs, embedding endpoints, and agent webhooks as high-throughput Rust services.
+tagline: Fast web framework for Rust
+
+github_url: https://github.com/actix/actix-web
+website_url: https://actix.rs
+docs_url: https://actix.rs/docs/
+install_command: cargo add actix-web
+
+category: Dev Tools
+tags: [rust, web-framework, async, http, api, developer-tools]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  High-QPS LLM gateways and agent webhooks in Rust need a battle-tested HTTP
+  layer, not a from-scratch Tokio server. Actix Web provides routing, extractors,
+  and middleware so teams ship fast inference APIs without assembling the stack
+  by hand.
+
+use_cases:
+  - Serve a high-throughput Rust LLM or embedding HTTP API
+  - Expose agent webhook endpoints with Actix extractors and middleware
+  - Build low-latency inference gateways that share actors and workers

--- a/tools/dev-tools/express.yaml
+++ b/tools/dev-tools/express.yaml
@@ -1,0 +1,25 @@
+name: Express
+description: Fast, unopinionated, minimalist web framework for Node.js. The default HTTP layer for countless LLM proxies, embedding APIs, and agent webhook servers.
+tagline: Fast, unopinionated, minimalist Node.js web framework
+
+github_url: https://github.com/expressjs/express
+website_url: https://expressjs.com
+docs_url: https://expressjs.com/en/guide/routing.html
+install_command: npm install express
+
+category: Dev Tools
+tags: [javascript, nodejs, web-framework, http, api, middleware, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Node teams need a tiny HTTP layer to wrap OpenAI calls, embeddings, and
+  agent webhooks without a full application framework. Express is the
+  default middleware stack for those services, with routing and plugins
+  that every Node engineer already knows.
+
+use_cases:
+  - Wrap an LLM or embedding client behind a Node.js HTTP API
+  - Receive agent webhooks and tool callbacks with Express middleware
+  - Prototype model-serving endpoints before moving to a heavier framework

--- a/tools/dev-tools/nestjs.yaml
+++ b/tools/dev-tools/nestjs.yaml
@@ -1,0 +1,25 @@
+name: NestJS
+description: Progressive Node.js framework for building scalable TypeScript server applications with modules, dependency injection, and decorators. Used to structure LLM APIs, agent backends, and enterprise AI services.
+tagline: Progressive Node.js framework for TypeScript APIs
+
+github_url: https://github.com/nestjs/nest
+website_url: https://nestjs.com
+docs_url: https://docs.nestjs.com
+install_command: npm install @nestjs/core @nestjs/common
+
+category: Dev Tools
+tags: [typescript, nodejs, web-framework, dependency-injection, api, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Express apps grow into untyped, unstructured backends as AI products add
+  auth, queues, and model clients. NestJS gives TypeScript modules, DI, and
+  decorators so LLM APIs and agent services stay organized as they scale
+  into enterprise backends.
+
+use_cases:
+  - Structure a TypeScript LLM API with modules and dependency injection
+  - Build an enterprise agent backend with guards, pipes, and providers
+  - Wrap model clients and tool handlers as injectable NestJS services

--- a/tools/rag/pageindex.yaml
+++ b/tools/rag/pageindex.yaml
@@ -1,0 +1,25 @@
+name: PageIndex
+description: Vectorless, reasoning-based document index that builds a tree of pages for RAG instead of chunk embeddings. Retrieve by reasoning over document structure rather than nearest-neighbor search.
+tagline: Vectorless reasoning-based document index for RAG
+
+github_url: https://github.com/VectifyAI/PageIndex
+website_url: https://pageindex.ai
+docs_url: https://docs.pageindex.ai
+install_command: pip install pageindex
+
+category: RAG
+tags: [python, rag, retrieval, documents, vectorless, reasoning, pdf]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Chunk-and-embed RAG loses document hierarchy and fails on long PDFs when
+  similarity search cannot follow section structure. PageIndex builds a page
+  tree and retrieves by reasoning over that tree, so answers cite the right
+  section without a vector database.
+
+use_cases:
+  - Index long PDFs as a page tree for reasoning-based retrieval
+  - Run vectorless RAG locally with your own LLM key
+  - Chat over document structure instead of nearest-neighbor chunks

--- a/tools/rag/raptor.yaml
+++ b/tools/rag/raptor.yaml
@@ -1,0 +1,24 @@
+name: RAPTOR
+description: Recursive abstractive processing for tree-organized retrieval. Clusters document chunks, summarizes them into a tree, and retrieves at multiple levels of abstraction for long-document RAG.
+tagline: Tree-organized retrieval with recursive summaries
+
+github_url: https://github.com/parthsarthi03/raptor
+website_url: https://arxiv.org/abs/2401.18059
+docs_url: https://github.com/parthsarthi03/raptor
+
+category: RAG
+tags: [python, rag, retrieval, summarization, tree, long-context, research]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Flat chunk retrieval misses high-level themes in long documents because
+  embeddings only see local passages. RAPTOR clusters chunks, summarizes
+  them recursively into a tree, and retrieves at multiple levels so RAG
+  can answer both detail and overview questions.
+
+use_cases:
+  - Build a summary tree over long documents for multi-level RAG
+  - Retrieve both fine-grained chunks and high-level abstracts
+  - Improve long-document QA where flat vector search loses theme


### PR DESCRIPTION
## Add Actix Web, NestJS, Express, PageIndex, RAPTOR to catalog

Five catalog entries for web frameworks and RAG retrieval methods.

- **Actix Web** (Dev Tools) — Fast Rust HTTP framework for LLM APIs
- **NestJS** (Dev Tools) — TypeScript Node.js framework for structured AI backends
- **Express** (Dev Tools) — Minimal Node.js HTTP layer for LLM proxies
- **PageIndex** (RAG) — Vectorless, reasoning-based page-tree document index
- **RAPTOR** (RAG) — Recursive summary trees for multi-level long-document retrieval

Local validation passed (`npx tsx scripts/validate-tool.ts`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Actix Web, Express, and NestJS to the developer-tools catalog, including installation details, documentation links, licensing, and AI-focused use cases.
  - Added PageIndex and RAPTOR to the RAG tools catalog, with descriptions of their long-document retrieval approaches, resources, licensing, and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->