### PR TITLE
Add Checkstyle, PMD, Error Prone, sbt, Pitest to catalog

### DIFF
--- a/tools/dev-tools/checkstyle.yaml
+++ b/tools/dev-tools/checkstyle.yaml
@@ -1,0 +1,25 @@
+name: Checkstyle
+description: Java source static analysis that enforces coding standards. Checkstyle ships Google Java Style and Sun conventions so JVM model-serving APIs and agent backends fail CI on style, imports, and complexity instead of waiting for review.
+tagline: Enforce Java coding standards in CI
+
+github_url: https://github.com/checkstyle/checkstyle
+website_url: https://checkstyle.org
+docs_url: https://checkstyle.org
+
+category: Dev Tools
+tags: [java, static-analysis, checkstyle, lint, jvm, ci]
+pricing: free
+is_open_source: true
+license: LGPL-2.1
+
+problem_solved: |
+  JVM AI services drift from team style when reviews are the only gate.
+  Checkstyle runs as a Maven, Gradle, or CLI check so model gateways and
+  agent workers fail the build on naming, import, and complexity rules
+  before merge, not after a late style nit.
+
+use_cases:
+  - Enforce Google Java Style on model-serving Spring Boot APIs in CI
+  - Fail PRs that exceed complexity limits in agent worker classes
+  - Standardize imports and naming across a multi-module JVM RAG backend
+  - Run Checkstyle from Maven or Gradle as a required quality gate

--- a/tools/dev-tools/error-prone.yaml
+++ b/tools/dev-tools/error-prone.yaml
@@ -1,0 +1,25 @@
+name: Error Prone
+description: javac plugin from Google that turns common Java mistakes into compile-time errors. Error Prone catches null, equals, and concurrency bugs so JVM model APIs fail the build instead of crashing in production.
+tagline: Catch Java mistakes as compile-time errors
+
+github_url: https://github.com/google/error-prone
+website_url: https://errorprone.info
+docs_url: https://errorprone.info
+
+category: Dev Tools
+tags: [java, static-analysis, error-prone, javac, google, jvm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Many Java bugs only show up after a model gateway is live. Error Prone
+  plugs into javac and rejects buggy patterns at compile time, so JVM
+  agent workers and serving APIs never ship equals, null, or lock bugs
+  that a green unit test would miss.
+
+use_cases:
+  - Fail compilation on null and equals bugs in Java inference APIs
+  - Catch concurrency mistakes in agent worker thread pools
+  - Add custom Error Prone checks for internal JVM ML libraries
+  - Enable Error Prone in Maven or Bazel builds for RAG backends

--- a/tools/dev-tools/pitest.yaml
+++ b/tools/dev-tools/pitest.yaml
@@ -1,0 +1,25 @@
+name: Pitest
+description: Mutation testing for the JVM that rewrites bytecode and reruns tests. Pitest shows which tests actually catch faults so Java model-serving APIs and agent workers do not ship coverage that never fails.
+tagline: Mutation testing for JVM test suites
+
+github_url: https://github.com/hcoles/pitest
+website_url: https://pitest.org
+docs_url: https://pitest.org
+
+category: Dev Tools
+tags: [java, mutation-testing, pitest, testing, jvm, ci]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Line coverage on JVM AI services can look high while tests never assert
+  real behavior. Pitest mutates bytecode and reruns the suite so weak
+  tests on model gateways and agent workers fail CI instead of hiding
+  behind a green coverage report.
+
+use_cases:
+  - Measure whether Java inference API tests catch real faults
+  - Fail CI when mutation score drops on agent worker modules
+  - Find untested branches in JVM RAG ingest and scoring code
+  - Plug Pitest into Maven or Gradle as a mutation-testing gate

--- a/tools/dev-tools/pmd.yaml
+++ b/tools/dev-tools/pmd.yaml
@@ -1,0 +1,25 @@
+name: PMD
+description: Extensible multilanguage static analyzer for Java, Apex, and related JVM sources. PMD finds unused code, empty catches, and copy-paste so AI backends fail CI on defect patterns, not only compiler errors.
+tagline: Multilanguage static analysis for JVM code
+
+github_url: https://github.com/pmd/pmd
+website_url: https://pmd.github.io
+docs_url: https://docs.pmd-code.org
+
+category: Dev Tools
+tags: [java, static-analysis, pmd, jvm, lint, ci]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Compilers miss unused variables, empty catch blocks, and duplicated
+  logic in JVM inference services. PMD scans source with built-in and
+  custom rules so agent workers and RAG ingest jobs fail the build on
+  those patterns instead of shipping dead or risky code.
+
+use_cases:
+  - Scan Java model-serving code for unused locals and empty catch blocks
+  - Detect copy-paste across multi-module JVM agent backends
+  - Add custom PMD rules for API-key handling in inference gateways
+  - Run PMD as a Maven or Gradle quality gate in CI

--- a/tools/dev-tools/sbt.yaml
+++ b/tools/dev-tools/sbt.yaml
@@ -1,0 +1,27 @@
+name: sbt
+description: Interactive build tool for Scala and JVM projects. sbt compiles, tests, and packages Scala ML libraries with incremental compilation, a REPL, and plugin ecosystem used across Spark and LLM Scala stacks.
+tagline: Interactive build tool for Scala projects
+
+github_url: https://github.com/sbt/sbt
+website_url: https://www.scala-sbt.org
+docs_url: https://www.scala-sbt.org/documentation.html
+
+install_command: brew install sbt
+
+category: Dev Tools
+tags: [scala, build, sbt, jvm, spark, ci]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Scala ML libraries and Spark jobs need incremental compile, test, and
+  publish that generic JVM builds do not express well. sbt's task graph,
+  REPL, and plugins compile multi-module Scala projects without a full
+  rebuild on every model-SDK change.
+
+use_cases:
+  - Build and test Scala Spark feature pipelines with incremental sbt tasks
+  - Publish versioned Scala libraries used by JVM agent backends
+  - Run a Scala REPL against LLM client modules during development
+  - Cache CI compiles for multi-module Scala inference services


### PR DESCRIPTION
## Add Checkstyle, PMD, Error Prone, sbt, Pitest to catalog

Five JVM/Scala developer tools for the Agentic AI For Good catalog.

| Tool | Category | Repo | Stars |
|------|----------|------|-------|
| Checkstyle | Dev Tools | checkstyle/checkstyle | 9.5k |
| PMD | Dev Tools | pmd/pmd | 5.5k |
| Error Prone | Dev Tools | google/error-prone | 7.2k |
| sbt | Dev Tools | sbt/sbt | 4.9k |
| Pitest | Dev Tools | hcoles/pitest | 1.9k |

Local validation passed (`npx tsx scripts/validate-tool.ts`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Checkstyle, Error Prone, PIT, PMD, and sbt.
  * Included tool descriptions, links, licensing and pricing details, installation information, and categorized tags.
  * Added practical use cases covering Java, Scala, JVM development, static analysis, testing, and CI quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->