### PR TITLE
Add AI21, Moondream, Apache Jena, RDFLib, ScrapeGraphAI to catalog

### DIFF
--- a/tools/data/apache-jena.yaml
+++ b/tools/data/apache-jena.yaml
@@ -1,0 +1,24 @@
+name: Apache Jena
+description: Java framework for RDF, SPARQL, and linked data. Build knowledge graphs, run SPARQL queries, and publish semantic data so GraphRAG and ontology pipelines have a standard Semantic Web stack.
+tagline: RDF and SPARQL framework for knowledge graphs
+
+github_url: https://github.com/apache/jena
+website_url: https://jena.apache.org
+docs_url: https://jena.apache.org/documentation/
+
+category: Data
+tags: [java, rdf, sparql, knowledge-graph, linked-data, apache]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  GraphRAG and ontology work need a standards-based RDF store and SPARQL
+  engine, not only a vector index. Apache Jena is a Java Semantic Web
+  framework for RDF, SPARQL, and linked data so knowledge graphs can be
+  queried and published without a proprietary triple store.
+
+use_cases:
+  - Store RDF triples and run SPARQL for GraphRAG context
+  - Publish linked-data APIs from enterprise ontologies
+  - Build Java knowledge-graph pipelines on Apache Jena Fuseki

--- a/tools/data/rdflib.yaml
+++ b/tools/data/rdflib.yaml
@@ -1,0 +1,25 @@
+name: RDFLib
+description: Python library for RDF graphs, SPARQL, and serializers such as Turtle and JSON-LD. Parse, query, and write linked data so Python RAG and knowledge-graph code can work with Semantic Web datasets.
+tagline: Python library for RDF and SPARQL
+
+github_url: https://github.com/RDFLib/rdflib
+website_url: https://rdflib.readthedocs.org
+docs_url: https://rdflib.readthedocs.org
+install_command: pip install rdflib
+
+category: Data
+tags: [python, rdf, sparql, knowledge-graph, linked-data, json-ld]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Python RAG and agent stacks often need to read ontologies and SPARQL
+  datasets, not only JSON. RDFLib is the standard Python library for RDF
+  graphs, SPARQL, and Turtle/JSON-LD so knowledge-graph code stays in
+  Python without a Java triple store.
+
+use_cases:
+  - Parse Turtle or JSON-LD and query it with SPARQL in Python
+  - Build a small knowledge graph for GraphRAG from RDF files
+  - Convert between RDF serializations in a data pipeline

--- a/tools/data/scrapegraphai.yaml
+++ b/tools/data/scrapegraphai.yaml
@@ -1,0 +1,25 @@
+name: ScrapeGraphAI
+description: Python scraper that uses LLMs to turn websites and documents into structured data. Describe the schema in natural language instead of writing brittle CSS selectors for every site.
+tagline: LLM-powered Python scraper for structured web data
+
+github_url: https://github.com/ScrapeGraphAI/Scrapegraph-ai
+website_url: https://scrapegraphai.com
+docs_url: https://docs.scrapegraphai.com
+install_command: pip install scrapegraphai
+
+category: Data
+tags: [python, scraping, llm, extraction, web, structured-data]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Traditional scrapers break when HTML changes and need a selector per
+  site. ScrapeGraphAI uses LLMs to extract structured data from pages and
+  documents from a natural-language schema, so pipelines collect training
+  and RAG content without brittle CSS.
+
+use_cases:
+  - Extract structured fields from websites with an LLM schema
+  - Scrape docs and articles into JSON for RAG corpora
+  - Replace selector-based scrapers for sites that change often

--- a/tools/llm/ai21.yaml
+++ b/tools/llm/ai21.yaml
@@ -1,0 +1,23 @@
+name: AI21
+description: LLM platform from AI21 Labs with Jamba models and an OpenAI-style API. Build RAG, agents, and production text apps on foundation models plus a Python SDK for chat, tools, and structured output.
+tagline: Jamba models and APIs for production LLM apps
+
+website_url: https://www.ai21.com
+docs_url: https://docs.ai21.com
+install_command: pip install ai21
+
+category: LLM
+tags: [llm, jamba, api, rag, python, enterprise]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Teams that want a production LLM API without locking to a single US lab
+  need models and an SDK for RAG and agents. AI21 provides Jamba models and
+  an OpenAI-style API with a Python SDK so chat, tools, and structured
+  output can ship without assembling a custom serving stack.
+
+use_cases:
+  - Call Jamba models from Python for chat and tool use
+  - Power RAG and document Q&A with AI21 APIs
+  - Generate structured output for enterprise text workflows

--- a/tools/llm/moondream.yaml
+++ b/tools/llm/moondream.yaml
@@ -1,0 +1,23 @@
+name: Moondream
+description: Tiny vision-language model for image captioning, visual Q&A, and on-device understanding. Open weights and a small footprint so you can add vision to agents without a giant multimodal API.
+tagline: Tiny vision-language model for on-device VQA
+
+github_url: https://github.com/m87-labs/moondream
+website_url: https://moondream.ai
+docs_url: https://moondream.ai/c/docs
+
+category: LLM
+tags: [python, vision, vlm, multimodal, on-device, open-weights]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Most vision-language models are too large for laptops and edge boxes.
+  Moondream is a tiny open VLM for captioning and visual Q&A, so agents and
+  apps can understand images locally without calling a giant multimodal API.
+
+use_cases:
+  - Caption images or answer visual questions on a laptop GPU
+  - Add screenshot understanding to a local agent without a cloud VLM
+  - Prototype multimodal RAG over diagrams and UI captures


### PR DESCRIPTION
## Add AI21, Moondream, Apache Jena, RDFLib, ScrapeGraphAI to catalog

Five catalog entries for LLMs and data/knowledge-graph tooling.

| Tool | Category | Notes |
|---|---|---|
| AI21 | LLM | Jamba models and production LLM APIs |
| Moondream | LLM | Tiny open vision-language model (~10k stars) |
| Apache Jena | Data | RDF/SPARQL Semantic Web framework (~1.4k stars) |
| RDFLib | Data | Python RDF and SPARQL library (~2.5k stars) |
| ScrapeGraphAI | Data | LLM-powered Python scraper (~30k stars) |

Local validation passed for all five YAML files.
