### PR TITLE
Add PyOTP, itsdangerous, setuptools, Flit to catalog

### DIFF
--- a/tools/dev-tools/flit.yaml
+++ b/tools/dev-tools/flit.yaml
@@ -1,0 +1,23 @@
+name: Flit
+description: "Simplified Python packaging tool that publishes pure-Python packages to PyPI from pyproject.toml, without a setup.py, for projects that do not need a heavyweight build backend."
+tagline: "Simple Python packaging from pyproject.toml"
+github_url: https://github.com/pypa/flit
+website_url: https://flit.pypa.io
+docs_url: https://flit.pypa.io/en/stable/
+install_command: "pip install flit"
+category: Dev Tools
+tags:
+  - python
+  - packaging
+  - pypi
+  - pyproject
+  - build
+  - publishing
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Publishing a small pure-Python library often means fighting setuptools boilerplate, setup.py scripts, and extra build configuration. Flit uses a short pyproject.toml, builds an sdist and wheel, and uploads to PyPI in a few commands, so CLI tools and lightweight libraries can ship without a full packaging toolchain."
+use_cases:
+  - "Publish a pure-Python library or CLI tool to PyPI with flit build and flit publish from pyproject.toml"
+  - "Replace setup.py on a small package with a short [project] table and a PEP 517 flit_core backend"
+  - "Build reproducible sdists and wheels for internal Python utilities without a heavyweight packaging stack"

--- a/tools/dev-tools/itsdangerous.yaml
+++ b/tools/dev-tools/itsdangerous.yaml
@@ -1,0 +1,23 @@
+name: itsdangerous
+description: "Pallets library that cryptographically signs data so it can be sent into untrusted environments such as cookies, URLs, and sessions, then verified later for integrity."
+tagline: "Sign data for untrusted environments"
+github_url: https://github.com/pallets/itsdangerous
+website_url: https://itsdangerous.palletsprojects.com
+docs_url: https://itsdangerous.palletsprojects.com
+install_command: "pip install itsdangerous"
+category: Dev Tools
+tags:
+  - python
+  - security
+  - signing
+  - sessions
+  - flask
+  - cryptography
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Web apps need to pass trusted values through cookies, query strings, and email links without a round trip to a database, but unsigned data can be forged. itsdangerous provides timed serializers and signer helpers that attach HMAC signatures (and optional expiration) so Flask sessions, password-reset tokens, and state cookies can leave the server and come back intact or be rejected as tampered."
+use_cases:
+  - "Sign Flask or custom session cookies so client-side session data cannot be forged without the secret key"
+  - "Create timed password-reset or email-confirmation tokens that expire after a set interval"
+  - "Pass signed state through OAuth redirects or webhook payloads and verify integrity on the way back"

--- a/tools/dev-tools/pyotp.yaml
+++ b/tools/dev-tools/pyotp.yaml
@@ -1,0 +1,23 @@
+name: PyOTP
+description: "Python library for generating and verifying HOTP and TOTP one-time passwords (RFC 4226 and RFC 6238), with provisioning URIs for authenticator apps such as Google Authenticator."
+tagline: "Python one-time password library"
+github_url: https://github.com/pyauth/pyotp
+website_url: https://pyauth.github.io/pyotp/
+docs_url: https://pyauth.github.io/pyotp/
+install_command: "pip install pyotp"
+category: Dev Tools
+tags:
+  - python
+  - 2fa
+  - totp
+  - hotp
+  - security
+  - authentication
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Adding two-factor authentication to a Python app usually means integrating a vendor SDK or reimplementing HOTP and TOTP from the RFCs. PyOTP is a small, dependency-light library that generates and verifies HMAC-based and time-based one-time passwords, plus otpauth provisioning URIs so users can enroll Google Authenticator, Authy, or any RFC-compliant authenticator without a third-party identity vendor."
+use_cases:
+  - "Add TOTP-based two-factor authentication to a Python web app or API so users can enroll Google Authenticator or Authy"
+  - "Generate otpauth provisioning URIs and QR payloads so new accounts can scan a secret into an authenticator app"
+  - "Verify HOTP or TOTP codes server-side during login, password reset, or sensitive action confirmation"

--- a/tools/dev-tools/setuptools.yaml
+++ b/tools/dev-tools/setuptools.yaml
@@ -1,0 +1,23 @@
+name: setuptools
+description: "Official Python packaging library used to build, distribute, and install packages. It implements setup.py and setup.cfg workflows, PEP 517 builds, and the backend most pip installs still rely on."
+tagline: "Python packaging and build backend"
+github_url: https://github.com/pypa/setuptools
+website_url: https://pypi.org/project/setuptools/
+docs_url: https://setuptools.pypa.io
+install_command: "pip install setuptools"
+category: Dev Tools
+tags:
+  - python
+  - packaging
+  - build
+  - pep517
+  - pypi
+  - pip
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Python libraries need a standard way to declare metadata, compile extensions, and produce installable distributions. setuptools is the long-standing build backend that reads setup.py, setup.cfg, or pyproject.toml, builds wheels and sdists, and remains the default engine behind pip install for thousands of packages, including scientific and ML projects that still ship C extensions."
+use_cases:
+  - "Declare package metadata and dependencies in setup.py or pyproject.toml so pip can install a library from source or PyPI"
+  - "Build wheels and source distributions for C-extension and pure-Python packages before uploading to PyPI"
+  - "Use setuptools as the PEP 517 build-backend for ML libraries that compile native extensions during install"


### PR DESCRIPTION
## Summary

Adds four Python developer tools to the Agentic AI For Good catalog:

- **PyOTP** — HOTP/TOTP one-time password library for 2FA
- **itsdangerous** — cryptographic signing for cookies, URLs, and sessions
- **setuptools** — official Python packaging and build backend
- **Flit** — simplified pyproject.toml packaging for pure-Python packages

## Files

- `tools/dev-tools/pyotp.yaml`
- `tools/dev-tools/itsdangerous.yaml`
- `tools/dev-tools/setuptools.yaml`
- `tools/dev-tools/flit.yaml`

Local validation passed for all four files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Flit, itsdangerous, PyOTP, and setuptools.
  - Included descriptions, documentation links, installation commands, categories, tags, licensing, pricing, and open-source details.
  - Documented key use cases, including Python package publishing, signed tokens, one-time passwords, and authentication provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->