### PR TITLE
Add Flutter, React Native, Spring Boot, nushell, shellcheck to catalog

### DIFF
--- a/tools/dev-tools/flutter.yaml
+++ b/tools/dev-tools/flutter.yaml
@@ -1,0 +1,26 @@
+name: Flutter
+description: Google's UI toolkit for building natively compiled apps for mobile, web, and desktop from a single Dart codebase. AI teams ship chat, vision, and on-device inference clients with a consistent widget layer, hot reload, and platform channels.
+tagline: Cross-platform UI toolkit for mobile, web, and desktop apps
+
+github_url: https://github.com/flutter/flutter
+website_url: https://flutter.dev
+docs_url: https://docs.flutter.dev
+install_command: brew install --cask flutter
+
+category: Dev Tools
+tags: [flutter, dart, mobile, desktop, ui, cross-platform]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Building the same AI product UI separately for iOS, Android, web, and desktop
+  multiplies design and inference-client work. Flutter gives one widget tree and
+  renderer so teams ship chat, camera, and on-device ML surfaces from a single
+  Dart codebase with hot reload instead of four native stacks.
+
+use_cases:
+  - Ship an AI chat or copilot client to iOS, Android, web, and desktop from one Dart UI
+  - Wrap on-device vision or speech models behind Flutter platform channels
+  - Prototype camera, file-picker, and streaming-token UIs with hot reload
+  - Package a branded inference demo as a Flutter web or desktop app for stakeholders

--- a/tools/dev-tools/nushell.yaml
+++ b/tools/dev-tools/nushell.yaml
@@ -1,0 +1,26 @@
+name: nushell
+description: A structured-data shell where pipelines pass tables instead of raw text. Engineers query logs, JSON, and CSVs from AI jobs with SQL-like commands rather than brittle grep, cut, and awk one-liners.
+tagline: A structured-data shell for tables, JSON, and pipelines
+
+github_url: https://github.com/nushell/nushell
+website_url: https://www.nushell.sh
+docs_url: https://www.nushell.sh/book/
+install_command: brew install nushell
+
+category: Dev Tools
+tags: [shell, cli, json, structured-data, rust, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI and data pipelines emit JSON, CSV, and logs that bash treats as unstructured
+  text, so parsing breaks on quoting and columns. Nushell pipelines operate on
+  typed tables so you can filter, join, and chart evaluation results, GPU job
+  output, and API responses without writing one-off Python.
+
+use_cases:
+  - Query JSONL evaluation traces and token-usage logs as tables from the terminal
+  - Convert model-benchmark CSVs and join them with git metadata in a pipeline
+  - Inspect HTTP JSON from inference APIs with typed filters instead of jq plus grep
+  - Script GPU-job and dataset inventory reports that stay readable in CI

--- a/tools/dev-tools/react-native.yaml
+++ b/tools/dev-tools/react-native.yaml
@@ -1,0 +1,27 @@
+name: React Native
+description: Framework for building native iOS and Android apps with React and JavaScript. AI products reuse web React skills for chat UIs, camera capture, and on-device model wrappers while still shipping real native views.
+tagline: Build native iOS and Android apps with React
+
+github_url: https://github.com/facebook/react-native
+website_url: https://reactnative.dev
+docs_url: https://reactnative.dev/docs/getting-started
+install_command: npm install react-native
+
+category: Dev Tools
+tags: [react-native, javascript, mobile, ios, android, react]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI products often start as web React apps, then need native mobile clients for
+  camera, notifications, and on-device inference. Rewriting in Swift and Kotlin
+  splits the team. React Native lets the same React components and JS tooling
+  drive native iOS and Android views so chat, capture, and model-wrapper code
+  stays in one language.
+
+use_cases:
+  - Build a native mobile chat or agent UI that shares React components with a web copilot
+  - Access camera, microphone, and file APIs for multimodal AI capture on iOS and Android
+  - Wrap on-device or edge inference SDKs in native modules called from JavaScript
+  - Ship Expo or bare React Native apps that talk to RAG and agent backends

--- a/tools/dev-tools/shellcheck.yaml
+++ b/tools/dev-tools/shellcheck.yaml
@@ -1,0 +1,26 @@
+name: shellcheck
+description: Static analysis for bash and sh scripts. ShellCheck flags quoting bugs, unquoted expansions, and portability issues that break ML training jobs, dataset download scripts, and CI installers before they hit production.
+tagline: Static analysis for bash and POSIX shell scripts
+
+github_url: https://github.com/koalaman/shellcheck
+website_url: https://www.shellcheck.net
+docs_url: https://github.com/koalaman/shellcheck/wiki
+install_command: brew install shellcheck
+
+category: Dev Tools
+tags: [shell, bash, lint, static-analysis, ci, devops]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Training, data, and deploy scripts are still bash, and a missing quote or
+  unquoted glob can wipe a directory or skip a GPU setup step. ShellCheck
+  catches those classes of bugs in CI so ML platform scripts fail the PR
+  instead of failing at 3am on a cluster node.
+
+use_cases:
+  - Lint bootstrap and CUDA-setup scripts before they run on training nodes
+  - Add ShellCheck to GitHub Actions so dataset download and eval shells stay safe
+  - Catch unquoted expansions in CI installers that fetch models and CLI tools
+  - Review POSIX portability of ops scripts that run on mixed Linux images

--- a/tools/dev-tools/spring-boot.yaml
+++ b/tools/dev-tools/spring-boot.yaml
@@ -1,0 +1,26 @@
+name: Spring Boot
+description: Standard Java framework for production services. Spring Boot auto-configures web, data, security, and observability so teams can ship model-serving APIs, RAG backends, and agent orchestration on the JVM with far less boilerplate.
+tagline: Production-grade Java services with auto-configuration
+
+github_url: https://github.com/spring-projects/spring-boot
+website_url: https://spring.io/projects/spring-boot
+docs_url: https://docs.spring.io/spring-boot/reference/index.html
+
+category: Dev Tools
+tags: [java, spring, jvm, api, microservices, backend]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  JVM teams that expose model inference, embeddings, or agent APIs spend too much
+  time wiring Tomcat, Jackson, datasources, and metrics. Spring Boot opinionated
+  starters and auto-configuration turn those into a runnable service so AI
+  backends get production HTTP, security, and actuator endpoints without a
+  custom framework.
+
+use_cases:
+  - Serve Java REST APIs in front of LLM, embedding, or vector-search backends
+  - Build Spring Data and messaging services that feed RAG and feature pipelines
+  - Expose health, metrics, and tracing for JVM model-serving with Actuator
+  - Package an agent or workflow orchestrator as a Spring Boot microservice


### PR DESCRIPTION
Add Flutter, React Native, Spring Boot, nushell, and shellcheck to the Agentic AI For Good catalog.

- Flutter: Google UI toolkit for mobile, web, and desktop (BSD-3-Clause)
- React Native: native iOS/Android apps with React (MIT)
- Spring Boot: production Java services with auto-configuration (Apache-2.0)
- nushell: structured-data shell for tables and JSON (MIT)
- shellcheck: static analysis for bash/POSIX scripts (GPL-3.0)

All entries validated locally with scripts/validate-tool.ts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Flutter, Nushell, React Native, ShellCheck, and Spring Boot to the developer tools catalog.
  * Added metadata for each tool, including descriptions, links, installation instructions, categories, tags, licensing, pricing, and practical use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->