### PR TITLE
Add uvloop, tenacity, msgspec, Ibis to catalog

### DIFF
--- a/tools/data/ibis.yaml
+++ b/tools/data/ibis.yaml
@@ -1,0 +1,28 @@
+name: Ibis
+description: A portable Python dataframe library that compiles the same DataFrame API to DuckDB, Postgres, BigQuery, Snowflake, Spark, and more. Write analytics and feature-engineering code once and run it locally or in the warehouse without rewriting SQL.
+tagline: Portable Python dataframes that compile to many backends
+
+github_url: https://github.com/ibis-project/ibis
+website_url: https://ibis-project.org
+docs_url: https://ibis-project.org/docs
+
+category: Data
+tags: [python, dataframe, sql, duckdb, analytics, feature-engineering, data-warehouse]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install ibis-framework
+
+problem_solved: |
+  ML and analytics teams rewrite the same transformations in pandas for
+  local work and SQL for the warehouse, which drifts and breaks pipelines.
+  Ibis gives one deferred DataFrame API that compiles to DuckDB, Postgres,
+  BigQuery, Snowflake, Spark, and other backends. Feature engineering and
+  dataset prep stay in Python while execution happens where the data lives.
+
+use_cases:
+  - Write feature-engineering DataFrame code once and run it on DuckDB locally or BigQuery and Snowflake in production
+  - Query parquet lakes and warehouse tables with the same Python API instead of maintaining dialect-specific SQL
+  - Prototype RAG and analytics datasets on a laptop, then scale the identical Ibis expressions to Spark
+  - Build backend-agnostic data-prep jobs that join, filter, and aggregate training data without locking to one engine

--- a/tools/dev-tools/msgspec.yaml
+++ b/tools/dev-tools/msgspec.yaml
@@ -1,0 +1,29 @@
+name: msgspec
+description: A fast serialization and validation library for Python with built-in JSON, MessagePack, YAML, and TOML support. Struct-based schemas decode and validate payloads at C speed, making msgspec a high-throughput alternative to Pydantic in AI services.
+tagline: Fast JSON and MessagePack serialization with schema validation
+
+github_url: https://github.com/msgspec/msgspec
+website_url: https://jcristharif.com/msgspec/
+docs_url: https://jcristharif.com/msgspec/
+
+category: Dev Tools
+tags: [python, serialization, json, msgpack, validation, performance, schemas]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install msgspec
+
+problem_solved: |
+  High-throughput inference APIs spend a large share of CPU on JSON encode,
+  decode, and schema checks. Pydantic and stdlib json are easy to use but
+  become bottlenecks at tens of thousands of requests per second. msgspec
+  provides Struct types that serialize and validate JSON and MessagePack at
+  C speed, cutting payload overhead in model servers, queues, and agent
+  message buses without giving up typed schemas.
+
+use_cases:
+  - Decode and validate LLM request and response payloads in FastAPI or custom ASGI inference servers
+  - Serialize agent messages, tool-call arguments, and job queues with MessagePack for lower latency than JSON
+  - Replace slower JSON libraries in embedding batch workers that process millions of records per hour
+  - Define typed Struct schemas for config files in YAML or TOML and fail fast on invalid fields

--- a/tools/dev-tools/tenacity.yaml
+++ b/tools/dev-tools/tenacity.yaml
@@ -1,0 +1,28 @@
+name: tenacity
+description: A retrying library for Python that wraps callables with configurable retry policies including exponential backoff, wait strategies, stop conditions, and exception filters. It is the standard retry layer for LLM API calls, network I/O, and flaky ML pipeline steps.
+tagline: Production-grade retry library for Python
+
+github_url: https://github.com/jd/tenacity
+website_url: https://tenacity.readthedocs.io
+docs_url: https://tenacity.readthedocs.io
+
+category: Dev Tools
+tags: [python, retry, backoff, resilience, llm-apis, networking, reliability]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install tenacity
+
+problem_solved: |
+  LLM APIs, vector databases, and remote feature stores fail with rate limits,
+  timeouts, and transient 5xx errors. Ad-hoc retry loops scatter sleep calls
+  and miss jitter, max attempts, and exception filters. tenacity wraps any
+  callable with declarative retry, wait, and stop policies so inference
+  clients and data jobs recover from flakes without custom retry code.
+
+use_cases:
+  - Retry OpenAI, Anthropic, and other LLM API calls on rate limits and timeouts with exponential backoff and jitter
+  - Harden embedding and vector-search clients against transient network errors in RAG pipelines
+  - Wrap flaky data-loader and feature-store fetches in training jobs with stop-after-attempt and wait-exponential policies
+  - Decorate agent tool calls so temporary HTTP failures do not abort a multi-step run

--- a/tools/dev-tools/uvloop.yaml
+++ b/tools/dev-tools/uvloop.yaml
@@ -1,0 +1,28 @@
+name: uvloop
+description: An ultra-fast drop-in replacement for asyncio's default event loop, implemented in Cython on top of libuv. uvloop typically makes Python async I/O 2-4x faster and is the loop behind uvicorn, FastAPI, and many production LLM serving stacks.
+tagline: Ultra-fast asyncio event loop built on libuv
+
+github_url: https://github.com/MagicStack/uvloop
+docs_url: https://github.com/MagicStack/uvloop
+
+category: Dev Tools
+tags: [python, asyncio, event-loop, libuv, performance, uvicorn, async]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install uvloop
+
+problem_solved: |
+  Python's default asyncio event loop is convenient but slow under high
+  concurrency, which shows up as extra latency in LLM API gateways, embedding
+  servers, and streaming inference proxies. uvloop is a drop-in Cython loop
+  on libuv that is typically 2-4x faster I/O with the same asyncio APIs. Teams
+  install it once, call uvloop.install(), and keep existing async code while
+  serving more concurrent requests on the same hardware.
+
+use_cases:
+  - Speed up FastAPI and uvicorn inference gateways that stream tokens from LLM providers
+  - Raise concurrency in async embedding, RAG retrieval, and tool-calling services without extra machines
+  - Drop uvloop into existing asyncio workers as a one-line install for production Python I/O
+  - Benchmark and replace the default event loop in high-QPS webhook and agent callback servers


### PR DESCRIPTION
## Summary

Adds 4 catalog entries for Python runtime and data libraries used in AI/ML services:

- **uvloop** (Dev Tools) — ultra-fast asyncio event loop on libuv (MagicStack/uvloop, ~11.9k★, Apache-2.0)
- **tenacity** (Dev Tools) — retry/backoff library for LLM APIs and flaky I/O (jd/tenacity, ~8.8k★, Apache-2.0)
- **msgspec** (Dev Tools) — fast JSON/MessagePack serialization and validation (msgspec/msgspec, ~4.1k★, BSD-3-Clause)
- **Ibis** (Data) — portable Python dataframes that compile to DuckDB, warehouses, and Spark (ibis-project/ibis, ~6.7k★, Apache-2.0)

Install commands verified on PyPI (`pip install uvloop`, `pip install tenacity`, `pip install msgspec`, `pip install ibis-framework`). Local `validate-tool.ts` passed for all four files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ibis to the data tools catalog, including installation details, resources, licensing, and common use cases.
  * Added msgspec, Tenacity, and uvloop to the developer tools catalog with descriptions, setup information, and practical use cases.
  * Expanded catalog coverage for dataframe workflows, serialization, retry handling, and high-performance asynchronous applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->