### PR TITLE
Add JUnit, Fastlane, Cucumber, Robot Framework, CocoaPods to catalog

### DIFF
--- a/tools/dev-tools/cocoapods.yaml
+++ b/tools/dev-tools/cocoapods.yaml
@@ -1,0 +1,28 @@
+name: CocoaPods
+description: Dependency manager for Swift and Objective-C Cocoa projects. CocoaPods resolves libraries into an Xcode workspace so iOS and macOS AI apps can pin on-device ML, networking, and UI SDKs with a Podfile.
+tagline: Dependency manager for Swift and Objective-C projects
+
+github_url: https://github.com/CocoaPods/CocoaPods
+website_url: https://cocoapods.org
+docs_url: https://guides.cocoapods.org
+
+category: Dev Tools
+tags: [ios, macos, swift, cocoapods, dependency-management, xcode]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: brew install cocoapods
+
+problem_solved: |
+  iOS AI apps pull Core ML wrappers, networking, and UI kits that Xcode
+  alone does not version well across a team. CocoaPods declares those
+  libraries in a Podfile, resolves versions, and generates a workspace
+  so on-device inference clients build the same graph on every laptop
+  and CI Mac.
+
+use_cases:
+  - Pin on-device ML, audio, and networking SDKs for iOS AI apps in a Podfile
+  - Share a resolved Podfile.lock so CI and developers install identical Cocoa libraries
+  - Integrate third-party camera, speech, and LLM client pods into Xcode workspaces
+  - Publish internal pods for shared mobile inference and chat UI modules

--- a/tools/dev-tools/cucumber.yaml
+++ b/tools/dev-tools/cucumber.yaml
@@ -1,0 +1,27 @@
+name: Cucumber
+description: Behavior-driven development tool that runs Gherkin feature files against step definitions. Cucumber keeps product examples in plain language so AI chat, RAG, and API behaviors stay reviewable by engineers and stakeholders.
+tagline: BDD tests from Gherkin feature files
+
+github_url: https://github.com/cucumber/cucumber-js
+website_url: https://cucumber.io
+docs_url: https://cucumber.io/docs/cucumber/
+
+category: Dev Tools
+tags: [bdd, testing, gherkin, cucumber, javascript, acceptance-tests]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: npm install @cucumber/cucumber
+
+problem_solved: |
+  Acceptance criteria for AI products live in tickets while tests live in
+  code, so behavior drifts. Cucumber runs Given/When/Then features against
+  step definitions, which keeps chat, RAG, and API examples in a shared
+  language that CI can execute and non-engineers can still read.
+
+use_cases:
+  - Express AI chat and RAG acceptance scenarios as Gherkin features that CI executes
+  - Share readable examples of model-gateway behavior with product and QA
+  - Drive HTTP and UI steps from the same feature files across JS services
+  - Keep regression coverage of streaming and tool-calling flows in versioned .feature files

--- a/tools/dev-tools/fastlane.yaml
+++ b/tools/dev-tools/fastlane.yaml
@@ -1,0 +1,28 @@
+name: Fastlane
+description: Automation toolkit for building, signing, and releasing iOS and Android apps. Fastlane replaces click-ops in App Store Connect and Play Console with lanes for screenshots, code signing, beta, and store upload so mobile AI apps ship from CI.
+tagline: Automate iOS and Android build and release lanes
+
+github_url: https://github.com/fastlane/fastlane
+website_url: https://fastlane.tools
+docs_url: https://docs.fastlane.tools
+
+category: Dev Tools
+tags: [mobile, ios, android, ci, release, fastlane]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: brew install fastlane
+
+problem_solved: |
+  Mobile AI apps stall on screenshots, certificates, and store uploads
+  that only one person can click. Fastlane encodes those steps as lanes
+  that run in CI, handling signing, TestFlight, Play tracks, and metadata
+  so on-device model updates and chat clients ship without a release
+  bottleneck.
+
+use_cases:
+  - Automate TestFlight and Play Console uploads for iOS and Android AI apps from CI
+  - Manage code signing and provisioning so on-device model builds are reproducible
+  - Generate screenshots and store metadata for mobile AI product releases
+  - Run beta lanes that ship camera, voice, and chat app builds to internal testers

