### PR TITLE
Add Gatling, Artillery, pyenv, pip-tools, Mockito to catalog

### DIFF
--- a/tools/dev-tools/artillery.yaml
+++ b/tools/dev-tools/artillery.yaml
@@ -1,0 +1,28 @@
+name: Artillery
+description: Node.js load testing platform for HTTP, GraphQL, WebSocket, and Playwright scenarios. Artillery describes tests in YAML or TypeScript, runs locally or distributed, and reports latency and error rates for production-grade API and browser load.
+tagline: Node.js load testing for APIs, GraphQL, and browsers
+
+github_url: https://github.com/artilleryio/artillery
+website_url: https://www.artillery.io
+docs_url: https://www.artillery.io/docs
+
+category: Dev Tools
+tags: [load-testing, nodejs, http, graphql, websocket, playwright]
+pricing: freemium
+is_open_source: true
+license: MPL-2.0
+
+install_command: npm install -g artillery
+
+problem_solved: |
+  JavaScript teams shipping AI chat UIs and GraphQL gateways need load tests
+  that speak HTTP, WebSocket, and real browsers, without switching to Java
+  tools. Artillery lets them write YAML or TypeScript scenarios, reuse any
+  Node module, and optionally drive Playwright so streaming LLM UIs and APIs
+  get the same production-grade load profile.
+
+use_cases:
+  - Load-test LLM HTTP and GraphQL APIs with YAML or TypeScript virtual-user scenarios
+  - Drive WebSocket streaming chat backends and measure latency under concurrent connections
+  - Run Playwright-based browser load against AI product UIs and dashboards
+  - Distribute tests across workers to simulate production traffic on model-serving stacks

--- a/tools/dev-tools/gatling.yaml
+++ b/tools/dev-tools/gatling.yaml
@@ -1,0 +1,26 @@
+name: Gatling
+description: Open-source load testing as code for HTTP, WebSocket, and JMS. Gatling uses a Scala DSL to describe virtual-user scenarios, then reports latency percentiles and throughput so teams can prove inference APIs and AI product backends hold up under load.
+tagline: Load testing as code for HTTP APIs and web apps
+
+github_url: https://github.com/gatling/gatling
+website_url: https://gatling.io
+docs_url: https://docs.gatling.io
+
+category: Dev Tools
+tags: [load-testing, performance-testing, scala, http, gatling, as-code]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Teams serving LLM APIs need repeatable, version-controlled load tests, but
+  GUI-only tools are hard to review in Git. Gatling treats scenarios as code
+  with a Scala DSL, injects virtual users against HTTP, WebSocket, and JMS
+  endpoints, and emits detailed percentile reports so ML platform teams can
+  gate releases on latency SLOs instead of ad-hoc wrk runs.
+
+use_cases:
+  - Script HTTP load tests against LLM inference, embedding, and RAG APIs as reviewable Scala code
+  - Measure WebSocket streaming chat backends for latency percentiles under ramping virtual users
+  - Gate model-serving releases in CI with Gatling reports on throughput and error rates
+  - Compare gateway and inference-server configs by replaying the same scenario against each stack

--- a/tools/dev-tools/mockito.yaml
+++ b/tools/dev-tools/mockito.yaml
@@ -1,0 +1,26 @@
+name: Mockito
+description: The most widely used Java mocking framework for unit tests. Mockito creates test doubles for collaborators so teams can isolate JVM services, model-serving adapters, and data clients without standing up real backends.
+tagline: Java mocking framework for isolated unit tests
+
+github_url: https://github.com/mockito/mockito
+website_url: https://site.mockito.org
+docs_url: https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html
+
+category: Dev Tools
+tags: [java, testing, mocking, unit-tests, jvm, mockito]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  JVM services around AI products talk to model APIs, vector stores, and
+  queues, and unit tests that hit those systems are slow and flaky. Mockito
+  generates mocks and spies with a fluent API so tests assert how adapters
+  call inference clients and feature stores without requiring live
+  infrastructure.
+
+use_cases:
+  - Unit-test Java inference adapters by mocking HTTP and gRPC model clients
+  - Isolate feature-store and database DAOs in JVM ML platform services
+  - Verify retry and timeout behavior around LLM APIs with stubbed failures
+  - Speed CI for Spring and Micronaut AI backends by replacing external collaborators

