### PR TITLE
Add Django, Tornado, Sanic, watchdog, marshmallow to catalog

### DIFF
--- a/tools/dev-tools/django.yaml
+++ b/tools/dev-tools/django.yaml
@@ -1,0 +1,29 @@
+name: Django
+description: The batteries-included Python web framework used to ship admin UIs, annotation portals, and model-serving backends. Django provides ORM, auth, templating, and a built-in admin so ML teams can expose datasets and inference without assembling a stack from scratch.
+tagline: Batteries-included Python web framework for apps and admin UIs
+
+github_url: https://github.com/django/django
+website_url: https://www.djangoproject.com
+docs_url: https://docs.djangoproject.com
+
+category: Dev Tools
+tags: [python, web-framework, orm, admin, api, backend, developer-tools]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install Django
+
+problem_solved: |
+  ML products still need login, CRUD, admin, and a database layer around
+  models and datasets. Assembling Flask plus an ORM, auth, and an admin
+  panel repeats the same work on every internal tool. Django ships those
+  pieces together so teams can publish annotation UIs, experiment dashboards,
+  and inference admin in a single framework with migrations and security
+  defaults.
+
+use_cases:
+  - Build dataset annotation and review portals with Django admin, auth, and ORM-backed records
+  - Expose model registry, experiment metadata, and human-in-the-loop review behind a staff-only Django app
+  - Serve REST or JSON APIs in front of batch inference jobs using Django views and the ORM
+  - Prototype internal ML ops tools (user accounts, permissions, audit logs) without assembling a custom stack

--- a/tools/dev-tools/marshmallow.yaml
+++ b/tools/dev-tools/marshmallow.yaml
@@ -1,0 +1,28 @@
+name: marshmallow
+description: A lightweight Python library for converting complex objects to and from simple datatypes. marshmallow schemas serialize, deserialize, and validate JSON payloads for APIs, job queues, and ML service contracts.
+tagline: Python object serialization and schema validation
+
+github_url: https://github.com/marshmallow-code/marshmallow
+website_url: https://marshmallow.readthedocs.io
+docs_url: https://marshmallow.readthedocs.io
+
+category: Dev Tools
+tags: [python, serialization, validation, schemas, json, api, dataclasses]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install marshmallow
+
+problem_solved: |
+  APIs, batch jobs, and agent tool calls pass nested JSON that must be
+  typed and validated before it hits a model. Hand-written dict checks
+  drift from the real payload shape. marshmallow schemas declare fields,
+  nested objects, and validators so load and dump stay consistent across
+  inference services, queues, and config files.
+
+use_cases:
+  - Validate LLM request bodies and tool-call arguments before they reach a model server
+  - Serialize ORM or dataclass objects to JSON for experiment tracking and job queues
+  - Share schema definitions between a training pipeline producer and an inference consumer
+  - Reject malformed dataset metadata and config files at the API boundary with field-level errors

--- a/tools/dev-tools/sanic.yaml
+++ b/tools/dev-tools/sanic.yaml
@@ -1,0 +1,28 @@
+name: Sanic
+description: A Python async web framework designed for fast HTTP APIs. Sanic runs on its own server or ASGI workers and is used to serve inference endpoints, webhooks, and agent callbacks with low request overhead.
+tagline: Fast async Python web framework for APIs
+
+github_url: https://github.com/sanic-org/sanic
+website_url: https://sanic.dev
+docs_url: https://sanic.dev/en/guide/
+
+category: Dev Tools
+tags: [python, web-framework, async, asgi, api, http, inference]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install sanic
+
+problem_solved: |
+  Inference gateways and agent webhooks need an async HTTP layer that is
+  fast to start and cheap per request. Heavier frameworks add ORM and
+  template weight that serving endpoints do not use. Sanic is an async
+  Python web framework with its own server, so teams can ship JSON APIs
+  for embeddings, tools, and model scoring with low latency.
+
+use_cases:
+  - Serve embedding and classification HTTP APIs with async handlers and JSON responses
+  - Host agent tool-callback and webhook endpoints that must stay responsive under burst traffic
+  - Put a lightweight HTTP front door in front of GPU workers without a full Django or Flask stack
+  - Build streaming or SSE inference routes on Sanic's async request cycle

