### PR TITLE
Add Maestro, MSW, Rest Assured to catalog

### DIFF
--- a/tools/dev-tools/maestro.yaml
+++ b/tools/dev-tools/maestro.yaml
@@ -1,0 +1,24 @@
+name: Maestro
+description: "YAML-based end-to-end UI automation for mobile and web. Flows are interpreted, not compiled, so tests stay readable and iterate fast across Android, iOS, and web without brittle, compiled test code."
+tagline: "Painless E2E automation for mobile and web"
+github_url: https://github.com/mobile-dev-inc/Maestro
+website_url: https://maestro.dev
+docs_url: https://docs.maestro.dev
+install_command: |
+  curl -fsSL "https://get.maestro.mobile.dev" | bash
+category: Dev Tools
+tags:
+  - mobile
+  - testing
+  - e2e
+  - android
+  - ios
+  - yaml
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Mobile UI tests are slow to write and easy to break when they live in compiled Espresso, XCUITest, or Appium suites. Maestro lets teams describe user flows in YAML that runs as-is on Android, iOS, and web, so QA and engineers can iterate on E2E coverage without rebuilding a test app or fighting flaky selectors."
+use_cases:
+  - "Automate Android and iOS smoke flows (login, checkout, onboarding) from YAML files in CI without compiling Espresso or XCUITest suites"
+  - "Run the same Maestro flow against a mobile app and its web counterpart to catch platform-specific UI regressions before release"
+  - "Give QA and product teams a readable YAML flow they can edit without writing Java, Kotlin, or Swift test code"

--- a/tools/dev-tools/msw.yaml
+++ b/tools/dev-tools/msw.yaml
@@ -1,0 +1,23 @@
+name: MSW
+description: "Industry-standard API mocking for JavaScript. Intercepts REST and GraphQL at the network layer via a Service Worker in the browser and a request interceptor in Node.js, so tests and local apps hit realistic APIs without a live backend."
+tagline: "API mocking at the network layer for browser and Node.js"
+github_url: https://github.com/mswjs/msw
+website_url: https://mswjs.io
+docs_url: https://mswjs.io/docs
+install_command: npm install msw --save-dev
+category: Dev Tools
+tags:
+  - javascript
+  - typescript
+  - testing
+  - mocking
+  - rest
+  - graphql
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Frontend and Node tests that hit real backends are slow, flaky, and hard to run offline. Stubbing fetch or axios inside the app diverges from production networking. MSW intercepts HTTP at the network boundary, so the same handlers work in the browser, Node, Storybook, and CI without changing application code."
+use_cases:
+  - "Mock REST and GraphQL endpoints in Vitest or Jest so component and integration tests run without a live API"
+  - "Run a local frontend against MSW handlers during development when the real backend is unavailable or incomplete"
+  - "Share the same request handlers between Storybook, Playwright, and unit tests so mocked API contracts stay consistent"

--- a/tools/dev-tools/rest-assured.yaml
+++ b/tools/dev-tools/rest-assured.yaml
@@ -1,0 +1,20 @@
+name: Rest Assured
+description: "Java DSL for testing REST services with a given-when-then fluent API. Validates JSON and XML bodies, headers, cookies, and authentication without the boilerplate of raw Java HTTP clients."
+tagline: "Fluent Java DSL for testing REST APIs"
+github_url: https://github.com/rest-assured/rest-assured
+docs_url: https://github.com/rest-assured/rest-assured/wiki/Usage
+category: Dev Tools
+tags:
+  - java
+  - testing
+  - rest
+  - api
+  - json
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Java teams testing REST APIs usually assemble HttpClient, JSON parsers, and assertion libraries by hand, which makes request setup and response validation verbose. REST Assured provides a Groovy-inspired given-when-then DSL so status codes, JSONPath, XML, headers, and auth can be asserted in a few readable lines."
+use_cases:
+  - "Write JUnit tests that GET or POST an endpoint and assert JSONPath fields, status codes, and headers in one fluent chain"
+  - "Validate XML or JSON REST responses with XPath and JsonPath matchers without a separate parser setup"
+  - "Test authenticated APIs using built-in basic, digest, OAuth, and certificate auth helpers in Java integration suites"


### PR DESCRIPTION
## Add Maestro, MSW, and Rest Assured to catalog

Dev Tools batch of testing and API-mocking infrastructure used by AI product teams.

### Tools
- **Maestro** — YAML-based E2E UI automation for Android, iOS, and web (`mobile-dev-inc/Maestro`, Apache-2.0)
- **MSW** — Network-layer REST/GraphQL mocking for browser and Node.js (`mswjs/msw`, MIT)
- **Rest Assured** — Fluent Java DSL for REST API tests (`rest-assured/rest-assured`, Apache-2.0)

All three validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Maestro, MSW, and REST Assured.
  * Included descriptions, documentation links, installation details, licensing, pricing, supported platforms, and primary use cases for each tool.
  * Highlighted use cases for mobile and web automation, API mocking, and REST API testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->