### PR TITLE
Add WireMock, Schemathesis, Karate to catalog

### DIFF
--- a/tools/dev-tools/karate.yaml
+++ b/tools/dev-tools/karate.yaml
@@ -1,0 +1,26 @@
+name: Karate
+description: Open-source test automation framework that combines API testing, mocks, and UI automation in one Gherkin-like DSL. Karate lets teams write HTTP, GraphQL, and browser tests without a separate programming language.
+tagline: API, mock, and UI test automation in one DSL
+
+github_url: https://github.com/karatelabs/karate
+website_url: https://www.karatelabs.io
+docs_url: https://docs.karatelabs.io
+
+category: Dev Tools
+tags: [api-testing, test-automation, gherkin, http, graphql, karate]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  API, mock, and UI tests for AI products usually live in three stacks,
+  so coverage drifts. Karate uses one readable DSL for HTTP and GraphQL
+  calls, payload assertions, service mocks, and browser steps, which
+  keeps inference APIs, webhooks, and product UIs under a single
+  reviewable test suite.
+
+use_cases:
+  - Write HTTP and GraphQL tests for LLM gateways and RAG APIs in a Gherkin-like DSL
+  - Mock partner and model HTTP services alongside consumer tests in the same framework
+  - Drive UI checks for AI chat and dashboard flows without a separate browser stack
+  - Run parallel API regression in CI against staging model-serving environments

--- a/tools/dev-tools/schemathesis.yaml
+++ b/tools/dev-tools/schemathesis.yaml
@@ -1,0 +1,28 @@
+name: Schemathesis
+description: Property-based API testing tool that reads OpenAPI and GraphQL schemas and generates traffic to find contract bugs. Schemathesis catches status-code, schema, and stateful failures in LLM and RAG HTTP APIs before users do.
+tagline: Property-based testing for OpenAPI and GraphQL APIs
+
+github_url: https://github.com/schemathesis/schemathesis
+website_url: https://schemathesis.readthedocs.io
+docs_url: https://schemathesis.readthedocs.io/en/stable/
+
+category: Dev Tools
+tags: [api-testing, openapi, graphql, property-based, python, hypothesis]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install schemathesis
+
+problem_solved: |
+  Hand-written API tests miss edge cases in request bodies and sequences,
+  so LLM gateways and RAG services ship contract bugs. Schemathesis reads
+  an OpenAPI or GraphQL schema, generates property-based cases (built on
+  Hypothesis), and reports schema violations, 5xx responses, and stateful
+  failures so teams fix the API before clients depend on it.
+
+use_cases:
+  - Fuzz OpenAPI specs for model-serving and embedding APIs to find 5xx and schema violations
+  - Run stateful sequences against RAG and agent HTTP APIs to catch broken workflows
+  - Gate CI on GraphQL and REST contract tests generated from the live schema
+  - Reproduce failing cases as pytest tests after property-based discovery

--- a/tools/dev-tools/wiremock.yaml
+++ b/tools/dev-tools/wiremock.yaml
@@ -1,0 +1,26 @@
+name: WireMock
+description: HTTP mock server for stubbing APIs, simulating faults, and recording traffic. WireMock runs standalone or in-process on the JVM so teams can test clients of LLM gateways, webhooks, and data APIs without depending on live backends.
+tagline: Mock HTTP services for tests and local development
+
+github_url: https://github.com/wiremock/wiremock
+website_url: https://wiremock.org
+docs_url: https://wiremock.org/docs/
+
+category: Dev Tools
+tags: [http, mocking, testing, java, stubs, api]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI product tests that call real model APIs and partner webhooks are slow,
+  flaky, and expensive. WireMock stubs HTTP responses, delays, and faults
+  so JVM and language-agnostic clients can exercise retries, streaming
+  payloads, and error paths against a deterministic mock instead of
+  production inference endpoints.
+
+use_cases:
+  - Stub LLM and embedding HTTP APIs in integration tests with fixed JSON and streamed responses
+  - Simulate timeouts, 429s, and 5xx faults to verify retry logic around model gateways
+  - Record and replay partner webhook traffic for offline CI of AI product backends
+  - Run a standalone mock server so local agents and RAG services develop without live vendor APIs


### PR DESCRIPTION
## Summary
Adds three Dev Tools catalog entries for HTTP mocking and API test automation:

- **WireMock** — HTTP mock server (wiremock/wiremock)
- **Schemathesis** — property-based OpenAPI/GraphQL testing
- **Karate** — API, mock, and UI test DSL

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all three files.

## Category
Dev Tools (`tools/dev-tools/`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Karate to the Dev Tools directory, including links, licensing details, and testing use cases.
  - Added Schemathesis as a property-based API testing tool for OpenAPI and GraphQL, with installation and usage information.
  - Added WireMock as an HTTP mocking tool, including links, pricing, licensing, and common testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->