### PR TITLE
Add Twine, bcrypt, Authlib, oauthlib, commitizen to catalog

### DIFF
--- a/tools/dev-tools/authlib.yaml
+++ b/tools/dev-tools/authlib.yaml
@@ -1,0 +1,23 @@
+name: Authlib
+description: "Python library for OAuth 1/2, OpenID Connect, and JOSE (JWS, JWE, JWK, JWT), used to build standards-compliant auth clients and servers without assembling one-off crypto code."
+tagline: "OAuth, OIDC, and JOSE for Python"
+github_url: https://github.com/authlib/authlib
+website_url: https://authlib.org
+docs_url: https://docs.authlib.org
+install_command: "pip install authlib"
+category: Dev Tools
+tags:
+  - python
+  - oauth
+  - oidc
+  - jwt
+  - authentication
+  - security
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Adding social login or an OAuth 2 server in Python often means stitching Flask-Dance, PyJWT, and ad-hoc HTTP together and getting the spec wrong. Authlib implements OAuth 1/2, OpenID Connect, and JOSE in one library, with integrations for Flask, Django, FastAPI, and Starlette so teams can ship spec-compliant clients and authorization servers."
+use_cases:
+  - "Add GitHub, Google, or OIDC login to a Flask or FastAPI app with Authlib's client integrations"
+  - "Build an OAuth 2 authorization server that issues access and refresh tokens for first-party APIs"
+  - "Sign and encrypt JWTs with JWS/JWE helpers instead of assembling JOSE from lower-level crypto"

--- a/tools/dev-tools/bcrypt.yaml
+++ b/tools/dev-tools/bcrypt.yaml
@@ -1,0 +1,22 @@
+name: bcrypt
+description: "Python bindings for the bcrypt password-hashing algorithm, used to store passwords as salted hashes that are expensive to brute-force compared with MD5 or SHA-1."
+tagline: "bcrypt password hashing for Python"
+github_url: https://github.com/pyca/bcrypt
+website_url: https://github.com/pyca/bcrypt
+docs_url: https://github.com/pyca/bcrypt
+install_command: "pip install bcrypt"
+category: Dev Tools
+tags:
+  - python
+  - security
+  - passwords
+  - hashing
+  - cryptography
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Storing login passwords with SHA-256 or unsalted hashes lets attackers crack dumps quickly. bcrypt provides a slow, adaptive, salted hash designed for passwords, with a Python API to hash and verify credentials so web apps and APIs can store secrets that remain expensive to brute-force even if the database leaks."
+use_cases:
+  - "Hash user passwords at registration with bcrypt.hashpw and a per-user salt before writing to the database"
+  - "Verify login attempts with bcrypt.checkpw without storing plaintext or reversible ciphertext"
+  - "Raise the bcrypt cost factor over time so password hashes stay expensive as hardware gets faster"

--- a/tools/dev-tools/commitizen.yaml
+++ b/tools/dev-tools/commitizen.yaml
@@ -1,0 +1,23 @@
+name: commitizen
+description: "Commit convention toolkit that enforces structured commit messages, auto-bumps versions, and generates changelogs from git history for Python and polyglot projects."
+tagline: "Conventional commits, versions, and changelogs"
+github_url: https://github.com/commitizen-tools/commitizen
+website_url: https://commitizen-tools.github.io/commitizen/
+docs_url: https://commitizen-tools.github.io/commitizen/
+install_command: "pip install commitizen"
+category: Dev Tools
+tags:
+  - python
+  - git
+  - versioning
+  - changelog
+  - ci
+  - conventional-commits
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "Teams that version packages by hand drift: commit messages stay unstructured, changelogs lag, and bumps miss the actual API change. commitizen prompts for conventional commits, computes the next semver from history, and writes a changelog so Python libraries and CLIs can release from CI without editing version files by hand."
+use_cases:
+  - "Run cz commit so contributors write conventional commit messages instead of free-form one-liners"
+  - "Auto-bump package versions and generate CHANGELOG.md in CI from git history before a PyPI release"
+  - "Standardize commit style across a monorepo so semantic-release tools and PR bots can parse history"

--- a/tools/dev-tools/oauthlib.yaml
+++ b/tools/dev-tools/oauthlib.yaml
@@ -1,0 +1,22 @@
+name: oauthlib
+description: "Generic, spec-compliant Python implementation of OAuth 1 and OAuth 2 request-signing logic that frameworks use as the protocol core rather than talking to a single vendor."
+tagline: "Spec-compliant OAuth for Python"
+github_url: https://github.com/oauthlib/oauthlib
+website_url: https://oauthlib.readthedocs.io
+docs_url: https://oauthlib.readthedocs.io
+install_command: "pip install oauthlib"
+category: Dev Tools
+tags:
+  - python
+  - oauth
+  - authentication
+  - security
+  - http
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "OAuth request signing is easy to get wrong: nonce reuse, missing PKCE, or malformed Authorization headers break providers and leak tokens. oauthlib is a transport-agnostic implementation of OAuth 1 and OAuth 2 used by requests-oauthlib and many web frameworks, so applications follow the spec without reimplementing signature and grant logic."
+use_cases:
+  - "Sign OAuth 1 or OAuth 2 requests from a Python client without depending on a single HTTP library"
+  - "Power requests-oauthlib or a custom API client that talks to Twitter, GitHub, or other OAuth providers"
+  - "Implement authorization-code, client-credentials, or PKCE flows with spec-checked parameter handling"

--- a/tools/dev-tools/twine.yaml
+++ b/tools/dev-tools/twine.yaml
@@ -1,0 +1,22 @@
+name: Twine
+description: "PyPA utility for publishing Python packages to PyPI and other indexes. It uploads sdists and wheels with API-token auth, GPG signing, and checks that files are well-formed before they go live."
+tagline: "Publish Python packages to PyPI"
+github_url: https://github.com/pypa/twine
+website_url: https://twine.readthedocs.io
+docs_url: https://twine.readthedocs.io
+install_command: "pip install twine"
+category: Dev Tools
+tags:
+  - python
+  - packaging
+  - pypi
+  - publishing
+  - wheels
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Uploading a package with raw HTTP or setup.py upload skips checks and often leaks credentials. Twine is the supported PyPA client: it validates distributions, uses PyPI API tokens over HTTPS, can GPG-sign artifacts, and refuses to upload broken metadata so releases to PyPI or a private index do not fail after the fact."
+use_cases:
+  - "Upload built sdists and wheels to PyPI with twine upload after a CI build"
+  - "Publish internal packages to a private Python index using repository URL and API token config"
+  - "Check distributions with twine check before tagging a release so long description rendering will not fail on PyPI"


### PR DESCRIPTION
## Summary

Adds five Python developer tools to the Agentic AI For Good catalog:

- **Twine** — PyPA client for publishing packages to PyPI
- **bcrypt** — password hashing bindings
- **Authlib** — OAuth, OIDC, and JOSE library
- **oauthlib** — spec-compliant OAuth request signing
- **commitizen** — conventional commits, version bumps, and changelogs

## Files

- `tools/dev-tools/twine.yaml`
- `tools/dev-tools/bcrypt.yaml`
- `tools/dev-tools/authlib.yaml`
- `tools/dev-tools/oauthlib.yaml`
- `tools/dev-tools/commitizen.yaml`

Local validation passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Authlib, bcrypt, Commitizen, OAuthlib, and Twine.
  * Included descriptions, installation instructions, documentation links, licensing, pricing, categories, and tags.
  * Added practical use cases for authentication, password security, commit workflows, OAuth integrations, and Python package publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->