### PR TITLE
Add Pydantic, cryptography, trio, ujson, lxml to catalog

### DIFF
--- a/tools/data/lxml.yaml
+++ b/tools/data/lxml.yaml
@@ -1,0 +1,27 @@
+name: lxml
+description: A Python XML and HTML toolkit on top of libxml2 and libxslt. lxml is used to parse messy web pages, sitemap XML, and document trees for scraping, RAG ingestion, and data extraction faster than stdlib ElementTree.
+tagline: Fast XML and HTML parsing for Python
+
+github_url: https://github.com/lxml/lxml
+website_url: https://lxml.de/
+docs_url: https://lxml.de/
+
+category: Data
+tags: [python, xml, html, parsing, scraping, xpath, data-extraction]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install lxml
+
+problem_solved: |
+  RAG crawlers and scrapers hit broken HTML and huge XML dumps that
+  stdlib ElementTree chokes on. Beautiful Soup is convenient but slow
+  on large trees. lxml binds libxml2 so XPath, CSS select, and XML
+  writes stay fast enough for document ingestion pipelines.
+
+use_cases:
+  - Parse crawled HTML for RAG chunking with XPath or CSS selectors
+  - Ingest sitemap and document XML at scale for a knowledge base
+  - Back Beautiful Soup with the lxml parser for faster scraping
+  - Transform XML feature dumps with XSLT before a training job

--- a/tools/data/ujson.yaml
+++ b/tools/data/ujson.yaml
@@ -1,0 +1,27 @@
+name: ujson
+description: An ultra-fast JSON encoder and decoder written in C with Python bindings. ujson is used in inference servers and data pipelines that serialize embeddings, traces, and request bodies where CPython json is the bottleneck.
+tagline: Ultra-fast C JSON encoder and decoder for Python
+
+github_url: https://github.com/ultrajson/ultrajson
+website_url: https://pypi.org/project/ujson/
+docs_url: https://github.com/ultrajson/ultrajson
+
+category: Data
+tags: [python, json, serialization, performance, c-extension, data-processing]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install ujson
+
+problem_solved: |
+  High-QPS model servers and feature stores spend a large share of CPU
+  on json.dumps of embeddings and traces. The stdlib json module is
+  correct but slow on large nested payloads. ujson encodes and decodes
+  in C so those hot paths stay off the interpreter.
+
+use_cases:
+  - Speed up JSON request and response bodies on a Python inference API
+  - Dump embedding batches and feature rows without stdlib json overhead
+  - Parse high-volume trace logs in an observability pipeline
+  - Drop-in replace json.dumps in a hot serialization loop after measuring

--- a/tools/dev-tools/cryptography.yaml
+++ b/tools/dev-tools/cryptography.yaml
@@ -1,0 +1,28 @@
+name: cryptography
+description: A Python library of cryptographic primitives and recipes, including TLS, Fernet, X.509, and hashing. cryptography is the package ML services use for API token signing, secret encryption, and certificate work instead of rolling custom crypto.
+tagline: Cryptographic recipes and primitives for Python
+
+github_url: https://github.com/pyca/cryptography
+website_url: https://cryptography.io
+docs_url: https://cryptography.io/en/latest/
+
+category: Dev Tools
+tags: [python, cryptography, tls, x509, encryption, security, hashing]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install cryptography
+
+problem_solved: |
+  Agent platforms store API keys, sign webhooks, and terminate TLS.
+  Homegrown AES or hashlib wrappers are easy to get wrong. cryptography
+  ships reviewed recipes such as Fernet plus low-level primitives so
+  Python services encrypt secrets and verify certificates without
+  inventing a cipher.
+
+use_cases:
+  - Encrypt API keys and model-cache blobs at rest with Fernet
+  - Sign and verify webhooks from LLM vendors and CI systems
+  - Load X.509 certificates for mTLS between training and serving
+  - Hash and compare secrets without depending on OpenSSL bindings directly

--- a/tools/dev-tools/pydantic.yaml
+++ b/tools/dev-tools/pydantic.yaml
@@ -1,0 +1,28 @@
+name: Pydantic
+description: Data validation and settings management for Python using type hints. Pydantic parses JSON and Python objects into typed models, rejects bad input, and is the schema layer behind FastAPI, LangChain, and most agent tool-calling stacks.
+tagline: Type-hint data validation for Python APIs and agents
+
+github_url: https://github.com/pydantic/pydantic
+website_url: https://docs.pydantic.dev
+docs_url: https://docs.pydantic.dev
+
+category: Dev Tools
+tags: [python, validation, type-hints, json-schema, fastapi, pydantic, serialization]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install pydantic
+
+problem_solved: |
+  Agent tools, APIs, and training configs ingest JSON that does not
+  match the expected shape. Hand-written checks miss nested fields and
+  drift from type hints. Pydantic turns annotated models into runtime
+  validators and JSON Schema so bad payloads fail fast instead of
+  corrupting a pipeline downstream.
+
+use_cases:
+  - Validate LLM tool-call arguments against a typed Pydantic model
+  - Parse API request bodies in FastAPI and agent gateways
+  - Generate JSON Schema for structured output and function calling
+  - Load YAML or env settings into typed config objects for training jobs

--- a/tools/dev-tools/trio.yaml
+++ b/tools/dev-tools/trio.yaml
@@ -1,0 +1,28 @@
+name: trio
+description: A Python async library for structured concurrency that cancels child tasks as a tree instead of leaking them. Trio is used for network clients, agent I/O, and test harnesses that need timeouts and nurseries without asyncio's unstructured task soup.
+tagline: Structured concurrency for Python async I/O
+
+github_url: https://github.com/python-trio/trio
+website_url: https://trio.readthedocs.io
+docs_url: https://trio.readthedocs.io
+
+category: Dev Tools
+tags: [python, async, concurrency, networking, structured-concurrency, io]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install trio
+
+problem_solved: |
+  asyncio tasks outlive their parents, so a failed LLM call can leave
+  sockets and child work running. Timeouts then become ad-hoc cancels.
+  Trio nurseries start and cancel a tree of tasks together, which makes
+  agent I/O, tests, and network clients fail cleanly instead of leaking
+  background work.
+
+use_cases:
+  - Run parallel tool calls with a nursery that cancels on first error
+  - Write async network clients with timeouts that actually stop I/O
+  - Test concurrent agent workflows without leftover asyncio tasks
+  - Port AnyIO backends that prefer Trio over asyncio for structured cancel


### PR DESCRIPTION
## Summary

Add five Python libraries used daily in AI/ML stacks:

- **Pydantic** (Dev Tools) — type-hint data validation; schema layer for FastAPI and agent tool calling
- **cryptography** (Dev Tools) — cryptographic recipes and primitives (Fernet, X.509, hashing)
- **trio** (Dev Tools) — structured concurrency for Python async I/O
- **ujson** (Data) — ultra-fast C JSON encoder/decoder
- **lxml** (Data) — libxml2-backed XML/HTML toolkit for scraping and RAG ingestion

All five are active, unarchived OSS packages with verified PyPI install commands.

## Validation

Local `npx tsx scripts/validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for lxml and ujson, including descriptions, installation details, metadata, and practical use cases.
  * Added developer-tool entries for cryptography, Pydantic, and Trio with documentation links, licensing information, installation commands, and common use cases.
  * Expanded the catalog’s coverage of XML/HTML parsing, JSON serialization, cryptography, data validation, and asynchronous Python development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->