### PR TITLE
Add msgpack, cachetools, more-itertools, wrapt, python-dateutil to catalog

### DIFF
--- a/tools/data/cachetools.yaml
+++ b/tools/data/cachetools.yaml
@@ -1,0 +1,28 @@
+name: cachetools
+description: Extensible memoizing collections and decorators for Python, including LRU, LFU, TTL, and RR caches. cachetools is used to memoize expensive function calls in ML services, embedding lookups, and API clients without standing up Redis.
+tagline: In-memory LRU and TTL caches for Python functions
+
+github_url: https://github.com/tkem/cachetools
+website_url: https://cachetools.readthedocs.io
+docs_url: https://cachetools.readthedocs.io
+
+category: Data
+tags: [python, caching, memoization, lru, ttl, ml-pipeline, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install cachetools
+
+problem_solved: |
+  Inference servers and data jobs recompute the same embeddings, token
+  counts, or HTTP lookups on every request. functools.lru_cache is
+  process-local and has no TTL. cachetools adds LRU, LFU, and TTL
+  mappings plus decorators so hot results stay in memory with eviction
+  instead of hitting a model or network again.
+
+use_cases:
+  - Memoize embedding lookups with an LRU cache in a FastAPI inference app
+  - TTL-cache prompt templates or tokenizer outputs for a few seconds
+  - Bound in-process caches for feature-store reads without Redis
+  - Decorate expensive preprocessing functions with @cached

--- a/tools/data/msgpack.yaml
+++ b/tools/data/msgpack.yaml
@@ -1,0 +1,28 @@
+name: msgpack
+description: A Python implementation of MessagePack, a compact binary serialization format faster and smaller than JSON. msgpack is used to ship embeddings, RPC payloads, and dataset records between ML services without the overhead of text JSON.
+tagline: Compact binary serialization for Python payloads
+
+github_url: https://github.com/msgpack/msgpack-python
+website_url: https://msgpack.org
+docs_url: https://github.com/msgpack/msgpack-python
+
+category: Data
+tags: [python, serialization, binary, rpc, json, ml-pipeline, data-processing]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install msgpack
+
+problem_solved: |
+  JSON is verbose for embeddings, feature rows, and RPC between training
+  and serving. pickle is Python-only and unsafe across trust boundaries.
+  msgpack packs nested dicts and arrays into a compact binary that other
+  languages can read, which is why many ML services use it for cache
+  values and inter-process messages.
+
+use_cases:
+  - Serialize embedding vectors and feature rows for a local or Redis cache
+  - Ship compact RPC payloads between a training job and a model server
+  - Replace JSON logs of nested metrics with smaller binary records
+  - Exchange dataset shards with non-Python workers that speak MessagePack

--- a/tools/dev-tools/more-itertools.yaml
+++ b/tools/dev-tools/more-itertools.yaml
@@ -1,0 +1,28 @@
+name: more-itertools
+description: Extra iterator tools beyond Python's itertools, including chunking, windowing, unique_everseen, and peekable streams. more-itertools is used in data loaders and ETL jobs that need readable batching without writing one-off generator helpers.
+tagline: Extra itertools for chunking, windows, and unique streams
+
+github_url: https://github.com/more-itertools/more-itertools
+website_url: https://more-itertools.readthedocs.io
+docs_url: https://more-itertools.readthedocs.io
+
+category: Dev Tools
+tags: [python, iterators, itertools, data-processing, etl, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install more-itertools
+
+problem_solved: |
+  Dataset loaders and ETL loops reinvent chunk, sliding window, and
+  unique-while-preserving-order helpers. Those one-offs are easy to get
+  wrong on empty input or peek. more-itertools ships tested recipes so
+  batching, grouping, and stream inspection stay one call instead of a
+  custom generator.
+
+use_cases:
+  - Chunk tokenized examples into training batches with ichunked
+  - Sliding-window over log lines or time series with windowed
+  - Dedupe streaming records while keeping first-seen order
+  - Peek at the next dataset item without consuming the iterator

--- a/tools/dev-tools/python-dateutil.yaml
+++ b/tools/dev-tools/python-dateutil.yaml
@@ -1,0 +1,28 @@
+name: python-dateutil
+description: Powerful extensions to Python datetime, including flexible parsing, relative deltas, recurrence rules, and time zone handling. python-dateutil is the default way ML pipelines parse messy timestamps from logs, APIs, and dataset metadata.
+tagline: Parse and compute datetimes beyond the Python stdlib
+
+github_url: https://github.com/dateutil/dateutil
+website_url: https://dateutil.readthedocs.io
+docs_url: https://dateutil.readthedocs.io
+
+category: Dev Tools
+tags: [python, datetime, parsing, timezone, scheduling, timestamps, developer-tools]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install python-dateutil
+
+problem_solved: |
+  Logs, APIs, and dataset manifests ship timestamps in mixed formats
+  that datetime.strptime cannot guess. Relative windows like "last 3
+  weekdays" are painful in the stdlib. python-dateutil parses fuzzy
+  dates, applies relativedelta, and handles time zones so training
+  windows and experiment stamps stay correct.
+
+use_cases:
+  - Parse mixed ISO and human timestamps from logs into timezone-aware datetimes
+  - Compute training-window start dates with relativedelta instead of handmade calendar math
+  - Expand RRULE recurrences for scheduled data refreshes
+  - Normalize dataset metadata dates from S3 object keys and APIs

--- a/tools/dev-tools/wrapt.yaml
+++ b/tools/dev-tools/wrapt.yaml
@@ -1,0 +1,28 @@
+name: wrapt
+description: A Python module for decorators, function wrappers, and monkey patching that preserves the wrapped object's signature and metadata. wrapt is used in tracing, APM, and library instrumentation so patches do not break inspect, typing, or bound methods.
+tagline: Correct function wrappers for decorators and monkey patches
+
+github_url: https://github.com/GrahamDumpleton/wrapt
+website_url: https://wrapt.readthedocs.io
+docs_url: https://wrapt.readthedocs.io
+
+category: Dev Tools
+tags: [python, decorators, wrapping, monkey-patch, instrumentation, tracing, developer-tools]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+install_command: pip install wrapt
+
+problem_solved: |
+  Naive decorator wrappers break inspect.signature, bound methods, and
+  classmethod behavior, which silently wrecks tracing and testing.
+  wrapt implements a wrapper object that looks like the original
+  function, so OpenTelemetry-style instrumentation and retry decorators
+  can patch APIs without changing call semantics.
+
+use_cases:
+  - Instrument LLM client calls with a decorator that keeps the original signature
+  - Monkey-patch HTTP libraries for tracing without breaking bound methods
+  - Write retry or timeout wrappers that still work with inspect and typing
+  - Patch third-party ML APIs in tests while preserving isinstance checks


### PR DESCRIPTION
## Add 5 tools to the catalog

Python serialization, caching, iterator, wrapping, and datetime libraries used in ML pipelines.

| Tool | Category | Stars | License |
|------|----------|-------|---------|
| msgpack | Data | 2.1k | Apache-2.0 |
| cachetools | Data | 2.8k | MIT |
| more-itertools | Dev Tools | 4.1k | MIT |
| wrapt | Dev Tools | 2.3k | BSD-2-Clause |
| python-dateutil | Dev Tools | 2.6k | Apache-2.0 |

- Install commands verified on PyPI
- Local YAML validation passed for all five files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for five open-source Python tools and libraries:
    * cachetools
    * msgpack
    * more-itertools
    * python-dateutil
    * wrapt
  * Each entry includes descriptions, documentation links, licensing, installation details, tags, and practical use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->