### PR TITLE
Add Renovate, APISIX, and Python WSGI/ASGI servers to catalog

### DIFF
--- a/tools/dev-tools/apisix.yaml
+++ b/tools/dev-tools/apisix.yaml
@@ -1,0 +1,22 @@
+name: APISIX
+description: "Apache cloud-native API gateway and AI gateway built on OpenResty, with dynamic routing, plugins, and traffic control for HTTP, gRPC, and LLM proxy use cases."
+tagline: "Cloud-native API and AI gateway"
+github_url: https://github.com/apache/apisix
+website_url: https://apisix.apache.org
+docs_url: https://apisix.apache.org/docs/
+category: Dev Tools
+tags:
+  - api-gateway
+  - reverse-proxy
+  - kubernetes
+  - llm
+  - openresty
+  - traffic
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Exposing model inference and microservices to the internet needs auth, rate limits, and routing without rewriting each service. APISIX is a high-performance gateway with a plugin model for JWT, limiting, observability, and AI/LLM proxying so teams put one control plane in front of APIs and model endpoints."
+use_cases:
+  - "Route HTTP and gRPC traffic to microservices with dynamic upstreams and health checks"
+  - "Put an AI gateway in front of LLM providers to apply auth, token quotas, and request logging"
+  - "Run APISIX on Kubernetes as the ingress data plane with etcd-backed configuration"

--- a/tools/dev-tools/hypercorn.yaml
+++ b/tools/dev-tools/hypercorn.yaml
@@ -1,0 +1,23 @@
+name: Hypercorn
+description: "ASGI and WSGI server based on the Hyper libraries and inspired by Gunicorn, with HTTP/1, HTTP/2, HTTP/3, and WebSocket support for FastAPI, Starlette, and Quart apps."
+tagline: "ASGI/WSGI server with HTTP/2 and HTTP/3"
+github_url: https://github.com/pgjones/hypercorn
+website_url: https://hypercorn.readthedocs.io
+docs_url: https://hypercorn.readthedocs.io
+install_command: "pip install hypercorn"
+category: Dev Tools
+tags:
+  - python
+  - asgi
+  - wsgi
+  - http2
+  - fastapi
+  - serving
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: "ASGI apps need HTTP/2, HTTP/3, and WebSockets in production, but many WSGI servers stop at HTTP/1.1. Hypercorn serves ASGI and WSGI with HTTP/2 and HTTP/3, so FastAPI, Starlette, and Quart services can take HTTP/2 traffic and WebSocket streams without a separate proxy just for protocol support."
+use_cases:
+  - "Serve a FastAPI or Quart app with HTTP/2 and WebSockets using hypercorn as the process"
+  - "Run mixed ASGI and WSGI applications in one worker when migrating a Flask service toward async"
+  - "Expose HTTP/3 endpoints for low-latency model APIs where a Gunicorn-only stack is not enough"

--- a/tools/dev-tools/renovate.yaml
+++ b/tools/dev-tools/renovate.yaml
@@ -1,0 +1,22 @@
+name: Renovate
+description: "Cross-platform dependency automation that opens pull requests to update npm, pip, Docker, GitHub Actions, and other manifests on a schedule, with grouping, automerge, and package-manager-aware versioning."
+tagline: "Automated dependency update pull requests"
+github_url: https://github.com/renovatebot/renovate
+website_url: https://mend.io/renovate
+docs_url: https://docs.renovatebot.com
+install_command: "npm install -g renovate"
+category: Dev Tools
+tags:
+  - dependencies
+  - ci
+  - github
+  - security
+  - automation
+pricing: freemium
+is_open_source: true
+license: AGPL-3.0
+problem_solved: "Keeping lockfiles and Docker images current across a polyglot repo is tedious, so teams fall behind on security patches. Renovate scans package files, respects version ranges and changelogs, and opens grouped PRs on GitHub, GitLab, or self-hosted git so ML and app repos stay patched without a human bumping every pin."
+use_cases:
+  - "Install the Renovate GitHub App so Python, Node, and Actions dependencies get scheduled update PRs"
+  - "Self-host renovate as a CLI or GitHub Action to update private registries and monorepos"
+  - "Group related package updates and automerge patch releases after CI passes to cut review load"

--- a/tools/dev-tools/waitress.yaml
+++ b/tools/dev-tools/waitress.yaml
@@ -1,0 +1,22 @@
+name: Waitress
+description: "Production WSGI server for Python 3 from the Pylons project. It is pure Python, has no required C extensions, and is designed to run on Windows and Unix without a reverse-proxy requirement in small deployments."
+tagline: "Pure-Python production WSGI server"
+github_url: https://github.com/Pylons/waitress
+website_url: https://docs.pylonsproject.org/projects/waitress/en/latest/
+docs_url: https://docs.pylonsproject.org/projects/waitress/en/latest/
+install_command: "pip install waitress"
+category: Dev Tools
+tags:
+  - python
+  - wsgi
+  - http
+  - serving
+  - web
+pricing: free
+is_open_source: true
+license: ZPL-2.1
+problem_solved: "Flask and Pyramid apps need a production WSGI server, but Gunicorn does not run on Windows and the built-in dev server is not safe for production. Waitress is a pure-Python WSGI server that works on Windows and Unix, so ML model APIs and internal tools can be served without compiling C extensions or depending on a Unix-only process manager."
+use_cases:
+  - "Serve a Flask or Pyramid ML scoring API in production on Windows or Linux with waitress-serve"
+  - "Replace the Flask development server before exposing an internal tool beyond localhost"
+  - "Run a WSGI app behind IIS or as a Windows service where Gunicorn is not available"


### PR DESCRIPTION
## Summary

Adds four developer tools to the Agentic AI For Good catalog:

- **Renovate** — automated dependency update PRs across package ecosystems
- **APISIX** — Apache cloud-native API gateway and AI gateway
- **Waitress** — pure-Python production WSGI server (Pylons)
- **Hypercorn** — ASGI/WSGI server with HTTP/2 and HTTP/3

## Files

- `tools/dev-tools/renovate.yaml`
- `tools/dev-tools/apisix.yaml`
- `tools/dev-tools/waitress.yaml`
- `tools/dev-tools/hypercorn.yaml`

Local validation passed for all four files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Apache APISIX, Hypercorn, Renovate, and Waitress.
  * Added descriptions, categories, tags, licensing, pricing, installation details, and relevant website and documentation links.
  * Documented practical use cases, including API gateway routing, HTTP/2 and HTTP/3 serving, dependency automation, and WSGI application hosting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->