### PR TITLE
Add Byaldi, ArcadeDB, Oxigraph to catalog

### DIFF
--- a/tools/rag/byaldi.yaml
+++ b/tools/rag/byaldi.yaml
@@ -1,0 +1,25 @@
+name: Byaldi
+description: Thin Python wrapper that lets you use late-interaction multimodal models such as ColPali in a few lines. Index PDFs and images for visual RAG without assembling a ColPali serving stack.
+tagline: Late-interaction multimodal RAG in a few lines
+
+github_url: https://github.com/AnswerDotAI/byaldi
+website_url: https://github.com/AnswerDotAI/byaldi
+docs_url: https://github.com/AnswerDotAI/byaldi
+install_command: pip install byaldi
+
+category: RAG
+tags: [python, rag, colpali, multimodal, pdf, visual-retrieval]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  ColPali-style visual RAG is powerful but wiring model loading, indexing,
+  and search is tedious. Byaldi wraps late-interaction multimodal models so
+  you can index PDFs and images and retrieve by screenshot or page without
+  assembling a custom ColPali stack.
+
+use_cases:
+  - Index PDFs with ColPali for visual, page-level RAG
+  - Search document screenshots without OCR-first chunking
+  - Prototype multimodal retrieval with a few lines of Python

--- a/tools/vector-databases/arcadedb.yaml
+++ b/tools/vector-databases/arcadedb.yaml
@@ -1,0 +1,24 @@
+name: ArcadeDB
+description: Multi-model database that speaks SQL, Cypher, Gremlin, MongoDB, and Redis protocols and stores vector embeddings. One engine for graph, document, and vector data in AI pipelines.
+tagline: Multi-model DBMS with vector embeddings
+
+github_url: https://github.com/ArcadeData/arcadedb
+website_url: https://arcadedb.com
+docs_url: https://docs.arcadedb.com
+
+category: Vector DB
+tags: [java, graph, document, vector, multi-model, cypher, embeddings]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI pipelines often juggle a graph store, a document DB, and a vector index.
+  ArcadeDB is a multi-model engine with SQL, Cypher, Gremlin, and vector
+  embeddings in one DBMS, so knowledge graphs and retrieval can share a
+  single source of truth.
+
+use_cases:
+  - Store graph, document, and vector embeddings in one database
+  - Query knowledge graphs with Cypher or Gremlin beside vector search
+  - Back RAG and agent memory without a separate vector-only store

--- a/tools/vector-databases/oxigraph.yaml
+++ b/tools/vector-databases/oxigraph.yaml
@@ -1,0 +1,25 @@
+name: Oxigraph
+description: SPARQL graph database and RDF toolkit written in Rust. Store knowledge graphs, run SPARQL queries, and serve RDF over HTTP for GraphRAG and linked-data pipelines.
+tagline: Rust SPARQL graph database for RDF
+
+github_url: https://github.com/oxigraph/oxigraph
+website_url: https://github.com/oxigraph/oxigraph
+docs_url: https://docs.rs/oxigraph
+install_command: pip install oxigraph
+
+category: Vector DB
+tags: [rust, sparql, rdf, graph, knowledge-graph, graphrag]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  GraphRAG and knowledge-graph pipelines need a SPARQL store that is small
+  enough to embed or run locally. Oxigraph is a Rust RDF database with a
+  SPARQL HTTP server and Python bindings, so teams query linked data without
+  standing up a heavyweight triple store.
+
+use_cases:
+  - Serve SPARQL over HTTP for GraphRAG knowledge graphs
+  - Store RDF triples and query them from Python with pyoxigraph
+  - Embed a local SPARQL database in an agent or RAG pipeline


### PR DESCRIPTION
## Add Byaldi, ArcadeDB, Oxigraph to catalog

Leftover validated YAML from a prior aborted catalog run.

| Tool | Category | Notes |
|---|---|---|
| Byaldi | RAG | ColPali late-interaction multimodal RAG wrapper (Apache-2.0) |
| ArcadeDB | Vector DB | Multi-model DBMS with vector embeddings (Apache-2.0) |
| Oxigraph | Vector DB | Rust SPARQL graph database for RDF / GraphRAG (Apache-2.0) |

Local validation passed for all three YAML files.
