### PR TITLE
Add TDengine, IoTDB to catalog

### DIFF
--- a/tools/data/iotdb.yaml
+++ b/tools/data/iotdb.yaml
@@ -1,0 +1,24 @@
+name: IoTDB
+description: Apache time-series database for IoT and edge data. Store aligned sensor sequences, query with SQL, and integrate with Spark and Flink so ML pipelines can train on device telemetry at scale.
+tagline: Apache time-series database for IoT telemetry
+
+github_url: https://github.com/apache/iotdb
+website_url: https://iotdb.apache.org
+docs_url: https://iotdb.apache.org/UserGuide/latest/
+
+category: Data
+tags: [java, timeseries, iot, apache, sql, spark, flink]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Device telemetry for ML is high-volume, aligned by time, and awkward in
+  row stores. Apache IoTDB is a time-series database for IoT with SQL and
+  Spark/Flink connectors so training and monitoring pipelines can query
+  sensor sequences without a custom ingest stack.
+
+use_cases:
+  - Store IoT sensor sequences for predictive-maintenance models
+  - Query device telemetry with SQL in an ML feature pipeline
+  - Stream edge time-series into Spark or Flink for training

--- a/tools/data/tdengine.yaml
+++ b/tools/data/tdengine.yaml
@@ -1,0 +1,24 @@
+name: TDengine
+description: High-performance time-series database for industrial IoT. Ingest high-cardinality sensor streams, run SQL analytics, and feed ML feature pipelines without a bloated general-purpose warehouse.
+tagline: Time-series database for industrial IoT
+
+github_url: https://github.com/taosdata/TDengine
+website_url: https://tdengine.com
+docs_url: https://docs.tdengine.com
+
+category: Data
+tags: [timeseries, iot, sql, database, analytics, sensors]
+pricing: freemium
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Industrial IoT and ML feature stores drown general-purpose databases in
+  high-cardinality sensor writes. TDengine is a time-series database built
+  for IIoT ingest and SQL analytics so telemetry pipelines can train and
+  monitor models without a warehouse for every tag.
+
+use_cases:
+  - Ingest high-cardinality IoT sensor streams for ML features
+  - Run SQL analytics on industrial time-series for anomaly detection
+  - Store metrics behind predictive-maintenance models


### PR DESCRIPTION
## Add TDengine, IoTDB to catalog

Remainder batch of two time-series databases for IoT and ML telemetry pipelines.

| Tool | Category | Notes |
|---|---|---|
| TDengine | Data | Industrial IoT time-series DB (~25k stars, AGPL-3.0) |
| IoTDB | Data | Apache IoT time-series DB (~6k stars) |

Local validation passed for both YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apache IoTDB to the available technology directory, including its features, integrations, pricing, and common use cases.
  * Added TDengine to the technology directory with details on its capabilities, integrations, pricing, and industrial IoT use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->