### PR TITLE
Add Werkzeug, alive-progress, PyJWT, XlsxWriter, coverage to catalog

### DIFF
--- a/tools/data/xlsxwriter.yaml
+++ b/tools/data/xlsxwriter.yaml
@@ -1,0 +1,27 @@
+name: XlsxWriter
+description: A Python module for writing Excel .xlsx files with charts, formatting, and images. XlsxWriter is used to export eval reports, cost spreadsheets, and dataset samples that stakeholders open in Excel without pandas ExcelWriter extras.
+tagline: Write Excel xlsx workbooks from Python
+
+github_url: https://github.com/jmcnamara/XlsxWriter
+website_url: https://xlsxwriter.readthedocs.io
+docs_url: https://xlsxwriter.readthedocs.io
+
+category: Data
+tags: [python, excel, xlsx, reporting, spreadsheets, export, data]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+install_command: pip install xlsxwriter
+
+problem_solved: |
+  Eval tables and cost reports need to land in Excel for non-Python
+  stakeholders. CSV drops charts and formatting, and COM automation
+  is Windows-only. XlsxWriter writes real .xlsx workbooks with styles
+  and charts from Python so reports open cleanly in Excel.
+
+use_cases:
+  - Export model eval scorecards as formatted Excel workbooks
+  - Write token-cost and usage spreadsheets with charts
+  - Dump dataset samples to xlsx for analyst review
+  - Generate multi-sheet experiment reports from a training job

--- a/tools/dev-tools/alive-progress.yaml
+++ b/tools/dev-tools/alive-progress.yaml
@@ -1,0 +1,27 @@
+name: alive-progress
+description: A Python progress bar that animates in the terminal and estimates ETA from live throughput. alive-progress is used in training loops, downloads, and long ETL jobs where tqdm-style bars need richer spinners and nested tracking.
+tagline: Animated terminal progress bars with live ETA
+
+github_url: https://github.com/rsalmei/alive-progress
+website_url: https://github.com/rsalmei/alive-progress
+docs_url: https://github.com/rsalmei/alive-progress
+
+category: Dev Tools
+tags: [python, cli, progress-bar, terminal, etl, training, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install alive-progress
+
+problem_solved: |
+  Long training, download, and ETL jobs look frozen without a bar, and
+  basic counters do not show ETA or nested work. alive-progress draws
+  animated bars with live throughput so operators can see whether a
+  job is moving and when it should finish.
+
+use_cases:
+  - Show ETA on dataset downloads and embedding backfills
+  - Track nested progress in multi-stage ETL before training
+  - Replace silent loops in CLI agent tools with an animated bar
+  - Monitor long-running evaluation jobs in a terminal session

--- a/tools/dev-tools/coverage.yaml
+++ b/tools/dev-tools/coverage.yaml
@@ -1,0 +1,27 @@
+name: coverage
+description: A tool for measuring Python code coverage of tests. coverage.py is used in CI for ML libraries and agent apps to see which branches ran, fail the build below a threshold, and publish HTML reports.
+tagline: Measure Python test coverage in CI and locally
+
+github_url: https://github.com/coveragepy/coveragepy
+website_url: https://coverage.readthedocs.io
+docs_url: https://coverage.readthedocs.io
+
+category: Dev Tools
+tags: [python, testing, coverage, ci, pytest, quality, developer-tools]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install coverage
+
+problem_solved: |
+  Agent and ML libraries ship code paths that tests never hit. pytest
+  green then still hides untested branches. coverage.py traces which
+  lines ran so CI can fail below a threshold and publish an HTML map
+  of gaps before a release.
+
+use_cases:
+  - Fail CI when Python coverage drops below a project threshold
+  - Publish HTML coverage reports for an agent or SDK repo
+  - Find untested branches in data-processing and tool-calling code
+  - Combine coverage from pytest shards in a matrix build

--- a/tools/dev-tools/pyjwt.yaml
+++ b/tools/dev-tools/pyjwt.yaml
@@ -1,0 +1,27 @@
+name: PyJWT
+description: A Python library to encode and decode JSON Web Tokens. PyJWT is used to sign API tokens, verify LLM gateway auth, and pass identity between agent services without a full OAuth stack.
+tagline: Encode and decode JSON Web Tokens in Python
+
+github_url: https://github.com/jpadilla/pyjwt
+website_url: https://pyjwt.readthedocs.io
+docs_url: https://pyjwt.readthedocs.io
+
+category: Dev Tools
+tags: [python, jwt, auth, security, api, tokens, identity]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install pyjwt
+
+problem_solved: |
+  Agent APIs and model gateways need short-lived identity between
+  services. Rolling HMAC tokens by hand is easy to get wrong, and a
+  full OAuth server is heavy. PyJWT encodes and verifies JWTs so
+  services can sign claims and reject expired or tampered tokens.
+
+use_cases:
+  - Sign short-lived JWTs for an inference or agent HTTP API
+  - Verify Authorization bearer tokens at a model gateway
+  - Pass user and workspace claims between microservices
+  - Encode service-to-service identity without a full OAuth server

--- a/tools/dev-tools/werkzeug.yaml
+++ b/tools/dev-tools/werkzeug.yaml
@@ -1,0 +1,28 @@
+name: Werkzeug
+description: A comprehensive WSGI web application library that powers Flask. Werkzeug is the request, response, routing, and debugging toolkit Python teams use when they serve model APIs and agent dashboards without a full framework.
+tagline: WSGI utilities, routing, and debugger behind Flask
+
+github_url: https://github.com/pallets/werkzeug
+website_url: https://werkzeug.palletsprojects.com
+docs_url: https://werkzeug.palletsprojects.com
+
+category: Dev Tools
+tags: [python, wsgi, flask, http, routing, web, serving]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install werkzeug
+
+problem_solved: |
+  Serving an inference or agent HTTP API still needs routing, headers,
+  cookies, and a debugger. Rolling that on raw WSGI is error-prone.
+  Werkzeug is the library Flask is built on, so you get request objects,
+  URL routing, and an interactive debugger without adopting a full
+  framework.
+
+use_cases:
+  - Build a small WSGI wrapper around a model predict() function
+  - Debug Flask and agent dashboards with the interactive traceback
+  - Parse multipart uploads of datasets in a Python HTTP handler
+  - Share routing and header utilities across Flask-based ML services


### PR DESCRIPTION
## Summary

Add five Python libraries used in serving, CI, auth, and reporting:

- **Werkzeug** (Dev Tools) — WSGI request/response/routing toolkit that powers Flask
- **alive-progress** (Dev Tools) — animated terminal progress bars with live ETA
- **PyJWT** (Dev Tools) — encode and decode JSON Web Tokens
- **XlsxWriter** (Data) — write Excel .xlsx workbooks with charts and formatting
- **coverage** (Dev Tools) — Python test coverage measurement for CI

All five are active, unarchived OSS packages with verified PyPI install commands.

## Validation

Local `npx tsx scripts/validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog metadata for XlsxWriter, including Excel export capabilities and common reporting use cases.
  * Added developer-tool entries for alive-progress, coverage, PyJWT, and Werkzeug.
  * Documented installation commands, licensing, links, categories, tags, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->