### PR TITLE
Add nevergrad, FLAML, webdataset, structlog to catalog

### DIFF
--- a/tools/data/webdataset.yaml
+++ b/tools/data/webdataset.yaml
@@ -1,0 +1,27 @@
+name: webdataset
+description: A high-performance Python I/O library for large-scale deep learning datasets, with strong PyTorch support. webdataset streams tar-sharded samples so training can read from local disk or cloud object storage without a custom data server.
+tagline: Tar-sharded dataset I/O for large-scale PyTorch training
+
+github_url: https://github.com/webdataset/webdataset
+docs_url: https://github.com/webdataset/webdataset
+
+category: Data
+tags: [python, pytorch, datasets, data-loading, tar, object-storage, training]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install webdataset
+
+problem_solved: |
+  Image, audio, and multimodal training sets are too large to store as
+  millions of small files, and naive folder loaders crush filesystems and
+  object stores. webdataset packs samples into sequential tar shards that
+  stream from disk or S3 into PyTorch DataLoaders, so distributed jobs
+  read at sequential speed without a custom dataset server.
+
+use_cases:
+  - Stream tar-sharded image or multimodal datasets from S3 into PyTorch training workers
+  - Replace folder-of-files loaders that stall object storage with sequential shard reads
+  - Shuffle and mix large web-scale corpora across GPUs without loading the full set into RAM
+  - Publish reusable dataset shards that local laptops and cluster jobs can consume with the same API

--- a/tools/fine-tuning/flaml.yaml
+++ b/tools/fine-tuning/flaml.yaml
@@ -1,0 +1,28 @@
+name: FLAML
+description: A fast AutoML and tuning library from Microsoft. FLAML finds accurate models and hyperparameters with a low computational budget, covering classical ML, forecasting, NLP, and LLM-related tuning tasks.
+tagline: Fast AutoML and hyperparameter tuning from Microsoft
+
+github_url: https://github.com/microsoft/FLAML
+website_url: https://microsoft.github.io/FLAML/
+docs_url: https://microsoft.github.io/FLAML/
+
+category: Fine-tuning
+tags: [python, automl, hyperparameter-tuning, microsoft, nlp, forecasting, fine-tuning]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install flaml
+
+problem_solved: |
+  AutoML stacks often burn large compute on exhaustive search before a
+  usable model appears. FLAML allocates a time budget across learners and
+  hyperparameters so it finds strong configs cheaply. Teams use it to
+  tune classical models, forecasting, NLP, and LLM-related settings when
+  they cannot afford a full neural architecture search.
+
+use_cases:
+  - AutoML-train classifiers and regressors on tabular features with a wall-clock time budget
+  - Tune hyperparameters for forecasting and NLP tasks without a large GPU cluster
+  - Search LLM and RAG settings (chunk size, k, temperature) as an inexpensive black-box study
+  - Compare learner families quickly before committing to a heavier fine-tuning run

--- a/tools/fine-tuning/nevergrad.yaml
+++ b/tools/fine-tuning/nevergrad.yaml
@@ -1,0 +1,28 @@
+name: nevergrad
+description: A Python toolbox for gradient-free optimization from Meta. nevergrad runs derivative-free algorithms over continuous, discrete, and mixed spaces for hyperparameter search, prompt tuning, and black-box model selection without needing gradients.
+tagline: Gradient-free optimization toolbox for black-box tuning
+
+github_url: https://github.com/facebookresearch/nevergrad
+website_url: https://facebookresearch.github.io/nevergrad/
+docs_url: https://facebookresearch.github.io/nevergrad/
+
+category: Fine-tuning
+tags: [python, hyperparameter-tuning, optimization, black-box, automl, fine-tuning]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install nevergrad
+
+problem_solved: |
+  Many LLM and ML knobs cannot be differentiated: temperature, RAG chunk
+  size, prompt templates, and discrete architecture choices. Grid search
+  wastes budget and gradient methods do not apply. nevergrad provides
+  derivative-free optimizers over mixed parameter spaces so teams can
+  tune black-box pipelines with a small evaluation budget.
+
+use_cases:
+  - Tune LLM decoding, RAG chunk size, and retriever hyperparameters without gradients
+  - Search prompt templates and discrete tool-routing choices as mixed optimization variables
+  - Run black-box AutoML over sklearn or custom training scripts with a limited eval budget
+  - Optimize multi-objective metrics such as accuracy versus latency for inference configs

--- a/tools/monitoring/structlog.yaml
+++ b/tools/monitoring/structlog.yaml
@@ -1,0 +1,29 @@
+name: structlog
+description: A Python logging library that produces structured, context-rich log events instead of format-string messages. structlog binds request IDs, model names, and trace fields onto every event so AI services can query logs as data.
+tagline: Structured, context-rich logging for Python services
+
+github_url: https://github.com/hynek/structlog
+website_url: https://www.structlog.org
+docs_url: https://www.structlog.org
+
+category: Monitoring
+tags: [python, logging, structured-logging, observability, tracing, monitoring]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install structlog
+
+problem_solved: |
+  Production inference and agent services need logs you can filter by
+  request ID, model, tenant, and latency. stdlib logging emits strings
+  that break when fields are missing and are hard to query in log
+  platforms. structlog binds context once and emits structured events
+  (JSON or key-value) so dashboards and traces stay aligned with the
+  code path.
+
+use_cases:
+  - Bind request_id, model, and user_id onto every log line in an LLM API gateway
+  - Emit JSON logs from agent tool calls for search in Elasticsearch, Loki, or CloudWatch
+  - Add timing and token-count fields to inference logs without custom formatters
+  - Keep context across async tasks so a single trace is reconstructable from structured events


### PR DESCRIPTION
## Summary

Adds 4 catalog entries spanning fine-tuning, data loading, and observability:

- **nevergrad** (Fine-tuning) — gradient-free optimization toolbox (facebookresearch/nevergrad, ~4.2k★, MIT)
- **FLAML** (Fine-tuning) — fast AutoML and hyperparameter tuning (microsoft/FLAML, ~4.4k★, MIT)
- **webdataset** (Data) — tar-sharded dataset I/O for PyTorch (webdataset/webdataset, ~3.2k★, BSD-3-Clause)
- **structlog** (Monitoring) — structured Python logging (hynek/structlog, ~4.9k★, MIT/Apache dual, recorded as MIT)

Install commands verified on PyPI. Local `validate-tool.ts` passed for all four files.
