### PR TITLE
Add Kotest, dprint, procs, TestNG to catalog

### DIFF
--- a/tools/dev-tools/dprint.yaml
+++ b/tools/dev-tools/dprint.yaml
@@ -1,0 +1,26 @@
+name: dprint
+description: Pluggable code formatting platform written in Rust. dprint unifies TypeScript, JSON, Markdown, and TOML formatters behind one config so AI repos keep diffs clean without running a different formatter per language.
+tagline: Pluggable, configurable code formatting platform
+
+github_url: https://github.com/dprint/dprint
+website_url: https://dprint.dev
+docs_url: https://dprint.dev/overview/
+install_command: brew install dprint
+
+category: Dev Tools
+tags: [formatting, rust, cli, typescript, json, markdown]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Polyglot AI repos mix TypeScript, JSON, Markdown, and config files, so
+  teams juggle Prettier, language-specific formatters, and noisy diffs.
+  dprint is a fast Rust host with plugins and one config so every language
+  in the repo formats the same way in CI and on save.
+
+use_cases:
+  - Format TypeScript agent UIs and JSON tool schemas with one dprint config
+  - Run dprint in CI so Markdown docs and YAML catalogs stay style-clean
+  - Plug in TOML and Markdown formatters for ML experiment configs
+  - Replace slower Node formatters on large monorepos with a Rust CLI

--- a/tools/dev-tools/kotest.yaml
+++ b/tools/dev-tools/kotest.yaml
@@ -1,0 +1,25 @@
+name: Kotest
+description: Kotlin test framework with assertions, property testing, and data-driven tests. Kotest runs on JUnit and multiplatform targets so JVM AI services, Kotlin clients, and Android apps around model APIs get expressive tests without Java-only JUnit style.
+tagline: Powerful test framework for Kotlin
+
+github_url: https://github.com/kotest/kotest
+website_url: https://kotest.io
+docs_url: https://kotest.io/docs/quickstart
+
+category: Dev Tools
+tags: [kotlin, testing, kotest, junit, property-testing, jvm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Kotlin AI backends still need assertions and property tests, but JUnit
+  APIs feel Java-first and skip generators. Kotest adds matchers, property
+  testing, and data-driven specs so inference clients and agent workers on
+  the JVM fail with readable Kotlin-native output in CI.
+
+use_cases:
+  - Write spec-style tests for Kotlin wrappers around LLM and embedding APIs
+  - Property-test serializers for prompt payloads and tool-call JSON
+  - Data-drive tests across model versions and fixture prompts
+  - Run Kotest on JVM CI for Android or KMP apps that call inference backends

--- a/tools/dev-tools/procs.yaml
+++ b/tools/dev-tools/procs.yaml
@@ -1,0 +1,26 @@
+name: procs
+description: Modern replacement for ps written in Rust. procs adds color, tree view, and keyword search so ML engineers can find runaway Python, Node, or GPU-adjacent processes faster than scanning a raw process table.
+tagline: Modern, colorful replacement for ps
+
+github_url: https://github.com/dalance/procs
+website_url: https://github.com/dalance/procs
+docs_url: https://github.com/dalance/procs#readme
+install_command: brew install procs
+
+category: Dev Tools
+tags: [cli, rust, processes, devops, monitoring, ps]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Training and inference jobs leak workers, and classic ps output is hard
+  to scan on a busy GPU box. procs colors columns, shows process trees,
+  and filters by keyword so you can find a stuck dataloader or zombie
+  Python worker without piping through grep.
+
+use_cases:
+  - Find runaway Python training or eval processes by name on a workstation
+  - Show a process tree for a local agent runtime and its child workers
+  - Watch RSS and CPU for Node MCP servers during long tool-call sessions
+  - Replace ps on macOS and Linux jump hosts with a readable table

--- a/tools/dev-tools/testng.yaml
+++ b/tools/dev-tools/testng.yaml
@@ -1,0 +1,25 @@
+name: TestNG
+description: Flexible Java testing framework with annotations, groups, parallel runs, and data providers. TestNG covers more than unit tests so JVM teams can run integration suites for model-serving APIs, agent workers, and data pipelines in CI.
+tagline: Flexible testing framework for Java
+
+github_url: https://github.com/testng-team/testng
+website_url: https://testng.org
+docs_url: https://testng.org
+
+category: Dev Tools
+tags: [java, testing, testng, jvm, integration-tests, parallel]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  JUnit is great for isolated units, but JVM AI platforms also need groups,
+  dependencies, and parallel integration suites. TestNG adds those knobs so
+  model-gateway, queue, and database tests can run as named groups in CI
+  without a custom runner.
+
+use_cases:
+  - Group and parallel-run Java integration tests for model-serving APIs
+  - Data-provide prompt fixtures across TestNG methods for inference clients
+  - Depend integration tests on a shared Testcontainers setup for vector DBs
+  - Produce TestNG XML reports for JVM agent-worker pipelines in CI


### PR DESCRIPTION
## Add 4 Dev Tools to the catalog

- **Kotest** — Kotlin test framework (kotest/kotest, Apache-2.0, 4.7k★)
- **dprint** — Pluggable Rust code formatter (dprint/dprint, MIT, 4.0k★)
- **procs** — Modern `ps` replacement in Rust (dalance/procs, MIT, 6.1k★)
- **TestNG** — Flexible Java testing framework (testng-team/testng, Apache-2.0, 2.0k★)

All four validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for dprint, Kotest, procs, and TestNG.
  * Included descriptions, links, installation details, categories, tags, licensing, pricing, problem statements, and practical use cases for each developer tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->