### PR TITLE
Add Google Truth, Robolectric, JaCoCo, NullAway, RAGChecker to catalog

### DIFF
--- a/tools/dev-tools/google-truth.yaml
+++ b/tools/dev-tools/google-truth.yaml
@@ -1,0 +1,25 @@
+name: Google Truth
+description: Fluent assertions for Java and Android tests. Truth produces readable failure messages so JVM model APIs and on-device ML tests fail with clear diffs instead of opaque assertion dumps.
+tagline: Fluent Java assertions with readable failures
+
+github_url: https://github.com/google/truth
+website_url: https://truth.dev
+docs_url: https://truth.dev
+
+category: Dev Tools
+tags: [java, testing, assertions, android, jvm, google]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  JUnit assertEquals dumps are hard to debug when embedding or serving
+  tests fail. Truth gives fluent, type-aware assertions and readable
+  diffs so JVM RAG backends and Android ML apps fail with the actual
+  mismatch, not a stack of generic assertion errors.
+
+use_cases:
+  - Assert embedding vector sizes and metadata maps in Java unit tests
+  - Write readable Android instrumentation tests for on-device ML apps
+  - Compare protobuf and Guava types in JVM model-serving test suites
+  - Replace opaque JUnit asserts with fluent Truth subjects in CI

--- a/tools/dev-tools/jacoco.yaml
+++ b/tools/dev-tools/jacoco.yaml
@@ -1,0 +1,25 @@
+name: JaCoCo
+description: Java code coverage library that instruments JVM bytecode and reports line, branch, and instruction coverage. JaCoCo plugs into Maven, Gradle, and CI so model-serving APIs and agent workers fail the build when coverage drops.
+tagline: Java code coverage for Maven and Gradle
+
+github_url: https://github.com/jacoco/jacoco
+website_url: https://www.jacoco.org/jacoco
+docs_url: https://www.jacoco.org/jacoco/trunk/doc/index.html
+
+category: Dev Tools
+tags: [java, coverage, testing, jvm, maven, gradle, ci]
+pricing: free
+is_open_source: true
+license: EPL-2.0
+
+problem_solved: |
+  JVM AI services ship untested branches in embedding, retrieval, and
+  tool-call code. JaCoCo instruments classes at runtime and publishes
+  HTML and XML reports so Maven or Gradle CI can gate merges on coverage
+  for model gateways and agent workers.
+
+use_cases:
+  - Gate PRs on line and branch coverage for Java inference APIs
+  - Publish JaCoCo HTML reports for RAG backend test suites
+  - Track coverage of agent worker and tool-calling Java modules
+  - Integrate JaCoCo with Maven Surefire or Gradle test tasks in CI

--- a/tools/dev-tools/nullaway.yaml
+++ b/tools/dev-tools/nullaway.yaml
@@ -1,0 +1,25 @@
+name: NullAway
+description: Error Prone plugin from Uber that catches NullPointerExceptions at compile time. NullAway uses @Nullable annotations with low build overhead so JVM model APIs fail the compile instead of crashing in production.
+tagline: Fast compile-time null checking for Java
+
+github_url: https://github.com/uber/NullAway
+website_url: https://github.com/uber/NullAway
+docs_url: https://github.com/uber/NullAway/wiki
+
+category: Dev Tools
+tags: [java, null-safety, error-prone, static-analysis, jvm, uber]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  NullPointerExceptions still take down Java model gateways after tests
+  pass. NullAway runs as an Error Prone check on every compile, using
+  @Nullable annotations to reject unsafe dereferences with under 10%
+  build overhead so agent workers fail CI, not production.
+
+use_cases:
+  - Enforce @Nullable contracts on Java embedding and retrieval APIs
+  - Fail compilation on unsafe dereferences in agent worker code
+  - Add NullAway to Gradle or Maven Error Prone pipelines for JVM ML
+  - Adopt JSpecify nullness annotations on a Java RAG backend

--- a/tools/dev-tools/robolectric.yaml
+++ b/tools/dev-tools/robolectric.yaml
@@ -1,0 +1,25 @@
+name: Robolectric
+description: Android unit testing framework that runs Android APIs on the JVM. Robolectric lets teams test on-device ML apps, camera pipelines, and agent UIs without an emulator or device farm.
+tagline: Run Android unit tests on the JVM
+
+github_url: https://github.com/robolectric/robolectric
+website_url: https://robolectric.org
+docs_url: https://robolectric.org
+
+category: Dev Tools
+tags: [android, testing, java, jvm, unit-testing, mobile]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Android ML and agent apps need fast unit tests, but emulators are slow
+  and flaky. Robolectric shadows the Android framework on the JVM so
+  Activities, Services, and on-device inference wrappers can be tested
+  in milliseconds on CI without a device farm.
+
+use_cases:
+  - Unit-test Android Activities that host on-device LLM or vision models
+  - Exercise camera and sensor pipelines for mobile ML without an emulator
+  - Run JVM-speed CI for Android agent UIs and background workers
+  - Shadow Android APIs when testing TensorFlow Lite wrappers in Gradle

--- a/tools/rag/ragchecker.yaml
+++ b/tools/rag/ragchecker.yaml
@@ -1,0 +1,26 @@
+name: RAGChecker
+description: Fine-grained evaluation framework for diagnosing RAG systems. RAGChecker scores claim-level entailment and splits retriever vs generator metrics so teams can see whether retrieval or generation is the failure mode.
+tagline: Diagnose RAG with claim-level metrics
+
+github_url: https://github.com/amazon-science/RAGChecker
+website_url: https://github.com/amazon-science/RAGChecker
+docs_url: https://github.com/amazon-science/RAGChecker
+install_command: pip install ragchecker
+
+category: RAG
+tags: [python, rag, evaluation, retrieval, generation, amazon, benchmark]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  End-to-end RAG scores hide whether the retriever missed evidence or the
+  generator hallucinated. RAGChecker uses claim-level entailment plus
+  diagnostic retriever and generator metrics so teams can target the
+  failing stage instead of guessing from a single accuracy number.
+
+use_cases:
+  - Diagnose whether RAG failures come from retrieval or generation
+  - Score claim-level faithfulness of answers against retrieved chunks
+  - Benchmark a RAG pipeline on the RAGChecker multi-domain dataset
+  - Compare retriever and generator variants with diagnostic metrics


### PR DESCRIPTION
## Summary
Adds five catalog entries:

- **Google Truth** (Dev Tools) — fluent Java/Android assertions (`google/truth`, Apache-2.0, 2.8k★)
- **Robolectric** (Dev Tools) — Android unit tests on the JVM (`robolectric/robolectric`, MIT, 6.0k★)
- **JaCoCo** (Dev Tools) — Java code coverage (`jacoco/jacoco`, EPL-2.0, 4.6k★)
- **NullAway** (Dev Tools) — compile-time NPE checking via Error Prone (`uber/NullAway`, MIT, 4.1k★)
- **RAGChecker** (RAG) — claim-level RAG diagnosis (`amazon-science/RAGChecker`, Apache-2.0, 1.1k★)

Java libraries omit `install_command` (Maven/Gradle). RAGChecker uses `pip install ragchecker`.

## Test plan
- [x] Local `npx tsx scripts/validate-tool.ts` passed for all five files
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Google Truth, JaCoCo, NullAway, and Robolectric, expanding developer-tool coverage for Java, JVM, Android, testing, coverage, and null-safety workflows.
  - Added a RAGChecker catalog entry with installation details, documentation links, and use cases for evaluating retrieval-augmented generation quality.
  - Included licensing, pricing, categorization, project metadata, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->