### PR TITLE
Add toolz, diskcache, cloudpickle, anyio, dill to catalog

### DIFF
--- a/tools/data/cloudpickle.yaml
+++ b/tools/data/cloudpickle.yaml
@@ -1,0 +1,27 @@
+name: cloudpickle
+description: Extended Python pickling that serializes functions, lambdas, and dynamic objects the stdlib pickle cannot. cloudpickle is the default serializer for Dask, Joblib, and many distributed ML runtimes that ship code to workers.
+tagline: Serialize Python functions for distributed workers
+
+github_url: https://github.com/cloudpipe/cloudpickle
+docs_url: https://github.com/cloudpipe/cloudpickle
+
+category: Data
+tags: [python, serialization, pickle, distributed, dask, multiprocessing, ml-pipeline]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install cloudpickle
+
+problem_solved: |
+  Distributed training and job queues need to send closures, lambdas,
+  and dynamically defined classes to remote workers. stdlib pickle
+  fails on nested functions and interactive code. cloudpickle captures
+  the function and its globals so Dask, Ray-style dispatch, and Joblib
+  can ship Python callables across processes and machines.
+
+use_cases:
+  - Serialize nested functions and lambdas for Dask or Joblib workers
+  - Ship interactive notebook functions to a remote training cluster
+  - Persist dynamically generated feature transforms for later replay
+  - Replace pickle when multiprocessing a pipeline defined at runtime

--- a/tools/data/dill.yaml
+++ b/tools/data/dill.yaml
@@ -1,0 +1,28 @@
+name: dill
+description: A Python serializer that pickles almost every object type, including nested functions, lambdas, and interpreter state. dill is used in multiprocessing, checkpointing, and scientific workflows that need to dump more than stdlib pickle allows.
+tagline: Serialize almost any Python object, including functions
+
+github_url: https://github.com/uqfoundation/dill
+website_url: https://dill.readthedocs.io
+docs_url: https://dill.readthedocs.io
+
+category: Data
+tags: [python, serialization, pickle, multiprocessing, checkpointing, scientific-computing]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install dill
+
+problem_solved: |
+  Scientific and ML jobs often need to checkpoint closures, class
+  instances, and session state that pickle rejects. Restarting a
+  notebook or a multiprocessing pool then means rewriting objects.
+  dill extends pickle so nearly any Python object can be dumped and
+  restored, including nested functions and interpreter state.
+
+use_cases:
+  - Checkpoint experiment functions and closures between notebook sessions
+  - Send complex callables through multiprocessing pools
+  - Persist pathos or scientific pipeline state that pickle cannot dump
+  - Dump and restore interpreter objects for reproducible research runs

--- a/tools/data/diskcache.yaml
+++ b/tools/data/diskcache.yaml
@@ -1,0 +1,28 @@
+name: diskcache
+description: A pure-Python disk-backed cache with a Django-compatible API that is often faster than Redis or Memcached for local workloads. diskcache persists dict-like caches, queues, and Deques on disk for ML jobs, feature stores, and CLI tools that need durable local caching.
+tagline: Fast disk-backed cache for Python without Redis
+
+github_url: https://github.com/grantjenks/python-diskcache
+website_url: https://www.grantjenks.com/docs/diskcache/
+docs_url: https://www.grantjenks.com/docs/diskcache/
+
+category: Data
+tags: [python, caching, disk, persistence, django, ml-pipeline, data-processing]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install diskcache
+
+problem_solved: |
+  Training jobs, embedding lookups, and CLI tools need a durable cache
+  without standing up Redis. In-memory dicts vanish on crash and pickle
+  files are not concurrent-safe. diskcache stores a SQLite-backed cache
+  on disk with eviction, TTL, and queue APIs so local ML workloads can
+  persist expensive results across runs.
+
+use_cases:
+  - Cache embedding lookups and HTTP fetches across training or eval runs
+  - Persist intermediate dataset shards without a separate cache server
+  - Use a disk-backed queue to fan out preprocessing work on one machine
+  - Replace Redis for local Django or FastAPI caches during development

--- a/tools/dev-tools/anyio.yaml
+++ b/tools/dev-tools/anyio.yaml
@@ -1,0 +1,28 @@
+name: anyio
+description: An async concurrency and networking library that runs on asyncio or Trio with a single API. anyio adds structured task groups, cancellation, and sockets so FastAPI, HTTPX, and ML serving stacks stay backend-portable.
+tagline: Structured async concurrency on asyncio or Trio
+
+github_url: https://github.com/agronholm/anyio
+website_url: https://anyio.readthedocs.io
+docs_url: https://anyio.readthedocs.io
+
+category: Dev Tools
+tags: [python, async, asyncio, trio, concurrency, networking, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install anyio
+
+problem_solved: |
+  Async Python splits between asyncio and Trio, so libraries that spawn
+  tasks, cancel work, or open sockets lock into one runtime. anyio
+  provides a shared API for task groups, timeouts, and networking that
+  works on either backend, which is why HTTPX, FastAPI, and Starlette
+  use it for portable async I/O.
+
+use_cases:
+  - Write async HTTP and socket clients that run on asyncio or Trio
+  - Group inference or scrape tasks with structured cancellation
+  - Build FastAPI-compatible libraries without hardcoding asyncio
+  - Add timeouts and nurseries to long-running data fetch jobs

--- a/tools/dev-tools/toolz.yaml
+++ b/tools/dev-tools/toolz.yaml
@@ -1,0 +1,28 @@
+name: toolz
+description: A functional standard library for Python with composable helpers for iterators, dictionaries, and functions. toolz is used in data pipelines and ML preprocessing to write compact, lazy transformations without extra dependencies.
+tagline: Functional helpers for Python iterators and dicts
+
+github_url: https://github.com/pytoolz/toolz
+website_url: https://toolz.readthedocs.io
+docs_url: https://toolz.readthedocs.io
+
+category: Dev Tools
+tags: [python, functional, iterators, data-processing, pipelines, developer-tools]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install toolz
+
+problem_solved: |
+  Data and ML pipelines often mix nested dicts, generators, and one-off
+  helper functions that are hard to compose or test. Python's stdlib
+  itertools and functools cover pieces but not a coherent functional
+  toolkit. toolz gives curry, pipe, get-in, and lazy map/filter/reduce
+  so preprocessing and feature transforms stay small and reusable.
+
+use_cases:
+  - Compose lazy feature-transform pipelines with pipe, map, and filter
+  - Pluck nested keys from JSON or dataset records without nested loops
+  - Curry config-driven preprocessing functions for reuse across jobs
+  - Replace ad-hoc itertools helpers with a small, documented toolkit


### PR DESCRIPTION
## Add 5 tools to the catalog

Python functional, caching, serialization, and async libraries used in ML pipelines.

| Tool | Category | Stars | License |
|------|----------|-------|---------|
| toolz | Dev Tools | 5.1k | BSD-3-Clause |
| diskcache | Data | 2.9k | Apache-2.0 |
| cloudpickle | Data | 1.9k | BSD-3-Clause |
| anyio | Dev Tools | 2.5k | MIT |
| dill | Data | 2.4k | BSD-3-Clause |

- `pip install toolz` / `diskcache` / `cloudpickle` / `anyio` / `dill` verified on PyPI
- Local YAML validation passed for all five files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Cloudpickle, Dill, Diskcache, AnyIO, and Toolz.
  * Included descriptions, tags, categories, pricing, licensing, installation commands, project links, and representative use cases for each tool.
  * Expanded the catalog with serialization, caching, asynchronous programming, and functional programming utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->