### PR TITLE
Add FlashRank, OrientDB, HugeGraph, TurboPuffer, TigerGraph to catalog

### DIFF
--- a/tools/rag/flashrank.yaml
+++ b/tools/rag/flashrank.yaml
@@ -1,0 +1,25 @@
+name: FlashRank
+description: Ultra-lite, fast reranker for search and RAG pipelines. Runs SoTA listwise and pairwise reranking with LLMs and cross-encoders so retrieval stacks can reorder results without a heavy GPU service.
+tagline: Lite, super-fast reranking for search and RAG
+
+github_url: https://github.com/PrithivirajDamodaran/FlashRank
+website_url: https://github.com/PrithivirajDamodaran/FlashRank
+docs_url: https://github.com/PrithivirajDamodaran/FlashRank
+install_command: pip install FlashRank
+
+category: RAG
+tags: [python, rag, reranking, retrieval, cross-encoder, search]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  First-stage vector search returns noisy chunks that hurt RAG answer quality.
+  Heavy reranker services add GPU cost and latency. FlashRank runs SoTA
+  pairwise and listwise rerankers in a tiny Python package so pipelines can
+  reorder hits without standing up a separate model server.
+
+use_cases:
+  - Rerank vector search hits before feeding chunks to an LLM
+  - Add listwise or pairwise reranking to a RAG pipeline in a few lines
+  - Swap a GPU rerank service for a lite in-process cross-encoder

--- a/tools/vector-databases/hugegraph.yaml
+++ b/tools/vector-databases/hugegraph.yaml
@@ -1,0 +1,24 @@
+name: HugeGraph
+description: Apache graph database for hundred-billion-scale graphs with Gremlin, REST APIs, and GraphRAG tooling. OLTP plus OLAP backends for knowledge graphs, recommendations, and LLM-backed Q&A.
+tagline: Apache graph database for GraphRAG at scale
+
+github_url: https://github.com/apache/hugegraph
+website_url: https://hugegraph.apache.org
+docs_url: https://hugegraph.apache.org/docs/
+
+category: Vector DB
+tags: [java, graph, gremlin, knowledge-graph, graphrag, apache, oltp]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building GraphRAG and knowledge-graph apps at large scale needs a graph
+  store that speaks Gremlin, scales past a single machine, and plugs into
+  LLM pipelines. HugeGraph is an Apache graph database with OLTP, OLAP,
+  and HugeGraph-AI so teams query connected data without a closed stack.
+
+use_cases:
+  - Run GraphRAG over an enterprise knowledge graph with Gremlin and REST
+  - Store hundred-billion-edge graphs for recommendations and fraud detection
+  - Combine LLM Q&A with graph algorithms on Apache HugeGraph

--- a/tools/vector-databases/orientdb.yaml
+++ b/tools/vector-databases/orientdb.yaml
@@ -1,0 +1,24 @@
+name: OrientDB
+description: Multi-model DBMS for graph, document, full-text, and geospatial data with SQL and ACID transactions. Used as a knowledge-graph and document store behind RAG and agent memory.
+tagline: Multi-model graph and document DBMS
+
+github_url: https://github.com/orientechnologies/orientdb
+website_url: https://orientdb.dev
+docs_url: https://orientdb.org/docs
+
+category: Vector DB
+tags: [java, graph, document, multi-model, sql, knowledge-graph]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Teams that need graph relationships and document records together often
+  run two databases. OrientDB combines graph, document, full-text, and
+  geospatial models with SQL and ACID transactions, so knowledge graphs
+  and agent memory can live in one multi-model store.
+
+use_cases:
+  - Store knowledge graphs and documents in one multi-model DBMS
+  - Query connected entities with SQL for RAG context assembly
+  - Run distributed graph data behind agent memory and retrieval

--- a/tools/vector-databases/tigergraph.yaml
+++ b/tools/vector-databases/tigergraph.yaml
@@ -1,0 +1,22 @@
+name: TigerGraph
+description: Enterprise graph database for real-time multi-hop reasoning over billions of relationships. Used for GraphRAG, fraud detection, and agent context where AI decisions need connected, auditable evidence.
+tagline: Relationship intelligence for enterprise GraphRAG
+
+website_url: https://www.tigergraph.com
+docs_url: https://docs.tigergraph.com
+
+category: Vector DB
+tags: [graph, graphrag, enterprise, knowledge-graph, fraud, analytics]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Vector RAG retrieves documents but cannot explain multi-hop relationships
+  across people, accounts, and events. TigerGraph is an enterprise graph
+  database for real-time traversals over billions of edges so GraphRAG and
+  agents can reason on connected evidence instead of isolated chunks.
+
+use_cases:
+  - Ground GraphRAG answers in multi-hop enterprise relationship evidence
+  - Detect fraud rings across accounts, devices, and transactions in real time
+  - Give agents customer-360 and supply-chain context from a live graph

--- a/tools/vector-databases/turbopuffer.yaml
+++ b/tools/vector-databases/turbopuffer.yaml
@@ -1,0 +1,24 @@
+name: TurboPuffer
+description: Object-storage vector and full-text search database for billion-scale embeddings. Built for cheap, fast hybrid search so RAG and semantic retrieval can scale without a memory-resident index.
+tagline: Vector and full-text search on object storage
+
+github_url: https://github.com/turbopuffer/turbopuffer-python
+website_url: https://turbopuffer.com
+docs_url: https://turbopuffer.com/docs
+install_command: pip install turbopuffer
+
+category: Vector DB
+tags: [vector-database, embeddings, hybrid-search, rag, object-storage, python]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  In-memory vector indexes get expensive as corpora grow to billions of
+  embeddings. TurboPuffer stores vectors and full-text indexes on object
+  storage so semantic search, hybrid retrieval, and RAG can scale with
+  lower cost than memory-first vector databases.
+
+use_cases:
+  - Run billion-scale embedding search for RAG without a huge RAM cluster
+  - Combine vector and full-text search with metadata filters
+  - Back semantic search and recommendations on object storage


### PR DESCRIPTION
## Add FlashRank, OrientDB, HugeGraph, TurboPuffer, TigerGraph to catalog

Five catalog entries for RAG reranking and graph/vector stores.

| Tool | Category | Notes |
|---|---|---|
| FlashRank | RAG | Lite Python reranker (Apache-2.0, ~1k stars) |
| OrientDB | Vector DB | Multi-model graph/document DBMS (Apache-2.0, ~5k stars) |
| HugeGraph | Vector DB | Apache graph database with GraphRAG tooling (~3k stars) |
| TurboPuffer | Vector DB | Object-storage vector + full-text search (SaaS) |
| TigerGraph | Vector DB | Enterprise graph DB for GraphRAG and multi-hop reasoning |

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FlashRank to the tool catalog, highlighting its open-source reranking capabilities for search and RAG workflows.
  * Added HugeGraph, OrientDB, TigerGraph, and TurboPuffer to the vector database catalog.
  * Included product descriptions, links, pricing, licensing, categories, tags, and practical use cases for each listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->