### PR TITLE
Add TimesFM, Heretic, AirLLM, EAGLE, Marin to catalog

### DIFF
--- a/tools/fine-tuning/marin.yaml
+++ b/tools/fine-tuning/marin.yaml
@@ -1,0 +1,25 @@
+name: Marin
+description: Open-source framework from the Marin community for researching and training foundation models. Marin documents data, training, and evaluation so labs can reproduce large LLM runs instead of treating the stack as a black box.
+tagline: Open framework for foundation model research and training
+
+github_url: https://github.com/marin-community/marin
+website_url: https://marin.community
+docs_url: https://marin.community
+
+category: Fine-tuning
+tags: [python, llm, training, foundation-model, research, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Reproducing foundation-model training is hard because data mixes,
+  configs, and evals stay private. Marin publishes an open stack for
+  data, training, and evaluation so researchers can run and inspect
+  large LLM experiments instead of guessing from a paper appendix.
+
+use_cases:
+  - Reproduce an open foundation-model training run with public configs
+  - Experiment with data mixes and evals before a large LLM pretrain
+  - Teach LLM training using Marin's documented research stack
+  - Compare open training recipes against closed lab reports

--- a/tools/llm/airllm.yaml
+++ b/tools/llm/airllm.yaml
@@ -1,0 +1,26 @@
+name: AirLLM
+description: Inference library that streams LLM layers so 70B-class models run on a single 4GB GPU. AirLLM loads one layer at a time from disk or RAM so local agents can serve large open-weight models without a multi-GPU box.
+tagline: Run 70B LLMs on a single 4GB GPU
+
+github_url: https://github.com/lyogavin/airllm
+website_url: https://github.com/lyogavin/airllm
+docs_url: https://github.com/lyogavin/airllm
+install_command: pip install airllm
+
+category: LLM
+tags: [python, llm, inference, gpu, memory, local, quantization]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Large open-weight models need more VRAM than a single consumer GPU.
+  AirLLM streams transformer layers during decode so 70B-class models
+  run in about 4GB of VRAM, letting local agents and labs serve big
+  checkpoints without a multi-GPU cluster.
+
+use_cases:
+  - Serve a 70B chat model on one 4GB or 8GB GPU for local agents
+  - Prototype large-model RAG on a laptop-class NVIDIA card
+  - Stream MoE experts so only routed layers sit in VRAM
+  - Compare layer-streaming inference against full-load vLLM

--- a/tools/llm/eagle.yaml
+++ b/tools/llm/eagle.yaml
@@ -1,0 +1,26 @@
+name: EAGLE
+description: Speculative decoding method that drafts tokens from LLM feature trajectories. EAGLE trains a lightweight head on hidden states so serving stacks get 2-3x faster generation while matching the base model's output distribution.
+tagline: Speculative decoding from LLM feature trajectories
+
+github_url: https://github.com/SafeAILab/EAGLE
+website_url: https://github.com/SafeAILab/EAGLE
+docs_url: https://github.com/SafeAILab/EAGLE
+install_command: pip install eagle-llm
+
+category: LLM
+tags: [python, llm, inference, speculative-decoding, serving, acceleration]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Autoregressive decode is the latency bottleneck for chat and agents.
+  EAGLE trains a small draft head on second-top-layer features so the
+  base model verifies multiple tokens per step, speeding generation
+  2-3x without changing the sampled text distribution.
+
+use_cases:
+  - Speed up Vicuna or Llama chat serving with an EAGLE draft head
+  - Train an EAGLE head for a custom instruction-tuned checkpoint
+  - Combine EAGLE with quantization for higher tokens per second
+  - Benchmark speculative decoding against Medusa and vanilla generate

--- a/tools/llm/heretic.yaml
+++ b/tools/llm/heretic.yaml
@@ -1,0 +1,26 @@
+name: Heretic
+description: Automatic tool for removing refusal behavior from open-weight language models. Heretic searches residual-stream directions tied to refusals so researchers can measure and ablate safety fine-tuning without hand-crafted jailbreak prompts.
+tagline: Automatic refusal-direction ablation for open-weight LLMs
+
+github_url: https://github.com/p-e-w/heretic
+website_url: https://heretic-project.org
+docs_url: https://github.com/p-e-w/heretic
+install_command: pip install heretic-llm
+
+category: LLM
+tags: [python, llm, interpretability, abliteration, safety, research]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Measuring how much of an open-weight model is safety fine-tuning vs
+  pretraining usually means hand-written jailbreaks. Heretic automatically
+  finds and ablates residual-stream refusal directions so labs can
+  evaluate residual capability and safety tradeoffs on the weights.
+
+use_cases:
+  - Ablate refusal directions in an open-weight chat model for research
+  - Compare safety-tuned vs ablated checkpoints on capability benches
+  - Study residual-stream features tied to model refusals
+  - Produce a research checkpoint after automated abliteration

--- a/tools/llm/timesfm.yaml
+++ b/tools/llm/timesfm.yaml
@@ -1,0 +1,26 @@
+name: TimesFM
+description: Google Research time-series foundation model for zero-shot forecasting. TimesFM is a decoder-only pretrained model so teams can forecast metrics, demand, and LLM traffic without training a custom ARIMA or Transformer per series.
+tagline: Pretrained foundation model for time-series forecasting
+
+github_url: https://github.com/google-research/timesfm
+website_url: https://research.google/blog/a-decoder-only-foundation-model-for-time-series-forecasting/
+docs_url: https://github.com/google-research/timesfm
+install_command: pip install timesfm
+
+category: LLM
+tags: [python, time-series, forecasting, foundation-model, google, jax]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Forecasting GPU usage, traffic, and demand usually means training a
+  model per series. TimesFM is a pretrained decoder-only foundation
+  model from Google Research that zero-shot forecasts many series so
+  ML ops and product teams skip per-dataset training.
+
+use_cases:
+  - Forecast LLM API traffic and GPU utilization without per-series training
+  - Zero-shot demand and metric forecasts in an ML monitoring stack
+  - Benchmark TimesFM against ARIMA and Prophet on internal series
+  - Fine-tune TimesFM on domain time series after the zero-shot baseline


### PR DESCRIPTION
## Summary
Adds five catalog entries:

- **TimesFM** (LLM) — Google time-series foundation model (`google-research/timesfm`, Apache-2.0, 30k★)
- **Heretic** (LLM) — automatic refusal-direction ablation for open-weight models (`p-e-w/heretic`, AGPL-3.0, 30k★)
- **AirLLM** (LLM) — layer-streaming inference for 70B models on 4GB GPUs (`lyogavin/airllm`, Apache-2.0, 34k★)
- **EAGLE** (LLM) — speculative decoding from feature trajectories (`SafeAILab/EAGLE`, Apache-2.0, 2.5k★)
- **Marin** (Fine-tuning) — open foundation-model training framework (`marin-community/marin`, Apache-2.0, 3.3k★)

Marin omits `install_command` (no pip package for the training framework).

## Test plan
- [x] Local `npx tsx scripts/validate-tool.ts` passed for all five files
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog listings for Marin, AirLLM, EAGLE, Heretic, and TimesFM.
  * Included descriptions, links, installation details, licensing, pricing, categories, tags, and use cases for each tool.
  * Added resources covering foundation-model training, low-VRAM inference, speculative decoding, model behavior research, and time-series forecasting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->