### PR TITLE
Add OpenMontage, Pyroscope, Parca, OpenCompass, VectorChord to catalog

### DIFF
--- a/tools/agent-frameworks/openmontage.yaml
+++ b/tools/agent-frameworks/openmontage.yaml
@@ -1,0 +1,26 @@
+name: OpenMontage
+description: Open-source agentic video production system with 12 pipelines, 100-plus tools, and hundreds of agent skill files that turn an AI coding assistant into a local video production studio.
+tagline: Agentic pipelines that turn coding agents into a video studio
+
+github_url: https://github.com/calesthio/OpenMontage
+website_url: https://www.openmontage.video/
+docs_url: https://github.com/calesthio/OpenMontage
+
+category: Agents
+tags: [agents, video, production, ffmpeg, local, skills, open-source]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Video production with AI still splits across editors, TTS, captioning, B-roll, and
+  render tools, so coding agents cannot ship a finished cut from one repo. OpenMontage
+  packages production pipelines, tools, and skill files so an agent can storyboard,
+  generate, assemble, and export video locally instead of stitching one-off scripts.
+
+use_cases:
+  - Produce a product demo video from a repo using OpenMontage agent pipelines
+  - Run local TTS, captions, and FFmpeg assembly without a SaaS video editor
+  - Give a coding agent skill files for storyboarding, shot lists, and render presets
+  - Batch-generate social clips from a script with consistent brand motion graphics
+  - Prototype an end-to-end video workflow on a laptop before moving to a render farm

--- a/tools/monitoring/opencompass.yaml
+++ b/tools/monitoring/opencompass.yaml
@@ -1,0 +1,28 @@
+name: OpenCompass
+description: LLM evaluation platform from the OpenCompass project that benchmarks open and API models across 100-plus datasets, covering Llama, Qwen, GPT-4, Claude, and many other families.
+tagline: Open LLM evaluation across 100-plus datasets and model families
+
+github_url: https://github.com/open-compass/opencompass
+website_url: https://opencompass.org.cn/
+docs_url: https://opencompass.readthedocs.io/
+
+install_command: pip install -U opencompass
+
+category: Monitoring
+tags: [python, evaluation, benchmark, llm, datasets, huggingface]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Comparing LLMs usually means a handful of leaderboard scores that do not match your
+  tasks, or a pile of one-off eval scripts per model API. OpenCompass runs a shared
+  evaluation harness over 100-plus datasets and many model backends so teams can
+  measure open and closed models with the same protocol before they ship.
+
+use_cases:
+  - Benchmark Llama, Qwen, and GPT-4 on the same OpenCompass dataset suite
+  - Evaluate a fine-tuned checkpoint against base-model scores before production
+  - Add custom datasets to compare models on domain tasks instead of generic leaderboards
+  - Run local open-model evals with vLLM or LMDeploy backends from one config
+  - Publish reproducible eval reports for model selection reviews

--- a/tools/monitoring/parca.yaml
+++ b/tools/monitoring/parca.yaml
@@ -1,0 +1,26 @@
+name: Parca
+description: Open-source continuous profiling project that stores CPU and memory profiles over time so you can analyze resource usage down to the line number and reduce infrastructure cost.
+tagline: Continuous CPU and memory profiling down to the line number
+
+github_url: https://github.com/parca-dev/parca
+website_url: https://parca.dev/
+docs_url: https://www.parca.dev/docs/
+
+category: Monitoring
+tags: [profiling, observability, cpu, memory, eBPF, kubernetes, go]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Production services waste CPU and RAM for weeks before anyone attaches a profiler,
+  and ad-hoc pprof dumps disappear after the incident. Parca continuously collects
+  profiles, stores them as a time series, and lets you compare resource usage down to
+  the line number so performance work is part of normal operations, not a fire drill.
+
+use_cases:
+  - Continuously profile Kubernetes workloads with eBPF without changing application code
+  - Compare CPU profiles across deploys to catch performance regressions in CI or staging
+  - Track memory growth in long-running LLM workers and pin it to allocating functions
+  - Store pprof-compatible profiles as a queryable time series instead of local files
+  - Reduce node count by finding idle or wasteful code paths in production services

