### PR TITLE
Add Detekt, ktlint, SpotBugs, SwiftLint to catalog

### DIFF
--- a/tools/dev-tools/detekt.yaml
+++ b/tools/dev-tools/detekt.yaml
@@ -1,0 +1,25 @@
+name: Detekt
+description: Static analysis for Kotlin with complexity, style, and potential-bug rules. Detekt plugs into Gradle and CI so Kotlin AI clients, Android apps, and KMP modules around model APIs stay consistent before merge.
+tagline: Static code analysis for Kotlin
+
+github_url: https://github.com/detekt/detekt
+website_url: https://detekt.dev
+docs_url: https://detekt.dev/docs/intro
+install_command: brew install detekt
+
+category: Dev Tools
+tags: [kotlin, lint, static-analysis, detekt, gradle, code-quality]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Kotlin AI codebases accumulate complexity and style drift that compilers
+  do not catch. Detekt runs rule sets in Gradle and CI so inference clients
+  and agent workers fail the PR on smells instead of a later review.
+
+use_cases:
+  - Lint Kotlin LLM client modules in Gradle CI with Detekt rule sets
+  - Fail PRs on complexity spikes in agent orchestration code
+  - Format-adjacent style checks for Android apps that call embeddings
+  - Baseline existing issues then ratchet quality on new Kotlin AI code

--- a/tools/dev-tools/ktlint.yaml
+++ b/tools/dev-tools/ktlint.yaml
@@ -1,0 +1,25 @@
+name: ktlint
+description: Anti-bikeshedding Kotlin linter with a built-in formatter. ktlint enforces a single style so Kotlin AI services, Gradle scripts, and Android modules stop arguing about braces and stay CI-clean.
+tagline: Kotlin linter and formatter
+
+github_url: https://github.com/ktlint/ktlint
+website_url: https://ktlint.github.io
+docs_url: https://ktlint.github.io
+install_command: brew install ktlint
+
+category: Dev Tools
+tags: [kotlin, lint, formatting, ktlint, cli, code-quality]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Kotlin teams waste review time on style, and mixed IntelliJ settings
+  produce noisy diffs in AI client PRs. ktlint applies one official-ish
+  style plus a formatter so CI fails on format, not on taste.
+
+use_cases:
+  - Format Kotlin model-gateway and agent-worker modules on save
+  - Run ktlintCheck in Gradle CI for Android apps that call LLMs
+  - Standardize style across a KMP repo that shares inference clients
+  - Auto-fix style in pre-commit for Kotlin data and prompt helpers

--- a/tools/dev-tools/spotbugs.yaml
+++ b/tools/dev-tools/spotbugs.yaml
@@ -1,0 +1,24 @@
+name: SpotBugs
+description: Static analysis successor to FindBugs for Java bytecode. SpotBugs looks for null, concurrency, and security bugs so JVM model-serving APIs and agent workers fail CI on real defect patterns, not just style.
+tagline: FindBugs successor for Java static analysis
+
+github_url: https://github.com/spotbugs/spotbugs
+website_url: https://spotbugs.github.io
+docs_url: https://spotbugs.readthedocs.io
+
+category: Dev Tools
+tags: [java, static-analysis, spotbugs, findbugs, security, jvm]
+pricing: free
+is_open_source: true
+license: LGPL-2.1
+
+problem_solved: |
+  Compilers miss null, resource, and concurrency bugs in JVM AI services.
+  SpotBugs scans bytecode for those patterns so model gateways and queue
+  workers fail the build on defect detectors instead of production NPEs.
+
+use_cases:
+  - Scan Java model-serving bytecode for null and resource leaks in CI
+  - Catch concurrency bugs in agent worker thread pools
+  - Enable security detectors on JVM code that handles API keys
+  - Plug SpotBugs into Maven or Gradle for RAG ingest services

--- a/tools/dev-tools/swiftlint.yaml
+++ b/tools/dev-tools/swiftlint.yaml
@@ -1,0 +1,25 @@
+name: SwiftLint
+description: Linter that enforces Swift style and conventions. SwiftLint plugs into Xcode and CI so iOS and macOS apps that wrap on-device or cloud models stay consistent as teams ship agent UIs and inference clients.
+tagline: Enforce Swift style and conventions
+
+github_url: https://github.com/realm/SwiftLint
+website_url: https://realm.github.io/SwiftLint
+docs_url: https://realm.github.io/SwiftLint
+install_command: brew install swiftlint
+
+category: Dev Tools
+tags: [swift, lint, ios, macos, xcode, code-quality]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Swift AI apps mix UI, networking, and model clients, and style drift
+  slows reviews. SwiftLint encodes conventions as rules so Xcode and CI
+  fail on violations instead of arguing about naming in pull requests.
+
+use_cases:
+  - Lint iOS chat or agent UIs that call cloud LLM APIs
+  - Run SwiftLint in CI for macOS apps wrapping on-device models
+  - Custom-rule naming for inference client types in a Swift package
+  - Autocorrect style on save in Xcode for mixed UI and ML modules


### PR DESCRIPTION
## Add 4 Dev Tools to the catalog

- **Detekt** — Kotlin static analysis (detekt/detekt, Apache-2.0, 7.0k★)
- **ktlint** — Kotlin linter and formatter (ktlint/ktlint, MIT, 6.7k★)
- **SpotBugs** — Java bytecode static analysis (spotbugs/spotbugs, LGPL-2.1, 3.9k★)
- **SwiftLint** — Swift style linter (realm/SwiftLint, MIT, 19.7k★)

All four validated locally with `scripts/validate-tool.ts`.
