### PR TITLE
Add packaging, certifi, defusedxml, multiprocess to catalog

### DIFF
--- a/tools/dev-tools/certifi.yaml
+++ b/tools/dev-tools/certifi.yaml
@@ -1,0 +1,23 @@
+name: certifi
+description: "Curated Mozilla CA bundle for Python, used by Requests, urllib3, and pip to verify TLS certificates against a current set of root certificates instead of an incomplete system store."
+tagline: "Mozilla CA bundle for Python TLS"
+github_url: https://github.com/certifi/python-certifi
+website_url: https://github.com/certifi/python-certifi
+docs_url: https://github.com/certifi/python-certifi
+install_command: "pip install certifi"
+category: Dev Tools
+tags:
+  - python
+  - tls
+  - ssl
+  - certificates
+  - security
+  - http
+pricing: free
+is_open_source: true
+license: MPL-2.0
+problem_solved: "Python HTTPS clients fail or silently skip verification when the OS CA store is missing or outdated, especially in containers and Windows embeds. certifi ships the Mozilla root bundle and a where() helper so Requests, pip, and custom HTTP clients can verify TLS with a known-good CA set."
+use_cases:
+  - "Point Requests or urllib3 at certifi.where() so TLS verification uses the Mozilla CA bundle"
+  - "Bundle a current CA set in a Docker image that has no OS certificate package"
+  - "Give pip and other installers a trusted root store when installing packages over HTTPS"

--- a/tools/dev-tools/defusedxml.yaml
+++ b/tools/dev-tools/defusedxml.yaml
@@ -1,0 +1,22 @@
+name: defusedxml
+description: "Python XML parsers that block XML bombs and XXE attacks by disabling entity expansion and remote DTDs on top of the standard library xml modules."
+tagline: "Safe XML parsing against XXE and bombs"
+github_url: https://github.com/tiran/defusedxml
+website_url: https://github.com/tiran/defusedxml
+docs_url: https://github.com/tiran/defusedxml
+install_command: "pip install defusedxml"
+category: Dev Tools
+tags:
+  - python
+  - xml
+  - security
+  - xxe
+  - parsing
+pricing: free
+is_open_source: true
+license: PSF-2.0
+problem_solved: "The standard library xml modules expand external entities and nested entities by default, so untrusted XML can read files or exhaust memory. defusedxml wraps ElementTree, minidom, and sax with safe defaults so APIs that ingest XML, SOAP, or SVG do not become XXE or billion-laughs endpoints."
+use_cases:
+  - "Parse untrusted XML uploads with defusedxml.ElementTree instead of xml.etree"
+  - "Harden SOAP or RSS ingestion in a data pipeline against XXE and XML bombs"
+  - "Drop-in replace stdlib XML parsers in an existing service that accepts XML from users"

--- a/tools/dev-tools/multiprocess.yaml
+++ b/tools/dev-tools/multiprocess.yaml
@@ -1,0 +1,22 @@
+name: multiprocess
+description: "Drop-in multiprocessing replacement that uses dill for serialization, so worker processes can pickle closures, lambdas, and nested functions that the stdlib multiprocessing module cannot."
+tagline: "multiprocessing with dill serialization"
+github_url: https://github.com/uqfoundation/multiprocess
+website_url: https://multiprocess.readthedocs.io
+docs_url: https://multiprocess.readthedocs.io
+install_command: "pip install multiprocess"
+category: Dev Tools
+tags:
+  - python
+  - multiprocessing
+  - parallel
+  - dill
+  - serialization
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: "Python multiprocessing Pickler cannot send lambdas, nested functions, or many dynamic objects to workers, which breaks parallel map over closures. multiprocess uses dill so data science and ML jobs can fan work out to processes without rewriting callables as top-level functions."
+use_cases:
+  - "Parallelize a map over closures or lambdas that stdlib multiprocessing refuses to pickle"
+  - "Run CPU-bound feature extraction in worker processes from a notebook without extracting helpers to a module"
+  - "Replace multiprocessing.Pool with multiprocess.Pool in pathos-style scientific pipelines"

--- a/tools/dev-tools/packaging.yaml
+++ b/tools/dev-tools/packaging.yaml
@@ -1,0 +1,22 @@
+name: packaging
+description: "PyPA core utilities for Python package versions, specifiers, markers, and tags. Libraries and installers use it to parse PEP 440 versions and environment markers without reimplementing the specs."
+tagline: "Core Python packaging version utilities"
+github_url: https://github.com/pypa/packaging
+website_url: https://packaging.pypa.io
+docs_url: https://packaging.pypa.io
+install_command: "pip install packaging"
+category: Dev Tools
+tags:
+  - python
+  - packaging
+  - pep440
+  - pypi
+  - versions
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: "Comparing package versions with string splits breaks on PEP 440 epochs, pre-releases, and local versions. packaging is the shared library pip, setuptools, and build tools use to parse versions, specifiers, and markers so tools agree on whether 1.0a1 satisfies >=1.0."
+use_cases:
+  - "Parse and compare PEP 440 versions in a custom installer or lockfile tool"
+  - "Evaluate environment markers to decide whether a dependency applies on the current platform"
+  - "Inspect wheel tags and specifiers when debugging why pip will not install a build"


### PR DESCRIPTION
## Summary

Adds four Python developer tools to the Agentic AI For Good catalog:

- **packaging** — PyPA version, specifier, and marker utilities
- **certifi** — Mozilla CA bundle for Python TLS
- **defusedxml** — XML parsers hardened against XXE and XML bombs
- **multiprocess** — multiprocessing with dill serialization

## Files

- `tools/dev-tools/packaging.yaml`
- `tools/dev-tools/certifi.yaml`
- `tools/dev-tools/defusedxml.yaml`
- `tools/dev-tools/multiprocess.yaml`

Local validation passed for all four files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for four Python development tools: `certifi`, `defusedxml`, `multiprocess`, and `packaging`.
  * Included installation details, documentation links, licensing information, categories, and practical use cases for each tool.
  * Added descriptions of security, parallel processing, package metadata, version parsing, and TLS certificate capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->