### PR TITLE
Add verl, Levanter, MiniMind, RouteLLM, SambaNova to catalog

### DIFF
--- a/tools/fine-tuning/levanter.yaml
+++ b/tools/fine-tuning/levanter.yaml
@@ -1,0 +1,25 @@
+name: Levanter
+description: JAX framework for training LLMs and foundation models with named tensors. Built for legible, scalable, bitwise-reproducible training on GPUs and TPUs, with Hugging Face import and export.
+tagline: Legible, scalable JAX training for foundation models
+
+github_url: https://github.com/marin-community/levanter
+website_url: https://levanter.readthedocs.io/en/latest/
+docs_url: https://levanter.readthedocs.io/en/latest/
+install_command: pip install levanter
+
+category: Fine-tuning
+tags: [python, jax, llm, tpu, gpu, training, named-tensors]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Large-scale JAX training code is hard to read and easy to make
+  non-reproducible after preemption. Levanter uses named tensors for
+  legible model code, distributed FSDP/tensor parallel training, and
+  bitwise-deterministic resumes so foundation-model runs stay reproducible.
+
+use_cases:
+  - Train or fine-tune an LLM on TPUs or GPUs with JAX
+  - Import and export Hugging Face checkpoints during JAX training
+  - Resume preempted foundation-model jobs with deterministic checkpoints

--- a/tools/fine-tuning/minimind.yaml
+++ b/tools/fine-tuning/minimind.yaml
@@ -1,0 +1,24 @@
+name: MiniMind
+description: Train a 26M to 104M parameter GPT-style LLM from scratch in about two hours. A full small-model pipeline for tokenizer, pretrain, SFT, and RLHF so you can learn LLM training without a giant cluster.
+tagline: Train a tiny LLM from scratch in about two hours
+
+github_url: https://github.com/jingyaogong/minimind
+website_url: https://jingyaogong.github.io/minimind
+docs_url: https://github.com/jingyaogong/minimind
+
+category: Fine-tuning
+tags: [python, llm, training, sft, rlhf, from-scratch, education]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Learning LLM training usually means reading papers or renting a huge
+  GPU cluster. MiniMind is a complete from-scratch pipeline for a 26M-104M
+  GPT-style model, covering tokenizer, pretrain, SFT, and RLHF so builders
+  can train a real LLM on a single GPU in about two hours.
+
+use_cases:
+  - Train a tiny GPT-style LLM from scratch for learning and demos
+  - Run SFT and RLHF on a small open model without a large cluster
+  - Prototype tokenizer, pretrain, and alignment steps on one GPU

--- a/tools/fine-tuning/verl.yaml
+++ b/tools/fine-tuning/verl.yaml
@@ -1,0 +1,25 @@
+name: verl
+description: Flexible RL post-training framework for LLMs (HybridFlow). Run PPO, GRPO, and related recipes at scale with vLLM or SGLang rollouts so teams can align models without a custom RL stack.
+tagline: RL post-training framework for LLMs
+
+github_url: https://github.com/verl-project/verl
+website_url: https://verl-project.github.io
+docs_url: https://verl.readthedocs.io
+install_command: pip install verl
+
+category: Fine-tuning
+tags: [python, rlhf, ppo, grpo, post-training, llm, vllm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  RL post-training for LLMs usually means stitching trainers, rollouts, and
+  GPU schedulers by hand. verl (HybridFlow) is a flexible RL framework with
+  production recipes for PPO, GRPO, and more, so teams align models at scale
+  without building a custom RL infrastructure.
+
+use_cases:
+  - Run PPO or GRPO post-training on an open LLM with vLLM rollouts
+  - Scale RLHF jobs across GPUs without a custom trainer
+  - Reproduce HybridFlow recipes for alignment and reasoning models

--- a/tools/llm/routellm.yaml
+++ b/tools/llm/routellm.yaml
@@ -1,0 +1,25 @@
+name: RouteLLM
+description: Framework for serving and evaluating LLM routers so cheaper models handle easy prompts and stronger models handle hard ones. Cut inference cost without a large drop in response quality.
+tagline: Route prompts to the right LLM to cut cost
+
+github_url: https://github.com/lm-sys/RouteLLM
+website_url: https://github.com/lm-sys/RouteLLM
+docs_url: https://github.com/lm-sys/RouteLLM
+install_command: pip install routellm
+
+category: LLM
+tags: [python, llm, routing, cost, inference, serving]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Sending every prompt to the strongest model wastes money on easy tasks.
+  RouteLLM serves and evaluates routers that send simple queries to cheaper
+  models and hard ones to frontier models, so teams cut LLM spend without
+  a large quality drop.
+
+use_cases:
+  - Route chat traffic between a cheap model and a frontier model
+  - Evaluate LLM routers on quality versus cost before production
+  - Serve a router in front of multiple OpenAI-compatible endpoints

--- a/tools/llm/sambanova.yaml
+++ b/tools/llm/sambanova.yaml
@@ -1,0 +1,23 @@
+name: SambaNova
+description: Premium LLM inference platform on reconfigurable dataflow hardware. OpenAI-compatible APIs and on-prem SambaRack systems for high-throughput serving of large models and agentic workloads.
+tagline: Fast LLM inference on dataflow hardware
+
+website_url: https://sambanova.ai
+docs_url: https://docs.sambanova.ai
+install_command: pip install sambanova
+
+category: LLM
+tags: [llm, inference, enterprise, openai-compatible, on-prem, serving]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Serving frontier-scale models with high tokens-per-watt is hard on
+  generic GPU clusters. SambaNova is an inference platform on reconfigurable
+  dataflow units with OpenAI-compatible APIs and on-prem racks, so teams
+  run large models and agent stacks at high throughput.
+
+use_cases:
+  - Serve large open models through an OpenAI-compatible inference API
+  - Deploy on-prem LLM inference for sovereign or regulated workloads
+  - Run multi-model agent workflows on SambaStack without GPU sprawl


### PR DESCRIPTION
## Add verl, Levanter, MiniMind, RouteLLM, SambaNova to catalog

Five catalog entries for LLM training, routing, and inference.

| Tool | Category | Notes |
|---|---|---|
| verl | Fine-tuning | RL post-training (HybridFlow), Apache-2.0, ~23k stars |
| Levanter | Fine-tuning | JAX foundation-model trainer, Apache-2.0 |
| MiniMind | Fine-tuning | Train a tiny LLM from scratch, Apache-2.0, ~57k stars |
| RouteLLM | LLM | LLM routers to cut inference cost, Apache-2.0, ~5k stars |
| SambaNova | LLM | Premium inference platform (SaaS / on-prem) |

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Tools**
  - Added Levanter for reproducible distributed JAX fine-tuning, checkpointing, and training workflows.
  - Added MiniMind for training compact GPT-style language models from scratch.
  - Added verl for reinforcement-learning post-training, including PPO, GRPO, and RLHF workflows.
  - Added RouteLLM for intelligent LLM routing.
  - Added SambaNova for hosted and on-premises LLM inference, OpenAI-compatible serving, and multi-model agent workflows.
  - Each listing includes descriptions, links, licensing, pricing, installation details, and representative use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->