### PR TITLE
Add MockK, AssertJ, Hamcrest, Spock, ArchUnit to catalog

### DIFF
--- a/tools/dev-tools/archunit.yaml
+++ b/tools/dev-tools/archunit.yaml
@@ -1,0 +1,25 @@
+name: ArchUnit
+description: Java architecture test library that asserts package, class, and dependency rules in plain unit tests. ArchUnit keeps JVM AI codebases from leaking domain logic into adapters, so model gateways and agent modules stay layered as the team grows.
+tagline: Architecture tests as unit tests for Java
+
+github_url: https://github.com/TNG/ArchUnit
+website_url: https://www.archunit.org
+docs_url: https://www.archunit.org/userguide/html/userguide.html
+
+category: Dev Tools
+tags: [java, architecture, testing, archunit, jvm, static-analysis]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Layered JVM AI services rot as inference clients, webhooks, and domain
+  code start importing each other. ArchUnit encodes package and dependency
+  rules as tests so a PR fails when agent adapters leak into the core
+  instead of waiting for a review comment.
+
+use_cases:
+  - Forbid domain packages from depending on LLM SDK adapters
+  - Keep agent webhook controllers out of the core inference module
+  - Enforce layered rules for RAG ingest versus serving code
+  - Run ArchUnit in JUnit CI so architecture regressions fail the build

--- a/tools/dev-tools/assertj.yaml
+++ b/tools/dev-tools/assertj.yaml
@@ -1,0 +1,25 @@
+name: AssertJ
+description: Fluent assertion library for Java and the JVM. AssertJ gives readable, chained matchers so tests for model-serving APIs, JSON payloads, and collections fail with diffs instead of opaque JUnit equals errors.
+tagline: Fluent assertions for Java and the JVM
+
+github_url: https://github.com/assertj/assertj
+website_url: https://assertj.github.io/doc/
+docs_url: https://assertj.github.io/doc/
+
+category: Dev Tools
+tags: [java, testing, assertions, assertj, jvm, junit]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  JUnit assertEquals dumps raw values when JSON, lists, or optionals from
+  AI backends mismatch. AssertJ fluent assertions and extracting helpers
+  produce readable diffs so model-gateway and agent-worker tests show
+  exactly which field broke.
+
+use_cases:
+  - Assert JSON and collection payloads from Java model-serving handlers
+  - Extract nested fields from tool-call responses in JUnit tests
+  - Soft-assert several properties on an embedding client result
+  - Compare exception messages from LLM gateway error mappers

--- a/tools/dev-tools/hamcrest.yaml
+++ b/tools/dev-tools/hamcrest.yaml
@@ -1,0 +1,25 @@
+name: Hamcrest
+description: Matcher library for Java tests and production code. Hamcrest combinators describe expected objects in English-like matchers so JUnit and TestNG suites for JVM AI services stay readable as payloads grow nested.
+tagline: Matcher library for declarative Java tests
+
+github_url: https://github.com/hamcrest/JavaHamcrest
+website_url: https://hamcrest.org
+docs_url: https://hamcrest.org/JavaHamcrest/tutorial
+
+category: Dev Tools
+tags: [java, testing, matchers, hamcrest, junit, jvm]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Nested JSON and collection checks in JVM AI tests become unreadable
+  boolean piles. Hamcrest matchers compose hasItem, hasProperty, and
+  equalTo so inference-client and agent-API tests state intent instead
+  of manual field walking.
+
+use_cases:
+  - Match nested fields in Java model-gateway JSON with hasProperty
+  - Combine collection matchers for batches of embedding vectors
+  - Plug Hamcrest into JUnit assertThat for agent webhook payloads
+  - Reuse custom matchers across TestNG integration suites

--- a/tools/dev-tools/mockk.yaml
+++ b/tools/dev-tools/mockk.yaml
@@ -1,0 +1,25 @@
+name: MockK
+description: Mocking library built for Kotlin. MockK supports coroutines, extension functions, and relaxed mocks so Kotlin AI clients, agent workers, and Android apps can unit-test inference adapters without Java Mockito friction.
+tagline: Kotlin-first mocking library
+
+github_url: https://github.com/mockk/mockk
+website_url: https://mockk.io
+docs_url: https://mockk.io/documentation.html
+
+category: Dev Tools
+tags: [kotlin, testing, mocking, mockk, jvm, coroutines]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Mockito does not map cleanly onto Kotlin coroutines, objects, or
+  extension functions, so tests for JVM AI clients stay brittle. MockK
+  mocks those Kotlin constructs so inference wrappers and agent workers
+  can isolate HTTP and gRPC neighbors in unit tests.
+
+use_cases:
+  - Mock coroutine LLM clients when unit-testing Kotlin agent workers
+  - Relaxed-mock Android or KMP UI layers that call embedding APIs
+  - Stub extension functions around vector-store helpers in Kotest specs
+  - Verify tool-call adapters without hitting a live model gateway

--- a/tools/dev-tools/spock.yaml
+++ b/tools/dev-tools/spock.yaml
@@ -1,0 +1,25 @@
+name: Spock
+description: Enterprise-ready testing and specification framework for Java and Groovy. Spock uses given-when-then specs, data tables, and mocks so JVM teams can document and test model-serving APIs without a pile of JUnit boilerplate.
+tagline: BDD-style testing framework for the JVM
+
+github_url: https://github.com/spockframework/spock
+website_url: https://spockframework.org
+docs_url: https://spockframework.org/spock/docs/current/index.html
+
+category: Dev Tools
+tags: [java, groovy, testing, spock, bdd, jvm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  JUnit tests for JVM AI services rarely read as specifications, so
+  reviewers miss intended behavior. Spock given-when-then blocks, data
+  tables, and built-in mocks turn inference and agent-API cases into
+  executable specs that CI still runs.
+
+use_cases:
+  - Specify Java model-gateway behavior with given-when-then Spock tests
+  - Data-table prompt fixtures across Groovy specs for an LLM client
+  - Mock HTTP neighbors while testing agent tool-call adapters
+  - Run Spock as the JUnit engine for mixed Java and Groovy AI modules


### PR DESCRIPTION
## Add 5 Dev Tools to the catalog

- **MockK** — Kotlin mocking library (mockk/mockk, Apache-2.0, 5.7k★)
- **AssertJ** — Fluent JVM assertions (assertj/assertj, Apache-2.0, 2.8k★)
- **Hamcrest** — Java matcher library (hamcrest/JavaHamcrest, BSD-3-Clause, 2.1k★)
- **Spock** — BDD testing for Java/Groovy (spockframework/spock, Apache-2.0, 3.6k★)
- **ArchUnit** — Java architecture tests (TNG/ArchUnit, Apache-2.0, 3.8k★)

All five validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Tools**
  - Added catalog entries for ArchUnit, AssertJ, Hamcrest, MockK, and Spock.
  - Included descriptions, documentation links, licensing and pricing details, supported technologies, and relevant testing use cases.
  - Expanded developer-tool coverage for Java, Kotlin, and Groovy testing workflows, including architecture testing, assertions, mocking, and behavior-driven specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->