--- a/tools/dev-tools/pip-tools.yaml
+++ b/tools/dev-tools/pip-tools.yaml
@@ -1,0 +1,28 @@
+name: pip-tools
+description: A set of command-line tools that compile loose Python requirements into hashed, pinned lock files and sync the environment to match. pip-tools keeps AI project dependencies reproducible without switching package managers.
+tagline: Pin and sync Python dependencies with pip-compile
+
+github_url: https://github.com/jazzband/pip-tools
+website_url: https://pip-tools.readthedocs.io
+docs_url: https://pip-tools.readthedocs.io/en/latest/
+
+category: Dev Tools
+tags: [python, pip, lockfile, dependencies, packaging, jazzband]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install pip-tools
+
+problem_solved: |
+  pip install of unpinned requirements.txt files drifts across machines and
+  CI, which breaks ML training and inference in subtle ways. pip-tools
+  compiles a high-level requirements.in into a fully pinned, hashed
+  requirements.txt and syncs the environment so every CUDA, NumPy, and
+  framework version matches what was reviewed in Git.
+
+use_cases:
+  - Compile requirements.in into hashed lock files for training and serving images
+  - Sync a virtualenv to the lock file so CI and laptops install identical ML stacks
+  - Keep CUDA, PyTorch, and data-library pins reviewable in Git without switching to Poetry
+  - Refresh only selected packages while leaving the rest of an AI dependency tree pinned

--- a/tools/dev-tools/pyenv.yaml
+++ b/tools/dev-tools/pyenv.yaml
@@ -1,0 +1,27 @@
+name: pyenv
+description: Simple Python version manager that installs multiple CPython, PyPy, and other interpreters side by side and switches them per user, shell, or project. pyenv keeps ML stacks on the exact Python they were trained and tested against.
+tagline: Per-project Python version management
+
+github_url: https://github.com/pyenv/pyenv
+docs_url: https://github.com/pyenv/pyenv#installation
+
+category: Dev Tools
+tags: [python, version-manager, pyenv, environments, cpython, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: brew install pyenv
+
+problem_solved: |
+  AI and ML projects pin a Python version that system packages and other
+  repos do not share, so a single global interpreter breaks training jobs
+  and CI. pyenv installs many interpreters into an isolated prefix and
+  switches by user, shell, or .python-version file so each experiment and
+  service runs the exact CPython it was validated on.
+
+use_cases:
+  - Install and switch CPython versions per ML repo with a .python-version file
+  - Keep training, notebook, and serving environments on the interpreter they were tested against
+  - Build isolated Pythons for CUDA and scientific stacks without replacing system Python
+  - Standardize CI images on a pyenv-managed interpreter matching local development


### PR DESCRIPTION
## Summary
Adds five Dev Tools catalog entries for load testing, Python environment pinning, and JVM unit testing:

- **Gatling** — load testing as code (gatling/gatling)
- **Artillery** — Node.js HTTP/GraphQL/WebSocket/Playwright load testing
- **pyenv** — Python version management
- **pip-tools** — pip-compile lock files and env sync
- **Mockito** — Java mocking framework

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all five files.

## Category
Dev Tools (`tools/dev-tools/`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Artillery, Gatling, Mockito, pip-tools, and pyenv.
  * Included descriptions, categories, tags, licensing and pricing details, relevant links, installation commands where applicable, and practical use cases.
  * Expanded tooling coverage for load testing, Java testing, Python dependency management, and Python version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->