### PR TITLE
Add Google Test, Quarkus, MkDocs, Nuclei to catalog

### DIFF
--- a/tools/dev-tools/google-test.yaml
+++ b/tools/dev-tools/google-test.yaml
@@ -1,0 +1,25 @@
+name: Google Test
+description: GoogleTest is Google's C++ testing and mocking framework. It provides assertions, fixtures, parameterized tests, and gMock so native inference engines, CUDA bindings, and tokenizer libraries get the same CI unit tests as application code.
+tagline: C++ testing and mocking framework from Google
+
+github_url: https://github.com/google/googletest
+website_url: https://google.github.io/googletest/
+docs_url: https://google.github.io/googletest/primer.html
+
+category: Dev Tools
+tags: [cpp, testing, googletest, gmock, unit-tests, native]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Native AI stacks (tokenizers, kernels, ONNX runtimes, llama.cpp-style
+  engines) are C++ and easy to ship without tests. GoogleTest plus gMock
+  gives assertions, death tests, and mocks that plug into CMake/CTest so
+  those libraries fail in CI instead of on a GPU box.
+
+use_cases:
+  - Unit-test C++ tokenizer, tensor, and serialization code with EXPECT macros
+  - Mock CUDA or RPC neighbors when testing inference client wrappers
+  - Parameterize numeric tests across dtypes, shapes, and model fixture files
+  - Run GoogleTest via CMake CTest in CI for native ML libraries

--- a/tools/dev-tools/mkdocs.yaml
+++ b/tools/dev-tools/mkdocs.yaml
@@ -1,0 +1,26 @@
+name: MkDocs
+description: Project documentation generator that builds a static site from Markdown. AI and ML teams publish model cards, API notes, and runbooks as versioned docs without a CMS, using themes and plugins from a single mkdocs.yml.
+tagline: Markdown-powered static documentation sites
+
+github_url: https://github.com/mkdocs/mkdocs
+website_url: https://www.mkdocs.org
+docs_url: https://www.mkdocs.org/user-guide/
+install_command: pip install mkdocs
+
+category: Dev Tools
+tags: [documentation, markdown, static-site, python, docs]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+problem_solved: |
+  Model cards, eval reports, and internal AI runbooks rot in wikis or Word
+  files that never ship with the repo. MkDocs turns Markdown in git into a
+  searchable static site so docs version with the code and deploy on every
+  merge.
+
+use_cases:
+  - Publish model cards, prompt catalogs, and eval notes next to the training repo
+  - Generate a searchable internal site for RAG and agent runbooks
+  - Preview docs locally while editing Markdown for an AI platform handbook
+  - Deploy versioned API docs for an inference SDK with Material or other themes

--- a/tools/dev-tools/nuclei.yaml
+++ b/tools/dev-tools/nuclei.yaml
@@ -1,0 +1,26 @@
+name: Nuclei
+description: Fast, template-driven vulnerability scanner. Nuclei runs YAML templates for CVEs, misconfigurations, and exposures so teams can check AI gateways, admin panels, and cloud endpoints the same way they scan the rest of the stack.
+tagline: YAML-template vulnerability scanner for apps and APIs
+
+github_url: https://github.com/projectdiscovery/nuclei
+website_url: https://docs.projectdiscovery.io/tools/nuclei
+docs_url: https://docs.projectdiscovery.io/tools/nuclei/overview
+install_command: brew install nuclei
+
+category: Dev Tools
+tags: [security, scanner, cve, yaml, devops, pentest]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI products add extra HTTP surfaces (playgrounds, admin UIs, webhook
+  receivers) that classic app scanners miss or are too slow to run in CI.
+  Nuclei runs community YAML templates against those endpoints so CVE and
+  misconfig checks land in the same pipeline as unit tests.
+
+use_cases:
+  - Scan staging inference APIs and playgrounds for known CVEs before release
+  - Check cloud and Kubernetes exposures on GPU clusters with community templates
+  - Run a Nuclei job in CI against preview URLs for agent and RAG services
+  - Author custom YAML templates for auth bypasses unique to an AI admin panel

--- a/tools/dev-tools/quarkus.yaml
+++ b/tools/dev-tools/quarkus.yaml
@@ -1,0 +1,25 @@
+name: Quarkus
+description: Kubernetes-native Java framework built for GraalVM and HotSpot. Quarkus boots fast and uses little RSS, so JVM teams can ship model-serving APIs, RAG services, and agent workers as containers without Spring-sized startup cost.
+tagline: Kubernetes-native Java framework for fast, small services
+
+github_url: https://github.com/quarkusio/quarkus
+website_url: https://quarkus.io
+docs_url: https://quarkus.io/guides/
+
+category: Dev Tools
+tags: [java, quarkus, kubernetes, graalvm, jvm, microservices]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  JVM AI services often sit behind Kubernetes and need fast scale-to-zero,
+  but traditional Java frameworks start slowly and waste memory per replica.
+  Quarkus plus optional native images cuts startup and RSS so inference
+  gateways and RAG APIs scale like other cloud-native workers.
+
+use_cases:
+  - Serve reactive HTTP APIs in front of LLM or embedding backends on the JVM
+  - Compile a GraalVM native image for a low-memory model-gateway container
+  - Use Quarkus extensions for Kafka, REST, and OpenTelemetry around AI pipelines
+  - Run JVM agent workers on Kubernetes with fast pod startup


### PR DESCRIPTION
Add Google Test, Quarkus, MkDocs, and Nuclei to the Agentic AI For Good catalog.

- Google Test: C++ testing and mocking framework (BSD-3-Clause)
- Quarkus: Kubernetes-native Java framework (Apache-2.0)
- MkDocs: Markdown static documentation generator (BSD-2-Clause)
- Nuclei: YAML-template vulnerability scanner (MIT)

All entries validated locally with scripts/validate-tool.ts.