--- a/tools/monitoring/pyroscope.yaml
+++ b/tools/monitoring/pyroscope.yaml
@@ -1,0 +1,26 @@
+name: Pyroscope
+description: Grafana continuous profiling platform that samples CPU, memory, and other runtime signals so you can debug performance issues down to a single line of code across services.
+tagline: Continuous profiling from Grafana, down to the line of code
+
+github_url: https://github.com/grafana/pyroscope
+website_url: https://grafana.com/oss/pyroscope/
+docs_url: https://grafana.com/docs/pyroscope/latest/
+
+category: Monitoring
+tags: [profiling, grafana, observability, cpu, memory, go, kubernetes]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Metrics and traces show that a service is slow, but they rarely name the function
+  burning CPU or allocating memory. Pyroscope continuously profiles production runtimes
+  so teams can compare flame graphs over time, find the hot line, and cut infrastructure
+  cost without attaching a one-off profiler during an incident.
+
+use_cases:
+  - Find the hottest functions in a Python or Go inference service from production profiles
+  - Compare CPU flame graphs before and after a model or dependency upgrade
+  - Cut cloud spend by spotting memory leaks in long-running agent workers
+  - Add continuous profiling to Grafana alongside metrics, logs, and traces
+  - Debug a latency spike down to a single line without reproducing it locally

--- a/tools/vector-databases/vectorchord.yaml
+++ b/tools/vector-databases/vectorchord.yaml
@@ -1,0 +1,26 @@
+name: VectorChord
+description: Scalable, disk-friendly vector search extension for Postgres and the successor to pgvecto.rs, built for fast similarity search without moving embeddings out of the database.
+tagline: Disk-friendly Postgres vector search, successor to pgvecto.rs
+
+github_url: https://github.com/supervc-stack/VectorChord
+website_url: https://docs.vectorchord.ai/vectorchord/getting-started/overview.html
+docs_url: https://docs.vectorchord.ai/vectorchord/getting-started/overview.html
+
+category: Vector DB
+tags: [postgres, vector-search, embeddings, sql, rag, disk, extension]
+pricing: freemium
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Postgres vector indexes either keep everything in memory or force you onto a separate
+  vector database as embedding tables grow. VectorChord, the successor to pgvecto.rs,
+  adds scalable disk-friendly vector search inside Postgres so RAG and similarity
+  workloads stay next to relational data without a second serving stack.
+
+use_cases:
+  - Store document embeddings in Postgres and run ANN search without a separate vector DB
+  - Migrate a pgvecto.rs workload to VectorChord for larger, disk-backed indexes
+  - Join vector similarity results with SQL filters, metadata, and access control
+  - Serve RAG retrieval from the same Postgres instance that holds application data
+  - Scale beyond in-memory HNSW limits using disk-friendly vector indexes


### PR DESCRIPTION
## Add OpenMontage, Pyroscope, Parca, OpenCompass, VectorChord to catalog

Five catalog entries, locally validated with `npx tsx scripts/validate-tool.ts`.

| Tool | Category | Repo | Notes |
|---|---|---|---|
| OpenMontage | Agents | calesthio/OpenMontage (55.7k★, AGPL-3.0) | Agentic video production; no single package, install omitted |
| Pyroscope | Monitoring | grafana/pyroscope (11.6k★, AGPL-3.0) | Grafana continuous profiling; Docker server, install omitted |
| Parca | Monitoring | parca-dev/parca (4.9k★, Apache-2.0) | Continuous profiling; Go server, install omitted |
| OpenCompass | Monitoring | open-compass/opencompass (7.3k★, Apache-2.0) | LLM eval harness; `pip install -U opencompass` |
| VectorChord | Vector DB | supervc-stack/VectorChord (1.7k★, AGPL-3.0 dual ELv2) | Postgres vector search, successor of pgvecto.rs |

Distinct from existing Grafana, Grafana Loki/Tempo/Mimir, pgvector, pgvecto.rs, and pgvectorscale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OpenMontage to the agent frameworks catalog for open-source, local video production workflows.
  - Added OpenCompass, Parca, and Pyroscope to the monitoring tools catalog for LLM evaluation and continuous application profiling.
  - Added VectorChord to the vector databases catalog for PostgreSQL-based vector search and RAG retrieval.
  - Included descriptions, links, licensing, pricing, tags, and representative use cases for each newly listed tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->