### PR TITLE
Add jsonschema, APScheduler, filelock, pathos to catalog

### DIFF
--- a/tools/data/pathos.yaml
+++ b/tools/data/pathos.yaml
@@ -1,0 +1,28 @@
+name: pathos
+description: A Python framework for parallel graph management and heterogeneous computing that wraps multiprocessing, threading, and SSH pools. pathos is used in scientific and ML workflows that need to map callables across local cores and remote hosts with dill serialization.
+tagline: Parallel maps across processes, threads, and remote hosts
+
+github_url: https://github.com/uqfoundation/pathos
+website_url: https://pathos.readthedocs.io
+docs_url: https://pathos.readthedocs.io
+
+category: Data
+tags: [python, parallel, multiprocessing, distributed, scientific-computing, dill, ml-pipeline]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install pathos
+
+problem_solved: |
+  Scientific and ML jobs need to map nested functions across cores and
+  remote SSH hosts, but stdlib multiprocessing cannot pickle those
+  callables. pathos uses dill-backed process, thread, and SSH pools so
+  the same map API runs locally or on a cluster without rewriting
+  closures into importable modules.
+
+use_cases:
+  - Parallelize embarrassingly parallel evals with ProcessPool and dill
+  - Map a nested notebook function across local cores without refactoring
+  - Fan work to remote hosts over SSH with a shared pool API
+  - Mix thread and process pools in a heterogeneous preprocessing graph

--- a/tools/dev-tools/apscheduler.yaml
+++ b/tools/dev-tools/apscheduler.yaml
@@ -1,0 +1,28 @@
+name: APScheduler
+description: An in-process Python task scheduler with cron, interval, and date triggers, plus job stores and executors. APScheduler runs retraining, data refresh, and cleanup jobs inside an app without requiring a separate Celery or cron host.
+tagline: In-process cron, interval, and date job scheduling for Python
+
+github_url: https://github.com/agronholm/apscheduler
+website_url: https://apscheduler.readthedocs.io
+docs_url: https://apscheduler.readthedocs.io
+
+category: Dev Tools
+tags: [python, scheduling, cron, jobs, background-tasks, ml-pipeline, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install APScheduler
+
+problem_solved: |
+  ML apps need periodic embedding rebuilds, cache expiry, and eval
+  sweeps but do not always want Celery or system cron. Sleep loops
+  miss DST and crash recovery. APScheduler stores jobs, supports cron
+  and interval triggers, and runs them in-process with persistent job
+  stores so schedules survive restarts.
+
+use_cases:
+  - Run nightly dataset refresh and embedding rebuild jobs inside a service
+  - Schedule interval health checks for a model-serving process
+  - Fire a one-shot eval job at a calendar datetime
+  - Persist scheduled retraining jobs in SQLAlchemy so they survive deploys

--- a/tools/dev-tools/filelock.yaml
+++ b/tools/dev-tools/filelock.yaml
@@ -1,0 +1,28 @@
+name: filelock
+description: A platform-independent file lock for Python that works on Linux, macOS, and Windows. filelock is used so concurrent training jobs, cache writers, and CLI tools do not corrupt a shared file when multiple processes run on one machine.
+tagline: Cross-platform inter-process file locking for Python
+
+github_url: https://github.com/tox-dev/filelock
+website_url: https://py-filelock.readthedocs.io
+docs_url: https://py-filelock.readthedocs.io
+
+category: Dev Tools
+tags: [python, locking, concurrency, multiprocessing, files, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install filelock
+
+problem_solved: |
+  Two training workers or CLI instances writing the same checkpoint,
+  cache, or config file race and corrupt it. OS lock APIs differ across
+  Windows and POSIX. filelock gives a single FileLock/Timeout API so
+  processes serialize access to shared artifacts without a Redis lock
+  or custom fcntl code.
+
+use_cases:
+  - Serialize checkpoint writes when several workers share a local directory
+  - Guard a disk cache or dataset download so parallel jobs do not clobber it
+  - Lock a local SQLite or YAML config used by multiple CLI processes
+  - Coordinate one-at-a-time model artifact promotion on a single host

--- a/tools/dev-tools/jsonschema.yaml
+++ b/tools/dev-tools/jsonschema.yaml
@@ -1,0 +1,28 @@
+name: jsonschema
+description: A Python implementation of the JSON Schema specification for validating JSON documents against drafts of the standard. jsonschema is used to check API payloads, dataset manifests, and agent tool arguments before they hit an ML service.
+tagline: Validate JSON documents against JSON Schema in Python
+
+github_url: https://github.com/python-jsonschema/jsonschema
+website_url: https://python-jsonschema.readthedocs.io
+docs_url: https://python-jsonschema.readthedocs.io
+
+category: Dev Tools
+tags: [python, json, validation, schema, api, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install jsonschema
+
+problem_solved: |
+  Dataset manifests, tool-calling arguments, and HTTP payloads arrive as
+  loosely typed JSON and fail late inside training or inference code.
+  Hand-written checks drift from the contract. jsonschema validates
+  documents against a published schema so bad records are rejected at
+  the boundary instead of crashing a job mid-run.
+
+use_cases:
+  - Validate agent tool-call arguments against a JSON Schema before execution
+  - Reject malformed dataset manifests at ingest instead of during training
+  - Check FastAPI or webhook payloads against a shared schema file
+  - Generate clearer error messages for config JSON used by ML pipelines


### PR DESCRIPTION
## Add 4 tools to the catalog

Python validation, scheduling, locking, and parallel-compute libraries used in ML pipelines.

| Tool | Category | Stars | License |
|------|----------|-------|---------|
| jsonschema | Dev Tools | 5.0k | MIT |
| APScheduler | Dev Tools | 7.6k | MIT |
| filelock | Dev Tools | 975 | MIT |
| pathos | Data | 1.5k | BSD-3-Clause |

- Install commands verified on PyPI
- Local YAML validation passed for all four files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for the Pathos parallel-processing framework and APScheduler task scheduler.
  * Added developer-tool entries for Filelock and JSON Schema validation.
  * Entries include descriptions, documentation links, licensing and pricing details, installation commands, and practical use cases.
  * Use cases cover parallel execution, scheduled jobs, file coordination, dataset and artifact management, and data validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->