### PR TITLE
Add attrs, pendulum, granian, websockets, urllib3 to catalog

### DIFF
--- a/tools/dev-tools/attrs.yaml
+++ b/tools/dev-tools/attrs.yaml
@@ -1,0 +1,28 @@
+name: attrs
+description: A Python library for defining classes without boilerplate. attrs generates __init__, comparison, hashing, and representation methods from typed attributes, used for configs, dataset records, and structured payloads in ML services.
+tagline: Boilerplate-free Python classes with typed attributes
+
+github_url: https://github.com/python-attrs/attrs
+website_url: https://www.attrs.org
+docs_url: https://www.attrs.org
+
+category: Dev Tools
+tags: [python, dataclasses, classes, typing, configuration, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install attrs
+
+problem_solved: |
+  Config objects, dataset rows, and API models need equality, hashing, and
+  init without a page of dunder methods. Hand-written classes drift and
+  dataclasses still leave some comparison and conversion work. attrs
+  declares attributes once and generates the class machinery, which is
+  why it underpins many Python ML libraries and service configs.
+
+use_cases:
+  - Define typed experiment and training-config objects with generated init, eq, and repr
+  - Model dataset records and feature rows as frozen attrs classes for hashing and caching
+  - Share structured payload types between a data pipeline and an inference service
+  - Replace verbose class boilerplate in agent tool argument containers

--- a/tools/dev-tools/granian.yaml
+++ b/tools/dev-tools/granian.yaml
@@ -1,0 +1,27 @@
+name: granian
+description: A Rust HTTP server for Python applications supporting ASGI, WSGI, and RSGI. granian is a faster alternative to uvicorn and gunicorn for serving FastAPI, Flask, and inference APIs with lower latency and higher throughput.
+tagline: Rust HTTP server for ASGI, WSGI, and RSGI Python apps
+
+github_url: https://github.com/emmett-framework/granian
+docs_url: https://github.com/emmett-framework/granian
+
+category: Dev Tools
+tags: [python, rust, asgi, wsgi, http-server, fastapi, inference]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install granian
+
+problem_solved: |
+  Python inference APIs spend a large share of latency in the HTTP server
+  process, especially under many concurrent streams. Pure-Python servers
+  struggle with that load. granian is a Rust server that speaks ASGI,
+  WSGI, and RSGI, so FastAPI and Flask model endpoints get a faster
+  worker without changing application code.
+
+use_cases:
+  - Serve FastAPI LLM and embedding APIs with a Rust ASGI worker instead of uvicorn
+  - Run Flask or Django WSGI model-admin apps behind granian for higher request throughput
+  - Host streaming inference endpoints that need cheaper concurrency than a pure-Python loop
+  - Benchmark and swap the process manager for production Python AI HTTP services

--- a/tools/dev-tools/pendulum.yaml
+++ b/tools/dev-tools/pendulum.yaml
@@ -1,0 +1,28 @@
+name: pendulum
+description: A Python datetime library that improves on the stdlib with a nicer API, time zone handling, and duration arithmetic. pendulum is a drop-in-friendly replacement for datetime used in scheduling, experiment timestamps, and log windows.
+tagline: Friendlier Python datetimes with proper time zones
+
+github_url: https://github.com/python-pendulum/pendulum
+website_url: https://pendulum.eustace.io
+docs_url: https://pendulum.eustace.io
+
+category: Dev Tools
+tags: [python, datetime, timezone, scheduling, timestamps, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install pendulum
+
+problem_solved: |
+  Training jobs, cron windows, and experiment logs break when naive
+  datetimes mix UTC and local time. The stdlib datetime API is easy to
+  misuse around DST and parsing. pendulum provides timezone-aware
+  datetimes, human durations, and consistent parsing so ML pipelines
+  schedule and stamp events without silent offset bugs.
+
+use_cases:
+  - Stamp experiment runs, checkpoints, and dataset versions with timezone-aware datetimes
+  - Compute training-window and SLA durations without DST mistakes
+  - Parse ISO timestamps from logs, APIs, and object-store metadata into a single type
+  - Schedule data-refresh and retraining jobs with readable datetime arithmetic

--- a/tools/dev-tools/urllib3.yaml
+++ b/tools/dev-tools/urllib3.yaml
@@ -1,0 +1,28 @@
+name: urllib3
+description: A powerful Python HTTP client used as the transport under requests and many SDKs. urllib3 provides connection pooling, retries, TLS, and file uploads for robust calls to LLM APIs, object storage, and internal model services.
+tagline: Production HTTP client with pooling and retries for Python
+
+github_url: https://github.com/urllib3/urllib3
+website_url: https://urllib3.readthedocs.io
+docs_url: https://urllib3.readthedocs.io
+
+category: Dev Tools
+tags: [python, http-client, retries, tls, networking, sdk, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install urllib3
+
+problem_solved: |
+  LLM SDKs, dataset downloads, and webhook clients need pooled TCP
+  connections, retries, and correct TLS. The stdlib http.client is low
+  level, and many wrappers hide retry behavior. urllib3 is the pooled
+  HTTP engine under requests and pip, so teams can configure retries,
+  timeouts, and uploads once for production Python I/O.
+
+use_cases:
+  - Configure connection pools and retries for LLM provider and vector-DB HTTP calls
+  - Download large training artifacts from S3-compatible endpoints with streaming responses
+  - Build custom Python SDK transports that need TLS, proxies, and retry policies
+  - Tune timeout and pool size for high-QPS embedding and inference clients

--- a/tools/dev-tools/websockets.yaml
+++ b/tools/dev-tools/websockets.yaml
@@ -1,0 +1,28 @@
+name: websockets
+description: A Python library for building WebSocket servers and clients. websockets implements RFC 6455 and is used for streaming LLM tokens, agent chat, and bidirectional tool events without a heavier real-time stack.
+tagline: RFC 6455 WebSocket library for Python servers and clients
+
+github_url: https://github.com/python-websockets/websockets
+website_url: https://websockets.readthedocs.io
+docs_url: https://websockets.readthedocs.io
+
+category: Dev Tools
+tags: [python, websockets, streaming, realtime, async, llm, networking]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install websockets
+
+problem_solved: |
+  Token streaming and agent UIs need a bidirectional socket, not request
+  and response HTTP. Rolling a WebSocket protocol by hand is error-prone
+  around ping, close, and fragmentation. websockets implements RFC 6455
+  for asyncio so Python services can stream model output and receive
+  client events on a standard socket.
+
+use_cases:
+  - Stream LLM tokens from a Python backend to a browser or desktop client
+  - Bidirectional agent chat where the server pushes tool results and the client sends interrupts
+  - Connect Python workers to a gateway over WebSockets for live job progress
+  - Prototype realtime inference demos without adopting a full Socket.IO stack


### PR DESCRIPTION
## Summary

Adds 5 catalog entries for Python runtime libraries used in AI services:

- **attrs** (Dev Tools) — boilerplate-free classes (python-attrs/attrs, ~5.8k★, MIT)
- **pendulum** (Dev Tools) — timezone-aware datetime library (python-pendulum/pendulum, ~6.7k★, MIT)
- **granian** (Dev Tools) — Rust HTTP server for ASGI/WSGI/RSGI (emmett-framework/granian, ~5.6k★, BSD-3-Clause)
- **websockets** (Dev Tools) — RFC 6455 WebSocket library (python-websockets/websockets, ~5.7k★, BSD-3-Clause)
- **urllib3** (Dev Tools) — pooled HTTP client under requests (urllib3/urllib3, ~4.1k★, MIT)

Install commands verified on PyPI. Local `validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for five Python developer tools: attrs, Granian, Pendulum, urllib3, and websockets.
  * Included descriptions, documentation links, installation instructions, licensing details, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->