### PR TITLE
Add testify, Pest, OWASP ZAP, Dropwizard, Micronaut to catalog

### DIFF
--- a/tools/dev-tools/dropwizard.yaml
+++ b/tools/dev-tools/dropwizard.yaml
@@ -1,0 +1,21 @@
+name: Dropwizard
+description: Opinionated Java library for production REST services. Dropwizard bundles Jetty, Jersey, Jackson, Metrics, and validation so JVM teams can ship model-serving APIs and agent backends with logging, health checks, and config out of the box.
+tagline: Production-ready REST services on the JVM
+github_url: https://github.com/dropwizard/dropwizard
+website_url: https://www.dropwizard.io
+docs_url: https://www.dropwizard.io/en/stable/getting-started.html
+category: Dev Tools
+tags: [java, dropwizard, rest, jvm, microservices, jetty, jersey]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  JVM teams wrapping LLMs still assemble Jetty, JSON, metrics, and YAML
+  config by hand. Dropwizard packages those into one service so inference
+  APIs and agent workers get health checks, structured logs, and validation
+  without a custom framework.
+use_cases:
+  - Serve Jersey REST APIs in front of LLM or embedding backends on the JVM
+  - Expose Dropwizard Metrics and health checks for a Java model gateway
+  - Validate YAML config for agent workers before they start
+  - Package a RAG or feature-store adapter as a Dropwizard application

--- a/tools/dev-tools/micronaut.yaml
+++ b/tools/dev-tools/micronaut.yaml
@@ -1,0 +1,21 @@
+name: Micronaut
+description: JVM framework for microservices and serverless with compile-time DI and AOT. Micronaut starts fast and uses little memory, so Java and Kotlin teams can run inference gateways, RAG APIs, and agent workers as small containers.
+tagline: Fast, low-memory JVM framework for microservices
+github_url: https://github.com/micronaut-projects/micronaut-core
+website_url: https://micronaut.io
+docs_url: https://docs.micronaut.io
+category: Dev Tools
+tags: [java, kotlin, micronaut, jvm, microservices, graalvm, aot]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Reflection-heavy Java frameworks start slowly and burn RAM per replica,
+  which hurts scale-to-zero for model gateways. Micronaut does DI and AOP
+  at compile time so Java and Kotlin inference APIs boot fast, fit GraalVM
+  native images, and run as small Kubernetes workers.
+use_cases:
+  - Serve HTTP APIs in front of LLM or embedding backends on Java or Kotlin
+  - Compile a GraalVM native image for a low-memory model-gateway container
+  - Run Micronaut serverless functions that wrap agent tool handlers
+  - Use Micronaut Data and HTTP clients around RAG and feature pipelines

--- a/tools/dev-tools/owasp-zap.yaml
+++ b/tools/dev-tools/owasp-zap.yaml
@@ -1,0 +1,21 @@
+name: OWASP ZAP
+description: Open-source web application security scanner from the OWASP and Checkmarx community. ZAP intercepts HTTP, spiders apps, and runs active and passive scans so AI-powered web UIs, agent APIs, and model gateways get DAST coverage before production.
+tagline: Open-source DAST scanner for web apps and APIs
+github_url: https://github.com/zaproxy/zaproxy
+website_url: https://www.zaproxy.org
+docs_url: https://www.zaproxy.org/docs/
+category: Dev Tools
+tags: [security, dast, owasp, zap, scanning, api, web]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  LLM chat UIs and agent APIs ship XSS, injection, and auth gaps that unit
+  tests never hit. OWASP ZAP proxies traffic, crawls the surface, and runs
+  active plus passive rules so prompt endpoints and tool webhooks get DAST
+  findings in CI before they reach users.
+use_cases:
+  - Spider and actively scan a chat or agent web UI for XSS and injection
+  - Proxy OpenAPI model-gateway traffic and run ZAP API scan in CI
+  - Baseline-scan staging RAG dashboards for missing headers and CSRF
+  - Intercept browser sessions to find auth issues on AI admin consoles

--- a/tools/dev-tools/pest.yaml
+++ b/tools/dev-tools/pest.yaml
@@ -1,0 +1,22 @@
+name: Pest
+description: Elegant PHP testing framework with an expressive API, architecture tests, and first-class parallel runs. Pest wraps PHPUnit so Laravel and Symfony apps that call LLMs, webhooks, and RAG backends get readable tests without boilerplate.
+tagline: Elegant testing framework for PHP
+github_url: https://github.com/pestphp/pest
+website_url: https://pestphp.com
+docs_url: https://pestphp.com/docs
+install_command: composer require pestphp/pest --dev --with-all-dependencies
+category: Dev Tools
+tags: [php, testing, pest, phpunit, laravel, unit-tests]
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: |
+  PHPUnit tests for PHP AI backends are verbose, so teams skip coverage on
+  webhook and inference wrappers. Pest keeps PHPUnit under the hood but uses
+  a describe-it API, expectations, and parallel runs so Laravel LLM features
+  fail the PR with readable output instead of production incidents.
+use_cases:
+  - Write expectation-style tests for Laravel jobs that call OpenAI or embeddings
+  - Architecture-test that agent controllers stay thin and stay in the right layer
+  - Run PHP test suites in parallel in CI for RAG and webhook backends
+  - Snapshot JSON responses from PHP model-gateway routes

--- a/tools/dev-tools/testify.yaml
+++ b/tools/dev-tools/testify.yaml
@@ -1,0 +1,22 @@
+name: testify
+description: A Go testing toolkit with assertions, mocks, and suites that sits on the standard testing package. testify is the default assertion library for Go services that wrap model APIs, gRPC inference clients, and agent workers.
+tagline: Assertions, mocks, and suites for Go tests
+github_url: https://github.com/stretchr/testify
+website_url: https://pkg.go.dev/github.com/stretchr/testify
+docs_url: https://pkg.go.dev/github.com/stretchr/testify
+install_command: go get github.com/stretchr/testify
+category: Dev Tools
+tags: [go, testing, assertions, mocks, testify, unit-tests]
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: |
+  Go's testing package has no rich assertions or mocks, so AI backends end up
+  with brittle if-err boilerplate and hand-rolled doubles. testify adds require
+  and assert helpers plus mock and suite types so inference clients, tool
+  handlers, and agent workers fail fast with readable diffs in CI.
+use_cases:
+  - Assert JSON payloads and error wrapping in Go model-serving HTTP handlers
+  - Mock gRPC or HTTP neighbors when testing agent tool-call adapters
+  - Group related tests into testify suites for embedding and vector clients
+  - Require exact status codes and error strings in LLM gateway integration tests


### PR DESCRIPTION
## Add 5 Dev Tools to the catalog

- **testify** — Go assertions/mocks on `testing` (stretchr/testify, MIT, 26k★)
- **Pest** — Elegant PHP testing framework on PHPUnit (pestphp/pest, MIT, 11k★)
- **OWASP ZAP** — Web app security scanner (zaproxy/zaproxy, Apache-2.0, 15k★)
- **Dropwizard** — Opinionated Java REST stack (dropwizard/dropwizard, Apache-2.0, 8.5k★)
- **Micronaut** — Compile-time DI JVM framework (micronaut-projects/micronaut-core, Apache-2.0, 6.4k★)

All five validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added five tools to the Dev Tools catalog:
    - Dropwizard and Micronaut for JVM application development.
    - OWASP ZAP for web and API security testing.
    - Pest for expressive PHP testing.
    - Testify for Go testing.
  - Each entry includes descriptions, links, licensing and pricing details, tags, and practical use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->