--- a/tools/dev-tools/junit.yaml
+++ b/tools/dev-tools/junit.yaml
@@ -1,0 +1,26 @@
+name: JUnit
+description: Programmer-friendly testing framework for Java and the JVM. JUnit 5 (Jupiter) provides annotations, assertions, extensions, and parameterized tests so teams can unit-test model-serving adapters, data pipelines, and AI platform services on the JVM.
+tagline: Standard unit testing framework for Java and the JVM
+
+github_url: https://github.com/junit-team/junit-framework
+website_url: https://junit.org
+docs_url: https://docs.junit.org
+
+category: Dev Tools
+tags: [java, testing, junit, jvm, unit-tests, jupiter]
+pricing: free
+is_open_source: true
+license: EPL-2.0
+
+problem_solved: |
+  JVM services around AI products need fast, isolated tests, but ad-hoc
+  main methods and custom harnesses do not integrate with CI or IDEs.
+  JUnit 5 gives a standard engine, nested and parameterized tests, and
+  an extension model so inference clients, feature stores, and orchestration
+  code get the same automated feedback loop as any other Java service.
+
+use_cases:
+  - Unit-test Java model-serving adapters, serializers, and retry wrappers with Jupiter assertions
+  - Parameterize tests across prompt fixtures, model versions, and payload shapes
+  - Plug JUnit into Maven or Gradle CI for JVM AI platform libraries
+  - Use extensions to spin up testcontainers or mocks around vector and queue clients

--- a/tools/dev-tools/robot-framework.yaml
+++ b/tools/dev-tools/robot-framework.yaml
@@ -1,0 +1,28 @@
+name: Robot Framework
+description: Generic open-source automation framework for acceptance testing and RPA. Robot Framework uses keyword-driven tests and a rich library ecosystem so teams can cover AI APIs, browsers, and desktop flows without a custom harness.
+tagline: Keyword-driven acceptance testing and RPA
+
+github_url: https://github.com/robotframework/robotframework
+website_url: https://robotframework.org
+docs_url: https://robotframework.org/robotframework/
+
+category: Dev Tools
+tags: [acceptance-testing, rpa, python, keyword-driven, automation, testing]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install robotframework
+
+problem_solved: |
+  End-to-end checks for AI products mix APIs, browsers, and files, and
+  custom pytest piles become unreadable for QA. Robot Framework gives a
+  keyword-driven syntax plus libraries for HTTP, Selenium, and OS tasks
+  so acceptance tests of chat UIs, document pipelines, and model APIs stay
+  executable and shareable.
+
+use_cases:
+  - Write keyword-driven acceptance tests for LLM HTTP APIs and RAG document flows
+  - Combine browser and API keywords to cover AI product UIs end to end
+  - Automate RPA-style file and desktop steps around document-AI pipelines
+  - Produce HTML logs and reports from CI for model-serving regression suites


### PR DESCRIPTION
## Summary
Adds five Dev Tools catalog entries for JVM testing, mobile release, BDD, and iOS dependencies:

- **JUnit** — Java/JVM testing (junit-team/junit-framework)
- **Fastlane** — iOS and Android build and release automation
- **Cucumber** — Gherkin BDD (cucumber/cucumber-js)
- **Robot Framework** — keyword-driven acceptance testing and RPA
- **CocoaPods** — Swift/ObjC dependency manager

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all five files.

## Category
Dev Tools (`tools/dev-tools/`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CocoaPods, Cucumber, Fastlane, JUnit, and Robot Framework to the Dev Tools catalog.
  - Added installation guidance, licensing and pricing details, official resource links, and descriptive metadata for each tool.
  - Added practical use cases covering mobile development, release automation, JVM testing, behavior-driven testing, API and UI validation, RPA, and AI application workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->