### PR TITLE
Add PyYAML, tabulate, fsspec, jsonpickle to catalog

### DIFF
--- a/tools/data/fsspec.yaml
+++ b/tools/data/fsspec.yaml
@@ -1,0 +1,27 @@
+name: fsspec
+description: A Python filesystem interface that gives one API over local disk, S3, GCS, Azure, HTTP, and more. fsspec is how Pandas, Dask, Hugging Face datasets, and training jobs open cloud paths without vendor-specific SDKs in application code.
+tagline: One filesystem API for local disk and cloud object stores
+
+github_url: https://github.com/fsspec/filesystem_spec
+website_url: https://filesystem-spec.readthedocs.io
+docs_url: https://filesystem-spec.readthedocs.io
+
+category: Data
+tags: [python, filesystem, s3, gcs, azure, pandas, dask, data-loading]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install fsspec
+
+problem_solved: |
+  Training and RAG pipelines read from S3, GCS, and local disk with
+  different SDKs. Switching storage then rewrites every open() call.
+  fsspec exposes a common filesystem API so Pandas, Dask, and dataset
+  loaders take s3:// or gcs:// URLs without vendor code in the job.
+
+use_cases:
+  - Open s3:// and gcs:// dataset paths from Pandas or Dask with one API
+  - Cache remote files locally during repeated Hugging Face dataset loads
+  - Write checkpoints to object storage without an AWS SDK in training code
+  - List and glob cloud prefixes the same way you glob a local directory

--- a/tools/data/jsonpickle.yaml
+++ b/tools/data/jsonpickle.yaml
@@ -1,0 +1,27 @@
+name: jsonpickle
+description: A Python library that serializes arbitrary object graphs to JSON and reconstitutes them. jsonpickle is used to persist custom classes, NumPy-adjacent objects, and experiment state when pickle is unsafe or not portable.
+tagline: Serialize arbitrary Python object graphs to JSON
+
+github_url: https://github.com/jsonpickle/jsonpickle
+website_url: https://jsonpickle.readthedocs.io
+docs_url: https://jsonpickle.readthedocs.io/en/latest/
+
+category: Data
+tags: [python, json, serialization, pickle, object-graph, checkpointing]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install jsonpickle
+
+problem_solved: |
+  Experiment state and custom Python classes are not JSON-serializable,
+  and pickle is binary, unsafe across trust boundaries, and version
+  brittle. jsonpickle encodes object graphs as JSON so checkpoints,
+  caches, and debug dumps stay readable and language-portable.
+
+use_cases:
+  - Checkpoint custom experiment objects as JSON instead of pickle
+  - Dump object graphs for debugging agent state without binary pickle
+  - Persist class instances in a cache that other languages can inspect
+  - Round-trip nested Python objects in notebooks and eval harnesses

--- a/tools/data/pyyaml.yaml
+++ b/tools/data/pyyaml.yaml
@@ -1,0 +1,27 @@
+name: PyYAML
+description: The canonical YAML parser and emitter for Python, wrapping libyaml for fast load and dump. PyYAML is the library most ML configs, Hydra defaults, and Kubernetes manifests go through when Python code reads YAML.
+tagline: Canonical YAML parser and emitter for Python
+
+github_url: https://github.com/yaml/pyyaml
+website_url: https://pyyaml.org
+docs_url: https://pyyaml.org/wiki/PyYAMLDocumentation
+
+category: Data
+tags: [python, yaml, config, parsing, serialization, kubernetes, hydra]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install pyyaml
+
+problem_solved: |
+  Training jobs, agent configs, and Kubernetes manifests live in YAML.
+  Without a standard parser, every tool invents a subset and silently
+  drops tags or duplicates. PyYAML is the canonical CPython binding so
+  load, dump, and custom constructors stay compatible across the stack.
+
+use_cases:
+  - Load Hydra, training, and agent YAML configs into Python dicts
+  - Dump experiment hyperparameters without breaking YAML 1.1 tools
+  - Parse Kubernetes and Compose manifests in Python deploy scripts
+  - Register custom YAML tags for dataset and model object constructors

--- a/tools/dev-tools/tabulate.yaml
+++ b/tools/dev-tools/tabulate.yaml
@@ -1,0 +1,27 @@
+name: tabulate
+description: Pretty-print tabular data in Python as plain text, Markdown, HTML, or LaTeX. tabulate is used in CLI tools, notebooks, and eval reports that need aligned tables from lists of dicts without pulling in a spreadsheet library.
+tagline: Pretty-print tables from Python data structures
+
+github_url: https://github.com/astanin/python-tabulate
+website_url: https://pypi.org/project/tabulate/
+docs_url: https://github.com/astanin/python-tabulate
+
+category: Dev Tools
+tags: [python, tables, cli, markdown, reporting, formatting, notebooks]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install tabulate
+
+problem_solved: |
+  Eval scores, token usage, and CLI inventory dumps are lists of rows
+  that print as ragged dicts. Spreadsheet libraries are heavy for a
+  terminal table. tabulate aligns columns and emits Markdown or HTML so
+  agent CLIs and notebooks show readable tables without extra deps.
+
+use_cases:
+  - Print model eval metrics as a Markdown table in a GitHub report
+  - Format CLI inventory of tools, jobs, or GPU nodes as aligned text
+  - Render notebook experiment comparisons without pandas styling
+  - Export HTML tables from Python scripts for internal dashboards


### PR DESCRIPTION
## Summary

Add four Python data and reporting libraries:

- **PyYAML** (Data) — canonical YAML parser/emitter for Python (libyaml)
- **tabulate** (Dev Tools) — pretty-print tables as text, Markdown, HTML, or LaTeX
- **fsspec** (Data) — unified filesystem API for local disk, S3, GCS, Azure, HTTP
- **jsonpickle** (Data) — serialize arbitrary Python object graphs to JSON

All four are active, unarchived OSS packages with verified PyPI install commands.

## Validation

Local `npx tsx scripts/validate-tool.ts` passed for all four files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for the `fsspec`, `jsonpickle`, and PyYAML Python libraries.
  * Added a Dev Tools catalog entry for the `tabulate` library.
  * Included descriptions, links, licensing, pricing, installation instructions, tags, and practical use cases for each entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->