--- a/tools/dev-tools/tornado.yaml
+++ b/tools/dev-tools/tornado.yaml
@@ -1,0 +1,28 @@
+name: Tornado
+description: A Python web framework and async networking library that uses a non-blocking I/O loop. Tornado is well suited to long-lived connections, WebSockets, and streaming HTTP used by chat UIs and token-streaming LLM proxies.
+tagline: Async Python web framework for long-lived connections
+
+github_url: https://github.com/tornadoweb/tornado
+website_url: https://www.tornadoweb.org
+docs_url: https://www.tornadoweb.org/en/stable
+
+category: Dev Tools
+tags: [python, web-framework, async, websockets, networking, streaming, http]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install tornado
+
+problem_solved: |
+  Token streaming, agent chat, and webhook fan-out need thousands of open
+  connections, which threaded WSGI servers handle poorly. Tornado provides
+  a non-blocking I/O loop, HTTP server, and WebSocket support in one
+  library so Python services can stream LLM output and keep sockets open
+  without a thread per client.
+
+use_cases:
+  - Stream LLM tokens to a browser over HTTP chunked responses or WebSockets
+  - Run long-lived agent chat backends that keep thousands of concurrent connections open
+  - Build webhook and notification fan-out services with Tornado's async HTTP client
+  - Prototype streaming inference proxies when you need WebSockets without a full ASGI stack

--- a/tools/dev-tools/watchdog.yaml
+++ b/tools/dev-tools/watchdog.yaml
@@ -1,0 +1,27 @@
+name: watchdog
+description: A Python library and CLI for monitoring filesystem events across platforms. watchdog watches directories for create, modify, and delete events so training jobs, dataset loaders, and hot-reload servers can react to file changes.
+tagline: Cross-platform Python filesystem event watcher
+
+github_url: https://github.com/gorakhargosh/watchdog
+docs_url: https://python-watchdog.readthedocs.io
+
+category: Dev Tools
+tags: [python, filesystem, file-watcher, monitoring, datasets, hot-reload, developer-tools]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install watchdog
+
+problem_solved: |
+  Training jobs, dataset drops, and config reloads need to notice new files
+  without polling every few seconds. Naive polling wastes CPU and misses
+  short-lived writes. watchdog listens to OS filesystem events (inotify,
+  FSEvents, ReadDirectoryChangesW) so Python services can enqueue new
+  data, retrain, or hot-reload as soon as a path changes.
+
+use_cases:
+  - Watch a landing directory and kick off preprocessing when new dataset files appear
+  - Hot-reload prompt templates, YAML tool configs, or model cards during local agent development
+  - Trigger embedding re-index jobs when documents are added or updated on disk
+  - Monitor checkpoint directories and copy or register new weights as training writes them


### PR DESCRIPTION
## Summary

Adds 5 catalog entries for Python web and serialization libraries used around AI services:

- **Django** (Dev Tools) — batteries-included web framework (django/django, ~89.6k★, BSD-3-Clause)
- **Tornado** (Dev Tools) — async web framework and networking library (tornadoweb/tornado, ~22.2k★, Apache-2.0)
- **Sanic** (Dev Tools) — fast async Python web framework (sanic-org/sanic, ~18.6k★, MIT)
- **watchdog** (Dev Tools) — cross-platform filesystem event watcher (gorakhargosh/watchdog, ~7.4k★, Apache-2.0)
- **marshmallow** (Dev Tools) — object serialization and schema validation (marshmallow-code/marshmallow, ~7.2k★, MIT)

Install commands verified on PyPI. Local `validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Django, Marshmallow, Sanic, Tornado, and Watchdog.
  * Included descriptions, documentation links, categories, tags, pricing, licensing, installation commands, and practical use cases for each developer tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->