### PR TITLE
Add boltons, python-dotenv, cattrs, cerberus, dateparser to catalog

### DIFF
--- a/tools/dev-tools/boltons.yaml
+++ b/tools/dev-tools/boltons.yaml
@@ -1,0 +1,28 @@
+name: boltons
+description: A pure-Python library of 250-plus constructs that extend the standard library with no extra dependencies. boltons is used in data and ML services for dict utils, retry, caching, and file helpers that would otherwise be one-off snippets.
+tagline: Battle-tested Python stdlib extras with zero dependencies
+
+github_url: https://github.com/mahmoud/boltons
+website_url: https://boltons.readthedocs.org
+docs_url: https://boltons.readthedocs.org
+
+category: Dev Tools
+tags: [python, stdlib, utilities, dict, retry, developer-tools]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install boltons
+
+problem_solved: |
+  Production Python services copy the same dict merge, retry, and file
+  helpers into every repo. Those snippets drift and pick up bugs.
+  boltons packages 250-plus tested recipes on top of the stdlib so
+  ML pipelines can reuse cache, iterutils, and fileutils without
+  pulling a heavy framework.
+
+use_cases:
+  - Use dictutils to merge nested experiment configs without custom recursion
+  - Retry flaky dataset downloads with boltons.iterutils and exception helpers
+  - Cache function results with a small in-process cache from boltons
+  - Read and write atomic files for local checkpoints with fileutils

--- a/tools/dev-tools/cattrs.yaml
+++ b/tools/dev-tools/cattrs.yaml
@@ -1,0 +1,28 @@
+name: cattrs
+description: Composable converters that turn attrs classes, dataclasses, and similar structures into dicts, JSON, and unstructured data. cattrs is used to (un)structure configs, dataset records, and API payloads without writing per-field glue.
+tagline: Convert attrs and dataclasses to and from unstructured data
+
+github_url: https://github.com/python-attrs/cattrs
+website_url: https://catt.rs
+docs_url: https://catt.rs
+
+category: Dev Tools
+tags: [python, attrs, dataclasses, serialization, converters, configuration, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install cattrs
+
+problem_solved: |
+  Typed experiment configs and dataset rows need to round-trip through
+  JSON and YAML. Hand-written asdict/from_dict misses unions, nested
+  collections, and custom types. cattrs generates converters for attrs
+  and dataclasses so ML services structure and unstructure payloads
+  without per-class boilerplate.
+
+use_cases:
+  - Unstructure training-config dataclasses to JSON for experiment tracking
+  - Structure API JSON into attrs classes for an inference service
+  - Convert nested dataset records with unions and optional fields
+  - Share one converter registry between a pipeline and a FastAPI app

--- a/tools/dev-tools/cerberus.yaml
+++ b/tools/dev-tools/cerberus.yaml
@@ -1,0 +1,28 @@
+name: cerberus
+description: A lightweight, extensible Python data validation library for dictionaries. cerberus is used to validate configs, form payloads, and dataset records with a schema that supports types, coercion, and custom rules without a heavy framework.
+tagline: Lightweight dictionary validation with extensible schemas
+
+github_url: https://github.com/pyeve/cerberus
+website_url: https://docs.python-cerberus.org
+docs_url: https://docs.python-cerberus.org
+
+category: Dev Tools
+tags: [python, validation, schema, dictionaries, configuration, developer-tools]
+pricing: free
+is_open_source: true
+license: ISC
+
+install_command: pip install cerberus
+
+problem_solved: |
+  Pipeline configs and ingested records are nested dicts that fail late
+  when a type or required key is wrong. JSON Schema is heavy for simple
+  dicts. cerberus validates and optionally coerces dictionaries with a
+  readable schema, plus custom rules, so bad experiment configs never
+  reach a GPU job.
+
+use_cases:
+  - Validate nested training hyperparameter dicts before a run starts
+  - Coerce string numbers from env-derived config into ints and floats
+  - Reject dataset rows missing required feature keys at ingest
+  - Add custom validators for model-name enums used across services

--- a/tools/dev-tools/dateparser.yaml
+++ b/tools/dev-tools/dateparser.yaml
@@ -1,0 +1,28 @@
+name: dateparser
+description: A Python parser for human-readable dates in many languages and formats. dateparser turns strings like "3 days ago" or "15/01/2024" into datetime objects for logs, crawlers, and dataset timestamps that are not ISO-8601.
+tagline: Parse human-readable dates in many languages
+
+github_url: https://github.com/scrapinghub/dateparser
+website_url: https://dateparser.readthedocs.org
+docs_url: https://dateparser.readthedocs.org
+
+category: Dev Tools
+tags: [python, datetime, parsing, nlp, scraping, timestamps, developer-tools]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install dateparser
+
+problem_solved: |
+  Scraped pages, support tickets, and dataset captions stamp dates as
+  "yesterday", "Jan 3rd", or locale-specific strings. strptime and
+  dateutil still miss many of those. dateparser detects language and
+  relative phrases so ETL and RAG ingest can normalize messy dates
+  into real datetimes.
+
+use_cases:
+  - Parse relative dates from scraped articles into timezone-aware datetimes
+  - Normalize mixed locale timestamps in user-uploaded datasets
+  - Convert "3 days ago" log phrases into training-window bounds
+  - Extract publication dates from multilingual web corpora for RAG

--- a/tools/dev-tools/python-dotenv.yaml
+++ b/tools/dev-tools/python-dotenv.yaml
@@ -1,0 +1,28 @@
+name: python-dotenv
+description: Reads key-value pairs from a .env file and loads them into environment variables. python-dotenv is the standard way ML apps keep API keys, model endpoints, and 12-factor config out of source while still running locally.
+tagline: Load .env files into environment variables for Python apps
+
+github_url: https://github.com/theskumar/python-dotenv
+website_url: https://saurabh-kumar.com/python-dotenv/
+docs_url: https://saurabh-kumar.com/python-dotenv/
+
+category: Dev Tools
+tags: [python, dotenv, configuration, secrets, environment, 12-factor, developer-tools]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install python-dotenv
+
+problem_solved: |
+  Training jobs and agent apps need OPENAI_API_KEY, database URLs, and
+  model endpoints without committing secrets. Exporting vars by hand
+  does not travel across laptops and CI. python-dotenv loads a .env
+  file into os.environ so local and 12-factor deploys share the same
+  config pattern.
+
+use_cases:
+  - Load LLM API keys from a gitignored .env in local agent development
+  - Share the same env-file pattern between FastAPI serving and training scripts
+  - Override nested config in pytest without exporting shell variables
+  - Keep model endpoint URLs out of committed YAML for staging vs production


### PR DESCRIPTION
## Add 5 tools to the catalog

Python stdlib extras, env loading, converters, validation, and date parsing used in ML pipelines.

| Tool | Category | Stars | License |
|------|----------|-------|---------|
| boltons | Dev Tools | 6.9k | BSD-3-Clause |
| python-dotenv | Dev Tools | 8.9k | BSD-3-Clause |
| cattrs | Dev Tools | 1.1k | MIT |
| cerberus | Dev Tools | 3.3k | ISC |
| dateparser | Dev Tools | 2.9k | BSD-3-Clause |

- Install commands verified on PyPI
- Local YAML validation passed for all five files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for five Python developer tools: boltons, cattrs, cerberus, dateparser, and python-dotenv.
  * Included descriptions, documentation links, licensing and pricing details, installation commands, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->