### PR TITLE
Add LightLLM, Semgrep, Gitleaks, TruffleHog, Hypothesis to catalog

### DIFF
--- a/tools/dev-tools/gitleaks.yaml
+++ b/tools/dev-tools/gitleaks.yaml
@@ -1,0 +1,24 @@
+name: Gitleaks
+description: Fast secret scanner for git repos, files, and CI. Detect API keys, tokens, and credentials in history so LLM apps and agent repos do not leak keys into GitHub.
+tagline: Find secrets in git repos and CI
+
+github_url: https://github.com/gitleaks/gitleaks
+website_url: https://gitleaks.io
+docs_url: https://github.com/gitleaks/gitleaks
+install_command: brew install gitleaks
+
+category: Dev Tools
+tags: [go, secrets, security, git, ci, scanning]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  LLM apps and agent configs often commit API keys by accident, and git
+  history keeps them forever. Gitleaks scans repos, files, and CI for
+  tokens and credentials so teams catch leaks before they hit GitHub.
+
+use_cases:
+  - Scan a git repo and history for leaked API keys
+  - Add a pre-commit or CI secret scan for LLM projects
+  - Audit agent config files for hardcoded tokens

--- a/tools/dev-tools/hypothesis.yaml
+++ b/tools/dev-tools/hypothesis.yaml
@@ -1,0 +1,25 @@
+name: Hypothesis
+description: Property-based testing library for Python. Generate many inputs from type hints and invariants so ML pipelines, parsers, and agent tools fail on edge cases unit tests miss.
+tagline: Property-based testing for Python
+
+github_url: https://github.com/HypothesisWorks/hypothesis
+website_url: https://hypothesis.readthedocs.io
+docs_url: https://hypothesis.readthedocs.io
+install_command: pip install hypothesis
+
+category: Dev Tools
+tags: [python, testing, property-based, pytest, fuzzing]
+pricing: free
+is_open_source: true
+license: MPL-2.0
+
+problem_solved: |
+  Example-based unit tests miss weird inputs that break parsers, tokenizers,
+  and data pipelines. Hypothesis generates cases from properties and type
+  hints so Python ML and agent code is tested against thousands of edge
+  cases instead of a handful of fixtures.
+
+use_cases:
+  - Property-test a tokenizer or JSON parser with generated inputs
+  - Find edge cases in data cleaning before training
+  - Combine Hypothesis with pytest for agent tool argument validation

--- a/tools/dev-tools/lightllm.yaml
+++ b/tools/dev-tools/lightllm.yaml
@@ -1,0 +1,24 @@
+name: LightLLM
+description: Python LLM inference and serving framework focused on a lightweight design and high throughput. Serve large models with easy scaling so teams can run OpenAI-style APIs without a heavy serving stack.
+tagline: Lightweight high-throughput LLM serving
+
+github_url: https://github.com/ModelTC/LightLLM
+website_url: https://github.com/ModelTC/LightLLM
+docs_url: https://github.com/ModelTC/LightLLM
+
+category: Dev Tools
+tags: [python, llm, inference, serving, gpu, openai-compatible]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Production LLM serving often means a heavy vLLM or TGI stack that is hard
+  to customize. LightLLM is a lightweight Python inference server built for
+  high throughput and easy scaling so teams can expose OpenAI-style APIs
+  without a bulky serving framework.
+
+use_cases:
+  - Serve an open LLM with an OpenAI-compatible HTTP API
+  - Scale token generation across GPUs for chat and agents
+  - Prototype a lighter alternative to vLLM for custom serving

--- a/tools/dev-tools/semgrep.yaml
+++ b/tools/dev-tools/semgrep.yaml
@@ -1,0 +1,25 @@
+name: Semgrep
+description: Lightweight static analysis that finds bugs with patterns that look like source code. Scan Python, JS, and 30-plus languages in CI so ML and agent repos catch secrets, injections, and code smells early.
+tagline: Pattern-based static analysis for many languages
+
+github_url: https://github.com/semgrep/semgrep
+website_url: https://semgrep.dev
+docs_url: https://semgrep.dev/docs
+install_command: pip install semgrep
+
+category: Dev Tools
+tags: [python, sast, security, static-analysis, ci, lint]
+pricing: freemium
+is_open_source: true
+license: LGPL-2.1
+
+problem_solved: |
+  Generic linters miss security bugs and custom anti-patterns in ML
+  codebases. Semgrep lets you write rules that look like source code and
+  scan 30-plus languages in CI, so teams catch injections, secrets, and
+  unsafe LLM-app patterns before merge.
+
+use_cases:
+  - Add SAST scans to CI for Python LLM and agent repos
+  - Write custom rules that look like source code for app-specific bugs
+  - Block secrets and injection patterns before they reach production

--- a/tools/dev-tools/trufflehog.yaml
+++ b/tools/dev-tools/trufflehog.yaml
@@ -1,0 +1,24 @@
+name: TruffleHog
+description: Secret scanner that finds, verifies, and analyzes leaked credentials in git, GitHub, and cloud stores. Check whether a key is live so teams can rotate real leaks instead of chasing false positives.
+tagline: Find and verify leaked credentials
+
+github_url: https://github.com/trufflesecurity/trufflehog
+website_url: https://trufflesecurity.com
+docs_url: https://docs.trufflesecurity.com
+
+category: Dev Tools
+tags: [go, secrets, security, git, credentials, scanning]
+pricing: freemium
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Secret scanners dump thousands of matches that may already be revoked.
+  TruffleHog finds credentials in git and cloud sources and verifies
+  whether they still work, so LLM and agent teams rotate real leaks
+  instead of triaging dead keys.
+
+use_cases:
+  - Scan git history for live API keys and cloud credentials
+  - Verify whether a leaked OpenAI or AWS key is still active
+  - Audit GitHub orgs for secrets before an incident


### PR DESCRIPTION
## Add LightLLM, Semgrep, Gitleaks, TruffleHog, Hypothesis to catalog

Five catalog entries for LLM serving, SAST, secret scanning, and property-based testing.

| Tool | Category | Notes |
|---|---|---|
| LightLLM | Dev Tools | Lightweight LLM inference server (~4k stars) |
| Semgrep | Dev Tools | Pattern-based SAST (~16k stars) |
| Gitleaks | Dev Tools | Git secret scanner (~29k stars) |
| TruffleHog | Dev Tools | Verified credential scanner (~28k stars) |
| Hypothesis | Dev Tools | Python property-based testing (~9k stars) |

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Gitleaks, Hypothesis, LightLLM, Semgrep, and TruffleHog.
  * Included descriptions, documentation links, installation details, licensing, pricing, categories, tags, and practical use cases for each tool.
  * Expanded the Dev Tools catalog with security scanning, property-based testing, LLM serving, and static-analysis solutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->