### PR TITLE
Add OlmOCR, SQLModel, Burn to catalog

### DIFF
--- a/tools/data/olmocr.yaml
+++ b/tools/data/olmocr.yaml
@@ -1,0 +1,28 @@
+name: OlmOCR
+description: Allen Institute toolkit that linearizes PDFs into clean text for LLM datasets and training, with a dedicated OCR model, benchmark, and GPU inference pipeline for large document collections.
+tagline: PDF-to-text toolkit for LLM training data
+
+github_url: https://github.com/allenai/olmocr
+website_url: https://olmocr.allenai.org/
+docs_url: https://github.com/allenai/olmocr
+
+install_command: pip install olmocr
+
+category: Data
+tags: [python, ocr, pdf, datasets, llm, allenai, documents]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  LLM training and RAG pipelines need linearized PDF text, but generic OCR mangles
+  tables, equations, and multi-column layouts, and cloud OCR APIs do not scale to
+  millions of papers. OlmOCR ships a document model, benchmark, and inference pipeline
+  so teams can turn PDFs into training-ready text without a commercial OCR stack.
+
+use_cases:
+  - Convert scientific PDFs into linearized text for LLM pretraining or fine-tuning
+  - Run GPU batch OCR over a document corpus instead of a per-page SaaS API
+  - Benchmark OCR quality on olmOCR-Bench before swapping extractors in a data pipeline
+  - Build a RAG corpus from scanned reports where layout-aware text extraction matters
+  - Train a custom OlmOCR checkpoint on domain documents using the included trainer

--- a/tools/data/sqlmodel.yaml
+++ b/tools/data/sqlmodel.yaml
@@ -1,0 +1,28 @@
+name: SQLModel
+description: FastAPI-adjacent Python library that combines SQLAlchemy and Pydantic so you can define a single model that works as an ORM table, a validation schema, and an API type.
+tagline: One Python model for SQL tables, validation, and APIs
+
+github_url: https://github.com/fastapi/sqlmodel
+website_url: https://sqlmodel.tiangolo.com/
+docs_url: https://sqlmodel.tiangolo.com/
+
+install_command: pip install sqlmodel
+
+category: Data
+tags: [python, sql, orm, pydantic, fastapi, sqlalchemy, database]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Python data APIs usually keep a SQLAlchemy table, a Pydantic schema, and a FastAPI
+  type in sync by hand, so fields drift and insert bugs show up at runtime. SQLModel
+  lets you declare one class that is an ORM model and a Pydantic model, so database
+  rows, validation, and API payloads share the same source of truth.
+
+use_cases:
+  - Define a single Python class for a Postgres table and a FastAPI request/response model
+  - Store agent run metadata with type-checked inserts instead of raw SQLAlchemy plus Pydantic
+  - Prototype a small data API without maintaining duplicate ORM and schema classes
+  - Migrate a FastAPI app off duplicated SQLAlchemy models onto SQLModel
+  - Query relational feature stores with editor autocomplete from the same model used in APIs

--- a/tools/other/burn.yaml
+++ b/tools/other/burn.yaml
@@ -1,0 +1,28 @@
+name: Burn
+description: Rust tensor library and deep learning framework focused on flexibility, efficiency, and portability across backends, so you can train and run models without locking into a Python-only stack.
+tagline: Rust deep learning framework that does not trade flexibility for speed
+
+github_url: https://github.com/tracel-ai/burn
+website_url: https://burn.dev
+docs_url: https://burn.dev/books/burn/
+
+install_command: cargo add burn
+
+category: Other
+tags: [rust, deep-learning, tensors, training, inference, gpu, autodiff]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Most deep learning stacks are Python-first, so production teams rewrite models in
+  another language for performance or embedding, then drift from the training code.
+  Burn is a Rust tensor and autodiff framework with pluggable backends so you can train
+  and deploy in one language without giving up dynamic graphs or hardware portability.
+
+use_cases:
+  - Train a neural net in Rust with autodiff instead of wrapping a Python training loop
+  - Deploy a model inside a Rust service without a Python runtime or FFI to PyTorch
+  - Switch backends for CPU, GPU, or fused kernels without rewriting model code
+  - Embed on-device inference in a Rust binary for edge or CLI tools
+  - Prototype research models in Rust when Python GIL overhead is the bottleneck


### PR DESCRIPTION
## Add OlmOCR, SQLModel, Burn to catalog

Remainder batch of three catalog entries, locally validated with `npx tsx scripts/validate-tool.ts`.

| Tool | Category | Repo | Notes |
|---|---|---|---|
| OlmOCR | Data | allenai/olmocr (19.4k★, Apache-2.0) | PDF linearization for LLM datasets; `pip install olmocr` |
| SQLModel | Data | fastapi/sqlmodel (18.2k★, MIT) | SQLAlchemy + Pydantic models; `pip install sqlmodel` |
| Burn | Other | tracel-ai/burn (15.8k★, Apache-2.0) | Rust DL framework; `cargo add burn` (not the unrelated PyPI `burn` package) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for OlmOCR, SQLModel, and Burn.
  * Included descriptions, links, installation instructions, categories, tags, pricing, licensing, and practical use cases for each project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->