### PR TITLE
Add Docusaurus, Expo, nvm, Catch2, MiniRAG to catalog

### DIFF
--- a/tools/dev-tools/catch2.yaml
+++ b/tools/dev-tools/catch2.yaml
@@ -1,0 +1,25 @@
+name: Catch2
+description: Modern C++ test framework for unit tests, TDD, and BDD. Catch2 uses a header-friendly design, sections, and matchers so native inference, tokenizer, and CUDA-wrapper libraries get readable tests without a heavy xUnit setup.
+tagline: Modern C++ unit-test framework for TDD and BDD
+
+github_url: https://github.com/catchorg/Catch2
+website_url: https://github.com/catchorg/Catch2
+docs_url: https://github.com/catchorg/Catch2/blob/devel/docs/Readme.md
+
+category: Dev Tools
+tags: [cpp, testing, tdd, bdd, native, unit-tests]
+pricing: free
+is_open_source: true
+license: BSL-1.0
+
+problem_solved: |
+  Native ML libraries need tests that stay close to the code, but older C++
+  frameworks are verbose and painful to bootstrap. Catch2 lets you write
+  TEST_CASE and SECTION blocks with string names and matchers so kernels,
+  parsers, and FFI shims fail in CI with readable output.
+
+use_cases:
+  - Unit-test C++ tokenizers, GGML-style kernels, and serialization helpers
+  - Use sections to share setup across numeric edge cases and dtypes
+  - Generate JUnit XML from Catch2 for native ML library CI
+  - BDD-style REQUIRE assertions in headers of a small inference SDK

--- a/tools/dev-tools/docusaurus.yaml
+++ b/tools/dev-tools/docusaurus.yaml
@@ -1,0 +1,26 @@
+name: Docusaurus
+description: Easy-to-maintain open source documentation websites powered by React and MDX. AI teams publish SDK docs, model cards, and changelogs as versioned static sites with search, versioning, and blog support from Markdown in git.
+tagline: React-powered documentation sites from Markdown
+
+github_url: https://github.com/facebook/docusaurus
+website_url: https://docusaurus.io
+docs_url: https://docusaurus.io/docs
+install_command: npm install @docusaurus/core
+
+category: Dev Tools
+tags: [documentation, react, markdown, static-site, mdx, docs]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  SDK and model docs often live in Notion or a stale GitBook that drifts from
+  the repo. Docusaurus builds versioned, searchable sites from Markdown and
+  MDX in git so API references, changelogs, and tutorials ship with every
+  release of an AI product.
+
+use_cases:
+  - Publish versioned docs for an inference SDK or agent framework
+  - Host model cards, eval reports, and changelog blog posts next to the code
+  - Add Algolia or local search so developers find RAG and API recipes fast
+  - Localize product docs for a multi-region AI platform

--- a/tools/dev-tools/expo.yaml
+++ b/tools/dev-tools/expo.yaml
@@ -1,0 +1,26 @@
+name: Expo
+description: Open-source framework for universal React Native apps on Android, iOS, and web. Expo supplies a managed toolchain, over-the-air updates, and native APIs so AI chat and camera apps ship without ejecting into Xcode and Android Studio on day one.
+tagline: Universal React Native apps with a managed toolchain
+
+github_url: https://github.com/expo/expo
+website_url: https://expo.dev
+docs_url: https://docs.expo.dev
+install_command: npm install expo
+
+category: Dev Tools
+tags: [expo, react-native, mobile, ios, android, javascript]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  React Native still demands native build tooling that slows AI product
+  teams who just need camera, notifications, and a JS client. Expo wraps
+  that in a managed workflow, EAS builds, and OTA updates so chat and
+  multimodal apps iterate without a full native release every time.
+
+use_cases:
+  - Scaffold a mobile AI chat or copilot app with Expo Router and camera APIs
+  - Push over-the-air JS updates to a production inference client
+  - Access microphone, filesystem, and notifications for multimodal capture
+  - Build iOS, Android, and web from one Expo project talking to a RAG backend

--- a/tools/dev-tools/nvm.yaml
+++ b/tools/dev-tools/nvm.yaml
@@ -1,0 +1,26 @@
+name: nvm
+description: Node Version Manager, a POSIX shell script that installs and switches multiple Node.js versions per user. ML and frontend teams pin Node for Next.js AI apps, MCP servers, and JS SDKs without fighting a single system-wide install.
+tagline: Per-user Node.js version manager for POSIX shells
+
+github_url: https://github.com/nvm-sh/nvm
+website_url: https://github.com/nvm-sh/nvm
+docs_url: https://github.com/nvm-sh/nvm#installing-and-updating
+install_command: brew install nvm
+
+category: Dev Tools
+tags: [node, javascript, version-manager, shell, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI web apps, MCP servers, and JS SDKs pin different Node versions, and a
+  single system Node breaks CI and laptops. nvm installs isolated Node and
+  npm trees per user so each project uses the version in .nvmrc without
+  sudo or containers.
+
+use_cases:
+  - Pin Node versions for Next.js AI dashboards via .nvmrc
+  - Switch Node quickly when testing MCP servers across LTS lines
+  - Install Node in CI images without baking a single global version
+  - Keep per-project npm global CLIs off the system Node

--- a/tools/rag/minirag.yaml
+++ b/tools/rag/minirag.yaml
@@ -1,0 +1,26 @@
+name: MiniRAG
+description: RAG framework from HKUDS that targets small, open-source language models. MiniRAG simplifies heterogeneous graph indexing and retrieval so on-device or edge RAG works without a large cloud LLM as the only reasoner.
+tagline: Simpler RAG for small and open-source language models
+
+github_url: https://github.com/HKUDS/MiniRAG
+website_url: https://arxiv.org/abs/2501.06713
+docs_url: https://github.com/HKUDS/MiniRAG
+install_command: pip install minirag-hku
+
+category: RAG
+tags: [rag, retrieval, small-models, graph, python, edge]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Most RAG stacks assume a large cloud LLM to stitch retrieved chunks.
+  On-device and edge apps cannot afford that. MiniRAG designs indexing and
+  retrieval for small open models so heterogeneous knowledge still answers
+  questions without a 70B-class reasoner.
+
+use_cases:
+  - Run RAG on a small open model for a private or on-device assistant
+  - Index heterogeneous notes and docs when GraphRAG-scale models are too heavy
+  - Prototype edge retrieval before promoting a corpus to a larger RAG stack
+  - Compare small-model RAG quality against LightRAG-style baselines


### PR DESCRIPTION
Add Docusaurus, Expo, nvm, Catch2, and MiniRAG to the Agentic AI For Good catalog.

- Docusaurus: React documentation sites from Markdown (MIT)
- Expo: managed React Native toolchain (MIT)
- nvm: Node.js version manager (MIT)
- Catch2: modern C++ test framework (BSL-1.0)
- MiniRAG: RAG for small open-source language models (MIT)

All entries validated locally with scripts/validate-tool.ts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Catch2, Docusaurus, Expo, and nvm to the developer tools catalog.
  - Added MiniRAG to the retrieval-augmented generation tools catalog.
  - Included descriptions, links, licensing, installation details, categories, tags, and practical use cases for each listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->