### PR TITLE
Add cAdvisor, Glances, orjson, loguru, ggml to catalog

### DIFF
--- a/tools/dev-tools/loguru.yaml
+++ b/tools/dev-tools/loguru.yaml
@@ -1,0 +1,28 @@
+name: loguru
+description: Python logging library that replaces the stdlib logging module with a single import, sensible defaults, structured sinks, and exception catching so apps get useful logs without boilerplate.
+tagline: Python logging that is actually simple
+
+github_url: https://github.com/Delgan/loguru
+website_url: https://loguru.readthedocs.io
+docs_url: https://loguru.readthedocs.io
+
+install_command: pip install loguru
+
+category: Dev Tools
+tags: [python, logging, observability, exceptions, structured-logs]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  The stdlib logging module needs handlers, formatters, and logger trees before a
+  script prints a useful line, so ML jobs and agent workers ship with print() or
+  silent failures. loguru gives a ready-to-use logger with rotation, colors, and
+  exception capture from one import so you spend time on the product, not logging config.
+
+use_cases:
+  - Add rotating file and stderr logs to a training script without logging.basicConfig
+  - Capture exceptions with stack traces in an agent worker using logger.catch
+  - Structure logs for later ingestion into Loki or a log platform
+  - Replace print debugging in a CLI tool with leveled, colored output
+  - Share one logger setup across FastAPI, Celery, and batch jobs

--- a/tools/dev-tools/orjson.yaml
+++ b/tools/dev-tools/orjson.yaml
@@ -1,0 +1,27 @@
+name: orjson
+description: Fast, correct Python JSON library written in Rust, with support for dataclasses, datetime, numpy, and strict UTF-8, used as a drop-in speed upgrade over the stdlib json module.
+tagline: Rust-backed JSON for Python that stays correct at speed
+
+github_url: https://github.com/ijl/orjson
+docs_url: https://github.com/ijl/orjson
+
+install_command: pip install orjson
+
+category: Dev Tools
+tags: [python, json, rust, serialization, numpy, performance]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Python services that serialize LLM traces, embeddings metadata, or API payloads
+  spend surprising CPU in json.dumps, and many fast libraries still mangle datetime
+  or numpy types. orjson is a Rust-backed encoder/decoder that is faster than the
+  stdlib while round-tripping dataclasses, datetimes, and numpy arrays correctly.
+
+use_cases:
+  - Speed up FastAPI or Flask JSON responses without changing response models
+  - Serialize numpy arrays and dataclasses in an ML scoring service
+  - Replace stdlib json in a high-QPS logging or tracing pipeline
+  - Parse large JSON datasets in a Python ETL job with lower CPU time
+  - Keep datetime and UTF-8 behavior correct while chasing p99 latency

--- a/tools/monitoring/cadvisor.yaml
+++ b/tools/monitoring/cadvisor.yaml
@@ -1,0 +1,26 @@
+name: cAdvisor
+description: Google container advisor that analyzes CPU, memory, filesystem, and network usage of running containers so you can debug resource problems without installing a per-container sidecar.
+tagline: Live resource metrics for every container on the node
+
+github_url: https://github.com/google/cadvisor
+website_url: https://github.com/google/cadvisor
+docs_url: https://github.com/google/cadvisor/blob/master/docs/runtime_options.md
+
+category: Monitoring
+tags: [containers, metrics, kubernetes, docker, google, cpu, memory]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Container hosts expose process stats, but teams still cannot see per-container CPU,
+  memory, and filesystem usage without a custom exporter. cAdvisor runs on the node,
+  discovers containers, and exports live resource metrics so Kubernetes and Prometheus
+  setups can debug noisy neighbors and leaks at container granularity.
+
+use_cases:
+  - Export per-container CPU and memory metrics from a Docker or containerd host
+  - Debug a noisy neighbor on a Kubernetes node without SSHing into every pod
+  - Feed Prometheus with cAdvisor container stats already used by kubelet
+  - Inspect filesystem and network usage for GPU training jobs packed on one machine
+  - Spot memory leaks in long-running inference containers from a single node agent

