### PR TITLE
Add SuperMemory, BCEmbedding, Mixedbread, Voyage AI, BitNet to catalog

### DIFF
--- a/tools/llm/bitnet.yaml
+++ b/tools/llm/bitnet.yaml
@@ -1,0 +1,25 @@
+name: BitNet
+description: Microsoft inference runtime for 1-bit LLMs. BitNet runs ternary BitNet b1.58 models with optimized kernels so teams can serve compact language models on CPUs and edge devices instead of full-precision GPUs.
+tagline: Official inference runtime for 1-bit LLMs
+
+github_url: https://github.com/microsoft/BitNet
+website_url: https://github.com/microsoft/BitNet
+docs_url: https://github.com/microsoft/BitNet
+
+category: LLM
+tags: [llm, inference, 1-bit, quantization, microsoft, cpu, edge]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Full-precision LLMs are too heavy for CPU and edge serving. BitNet is
+  Microsoft's official runtime for 1-bit and 1.58-bit models, with kernels
+  that run ternary transformers efficiently so local and edge inference
+  does not need a GPU cluster.
+
+use_cases:
+  - Serve BitNet b1.58 models on CPU for local chat and agents
+  - Benchmark 1-bit LLM latency against 4-bit GGUF on edge hardware
+  - Package a compact on-device assistant without a GPU
+  - Experiment with ternary transformer inference from Hugging Face checkpoints

--- a/tools/llm/voyage-ai.yaml
+++ b/tools/llm/voyage-ai.yaml
@@ -1,0 +1,24 @@
+name: Voyage AI
+description: Embedding and rerank API tuned for retrieval quality. Voyage AI hosts domain-specific embedding models so RAG and search stacks get higher-precision vectors without training or serving embedders in-house.
+tagline: Retrieval-tuned embedding and rerank APIs
+
+website_url: https://www.voyageai.com
+docs_url: https://docs.voyageai.com
+install_command: pip install voyageai
+
+category: LLM
+tags: [embeddings, rerank, api, rag, python, retrieval]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Generic embeddings underperform on code, legal, and finance retrieval.
+  Voyage AI serves retrieval-tuned embedding and rerank models over an
+  API so RAG pipelines get domain-aware vectors without training or
+  hosting a dedicated embedding cluster.
+
+use_cases:
+  - Embed code and docs for a developer RAG assistant
+  - Rerank vector search hits with Voyage rerank models
+  - Replace OpenAI embeddings with Voyage in a LangChain retriever
+  - Batch-embed a knowledge base through the Voyage Python SDK

--- a/tools/rag/bcembedding.yaml
+++ b/tools/rag/bcembedding.yaml
@@ -1,0 +1,26 @@
+name: BCEmbedding
+description: NetEase Youdao embedding and reranker models built for RAG. BCEmbedding maps bilingual queries and passages into a shared space and reranks hits so Chinese-English retrieval stacks get higher-precision chunks.
+tagline: Bilingual embeddings and rerankers for RAG
+
+github_url: https://github.com/netease-youdao/BCEmbedding
+website_url: https://github.com/netease-youdao/BCEmbedding
+docs_url: https://github.com/netease-youdao/BCEmbedding
+install_command: pip install BCEmbedding
+
+category: RAG
+tags: [python, embeddings, reranker, rag, bilingual, youdao, retrieval]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  English-centric embedding models miss bilingual RAG queries, especially
+  Chinese-English mixes. BCEmbedding ships Youdao embedding and reranker
+  checkpoints so retrieval pipelines can encode and rerank mixed-language
+  queries and passages without training a custom bilingual model.
+
+use_cases:
+  - Embed Chinese and English docs into one space for RAG retrieval
+  - Rerank bilingual search hits before sending chunks to an LLM
+  - Swap a generic embedder for Youdao BCEmbedding in LlamaIndex
+  - Evaluate bilingual retrieval quality on RAG product datasets

--- a/tools/rag/mixedbread.yaml
+++ b/tools/rag/mixedbread.yaml
@@ -1,0 +1,24 @@
+name: Mixedbread
+description: Search and embedding API for RAG and document parsing. Mixedbread serves retrieval-optimized embedding models and a search stack so teams can index, parse, and query documents without running their own vector infrastructure.
+tagline: Embedding and search API for RAG apps
+
+website_url: https://www.mixedbread.com
+docs_url: https://www.mixedbread.com/docs
+install_command: pip install mixedbread
+
+category: RAG
+tags: [embeddings, search, rag, api, python, retrieval]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Building a document search stack means wiring parsers, embedders, and
+  a vector store. Mixedbread exposes embedding and search APIs plus
+  document parsing so RAG apps can index and query files without
+  operating that pipeline in-house.
+
+use_cases:
+  - Embed documents for semantic search in a RAG product
+  - Parse PDFs and files into retrieval-ready chunks via the API
+  - Query a Mixedbread search index from a Python agent tool
+  - Swap a self-hosted embedder for Mixedbread in production RAG

--- a/tools/rag/supermemory.yaml
+++ b/tools/rag/supermemory.yaml
@@ -1,0 +1,28 @@
+name: SuperMemory
+description: Memory engine for AI agents that stores and retrieves long-term context. SuperMemory runs locally or as an API so coding agents and RAG apps keep user and project memory across sessions.
+tagline: Fast, local-first memory API for AI agents
+
+github_url: https://github.com/supermemoryai/supermemory
+website_url: https://supermemory.ai
+docs_url: https://supermemory.ai/docs
+install_command: |
+  pip install supermemory
+  npm install supermemory
+
+category: RAG
+tags: [memory, rag, agents, context, python, typescript, local]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Agents forget everything between sessions and stuffing chat history
+  into the prompt does not scale. SuperMemory is a fast memory engine
+  you can run locally or via API so tools, coding agents, and RAG apps
+  persist and retrieve user and project context over time.
+
+use_cases:
+  - Give a coding agent persistent memory of repo decisions and prefs
+  - Store user facts and retrieve them in later RAG conversations
+  - Run SuperMemory locally for private agent memory without a cloud store
+  - Add a memory API to a multi-agent workflow that spans sessions


### PR DESCRIPTION
## Summary
Adds five catalog entries:

- **SuperMemory** (RAG) — local-first agent memory engine (`supermemoryai/supermemory`, MIT, 29k★)
- **BCEmbedding** (RAG) — Youdao bilingual embeddings and rerankers (`netease-youdao/BCEmbedding`, Apache-2.0, 1.9k★)
- **Mixedbread** (RAG) — embedding and search API (SaaS; `pip install mixedbread`)
- **Voyage AI** (LLM) — retrieval-tuned embedding and rerank API (SaaS; `pip install voyageai`)
- **BitNet** (LLM) — Microsoft 1-bit LLM inference runtime (`microsoft/BitNet`, MIT, 40k★)

BitNet omits `install_command` (CMake/C++ runtime; PyPI `bitnet` is an unrelated package). Mixedbread and Voyage AI are SaaS (`is_open_source: false`, website_url only).

## Test plan
- [x] Local `npx tsx scripts/validate-tool.ts` passed for all five files
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for BitNet, Voyage AI, BCEmbedding, Mixedbread, and SuperMemory.
  * Expanded the catalog with tools for 1-bit model inference, embedding and reranking, bilingual retrieval, document parsing, search, and persistent AI-agent memory.
  * Added metadata including descriptions, use cases, links, installation details, pricing, licensing, and open-source status where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->