### PR TITLE
Add wrk, JMeter, Appium, virtualenv to catalog

### DIFF
--- a/tools/dev-tools/appium.yaml
+++ b/tools/dev-tools/appium.yaml
@@ -1,0 +1,29 @@
+name: Appium
+description: Cross-platform mobile automation framework built on the W3C WebDriver protocol. Appium drives native, hybrid, and mobile-web apps on iOS, Android, and desktop without modifying the app, using one API across platforms for tests and device farms.
+tagline: Cross-platform mobile automation on the WebDriver protocol
+
+github_url: https://github.com/appium/appium
+website_url: https://appium.io
+docs_url: https://appium.io/docs/en/latest/
+
+category: Dev Tools
+tags: [mobile, testing, automation, webdriver, ios, android, e2e]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: npm install -g appium
+
+problem_solved: |
+  AI products ship iOS and Android clients with chat UIs, camera capture, and
+  on-device models, but each platform has a different automation stack. Appium
+  wraps those stacks behind the W3C WebDriver protocol so one test suite
+  drives native, hybrid, and mobile-web apps without rebuilding the app or
+  rewriting tests per OS, which keeps mobile AI features covered in CI and
+  device farms.
+
+use_cases:
+  - Automate end-to-end tests of AI chat, camera, and voice features in iOS and Android apps
+  - Run the same WebDriver tests against native, hybrid, and mobile-web clients without app rebuilds
+  - Drive device-farm CI for on-device model inference, permissions, and offline AI flows
+  - Scrape or exercise mobile UIs as part of dataset collection and regression suites for ML products

--- a/tools/dev-tools/jmeter.yaml
+++ b/tools/dev-tools/jmeter.yaml
@@ -1,0 +1,27 @@
+name: JMeter
+description: Apache JMeter is an open-source load and performance testing tool for web apps, APIs, databases, and other services. It runs GUI or CLI test plans with HTTP, JDBC, JMS, and plugin samplers so teams can stress AI inference APIs and data pipelines.
+tagline: Apache load testing for APIs, web apps, and data services
+
+github_url: https://github.com/apache/jmeter
+website_url: https://jmeter.apache.org
+docs_url: https://jmeter.apache.org/usermanual/index.html
+
+category: Dev Tools
+tags: [load-testing, performance-testing, java, http, api, apache]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI platforms expose many protocols at once — REST inference, JDBC feature
+  stores, message queues, and web UIs — and teams need one test plan that
+  covers them. JMeter records or authors multi-protocol scenarios, then runs
+  them in GUI or headless CLI mode with thread groups, assertions, and
+  listeners so ML ops can prove an inference stack and its backing data
+  services hold up under concurrent users without writing a custom harness.
+
+use_cases:
+  - Load-test LLM and embedding HTTP APIs with thread groups, timers, and percentile reports
+  - Exercise JDBC feature stores and metadata databases alongside inference endpoints in one test plan
+  - Run headless JMeter in CI to gate model-serving releases on latency and error-rate thresholds
+  - Simulate mixed web and API traffic against AI product UIs, dashboards, and streaming chat backends

--- a/tools/dev-tools/virtualenv.yaml
+++ b/tools/dev-tools/virtualenv.yaml
@@ -1,0 +1,28 @@
+name: virtualenv
+description: Tool for creating isolated Python environments with their own site-packages, interpreter, and pip installs. virtualenv keeps project dependencies separate so AI and ML stacks do not collide across experiments, CI jobs, and production services.
+tagline: Isolated Python environments for projects and experiments
+
+github_url: https://github.com/pypa/virtualenv
+website_url: https://virtualenv.pypa.io
+docs_url: https://virtualenv.pypa.io/en/latest/
+
+category: Dev Tools
+tags: [python, virtualenv, environments, packaging, pip, pypa]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install virtualenv
+
+problem_solved: |
+  Python AI and ML projects pin conflicting CUDA, NumPy, and framework
+  versions, and a shared site-packages tree breaks experiments and CI.
+  virtualenv creates a per-project interpreter and package prefix so each
+  training job, notebook, or service installs its own deps without
+  contaminating the system Python or sibling projects.
+
+use_cases:
+  - Isolate CUDA, PyTorch, and NumPy versions per training experiment without polluting system Python
+  - Create reproducible CI environments for lint, test, and packaging jobs on ML repositories
+  - Seed Docker images and local shells with a project-specific interpreter and pip prefix
+  - Run multiple model-serving services on one host with independent dependency trees

--- a/tools/dev-tools/wrk.yaml
+++ b/tools/dev-tools/wrk.yaml
@@ -1,0 +1,28 @@
+name: wrk
+description: A modern HTTP benchmarking tool that generates high request rates from a single multi-core machine using multithreaded event-driven I/O and optional LuaJIT scripts for custom request generation, response handling, and reporting.
+tagline: High-throughput HTTP load generator for a single machine
+
+github_url: https://github.com/wg/wrk
+docs_url: https://github.com/wg/wrk
+
+category: Dev Tools
+tags: [http, load-testing, benchmarking, performance, lua, cli]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: brew install wrk
+
+problem_solved: |
+  Teams serving LLM APIs and model inference endpoints need to measure latency
+  and throughput under realistic HTTP load, but many tools are too slow on one
+  box or require a heavy distributed setup. wrk saturates a target from a single
+  machine using multithreaded epoll/kqueue I/O, reporting latency stats and
+  requests per second so ML platform teams can find bottlenecks in inference
+  servers, reverse proxies, and RAG APIs before production.
+
+use_cases:
+  - Benchmark LLM inference and embedding HTTP endpoints for latency percentiles and requests per second
+  - Stress-test reverse proxies and API gateways in front of model servers from a single multi-core box
+  - Script custom request bodies and headers with LuaJIT to mimic production chat and RAG traffic
+  - Compare throughput of streaming versus non-streaming inference paths under sustained connection load


### PR DESCRIPTION
## Summary
Adds four Dev Tools catalog entries for load testing, mobile automation, and Python environment isolation:

- **wrk** — high-throughput HTTP benchmarking (wg/wrk, 40k+)
- **JMeter** — Apache multi-protocol load testing
- **Appium** — cross-platform mobile WebDriver automation
- **virtualenv** — PyPA isolated Python environments

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all four files.

## Category
Dev Tools (`tools/dev-tools/`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Appium to the development-tools catalog, including mobile automation details and installation guidance.
  * Added JMeter with metadata and use cases for load testing AI services, databases, and mixed traffic.
  * Added virtualenv with setup information and use cases for isolated, reproducible environments.
  * Added wrk with benchmarking details and use cases for measuring inference and HTTP performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->