--- a/tools/monitoring/glances.yaml
+++ b/tools/monitoring/glances.yaml
@@ -1,0 +1,28 @@
+name: Glances
+description: Cross-platform system monitor and top/htop alternative that shows CPU, memory, disk, network, and process stats in a terminal, web UI, or API on Linux, macOS, BSD, and Windows.
+tagline: Cross-platform top/htop alternative with a web UI and API
+
+github_url: https://github.com/nicolargo/glances
+website_url: http://nicolargo.github.io/glances/
+docs_url: https://glances.readthedocs.io/
+
+install_command: pip install glances
+
+category: Monitoring
+tags: [python, monitoring, system, terminal, metrics, cross-platform]
+pricing: free
+is_open_source: true
+license: LGPL-3.0
+
+problem_solved: |
+  Server debugging still starts with top, htop, or a cloud dashboard, none of which
+  work the same on Linux, macOS, and Windows or expose an API for scripts. Glances
+  is a single cross-platform monitor with terminal, web, and API modes so you can
+  watch CPU, memory, disk, and processes the same way on a laptop or a GPU box.
+
+use_cases:
+  - Watch GPU box CPU, memory, and disk from a terminal during model training
+  - Run Glances in web mode to share live host stats without a full observability stack
+  - Query process and memory stats from the Glances API inside an ops script
+  - Replace htop on mixed Linux and macOS fleets with one monitor
+  - Alert on disk or memory pressure from a lightweight local agent

--- a/tools/other/ggml.yaml
+++ b/tools/other/ggml.yaml
@@ -1,0 +1,26 @@
+name: ggml
+description: Tensor library for machine learning in C/C++ that powers local LLM inference stacks, with quantized ops and backends used by llama.cpp and related runtimes.
+tagline: C tensor library behind local LLM inference
+
+github_url: https://github.com/ggml-org/ggml
+website_url: https://github.com/ggml-org
+docs_url: https://github.com/ggml-org/ggml
+
+category: Other
+tags: [c, cpp, tensors, llm, quantization, inference, ggml]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Running neural nets locally still means pulling Python, CUDA wheels, and a huge
+  framework just to multiply tensors. ggml is a small C tensor library with
+  quantization and multiple backends so inference tools can ship a single binary
+  that runs LLMs on CPU or GPU without a Python runtime.
+
+use_cases:
+  - Embed quantized tensor ops in a C or C++ inference binary
+  - Prototype new GGML kernels that later land in llama.cpp
+  - Run local LLM math on CPU with 4-bit quantized weights
+  - Build a native app that infers without shipping PyTorch
+  - Share tensor primitives across whisper.cpp, llama.cpp, and related tools


### PR DESCRIPTION
## Add cAdvisor, Glances, orjson, loguru, ggml to catalog

Five catalog entries after candidate-pool replenishment. Locally validated with `npx tsx scripts/validate-tool.ts`.

| Tool | Category | Repo | Notes |
|---|---|---|---|
| cAdvisor | Monitoring | google/cadvisor (19.3k★, Apache-2.0) | Container metrics; Docker server, install omitted |
| Glances | Monitoring | nicolargo/glances (33.5k★, LGPL-3.0) | Cross-platform system monitor; `pip install glances` |
| orjson | Dev Tools | ijl/orjson (8.2k★, Apache-2.0) | Fast Python JSON; `pip install orjson` |
| loguru | Dev Tools | Delgan/loguru (24.0k★, MIT) | Simple Python logging; `pip install loguru` |
| ggml | Other | ggml-org/ggml (15.2k★, MIT) | C tensor library behind llama.cpp; no pip, install omitted |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Loguru and orjson, including installation details, documentation links, licensing, categories, and use cases.
  - Added monitoring entries for cAdvisor and Glances with platform information, setup details, and monitoring scenarios.
  - Added a ggml entry covering local inference capabilities, supported technologies, licensing, and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->