### PR TITLE
Add semantic-release, Please, Spinnaker, Buildkite, cytoolz to catalog

### DIFF
--- a/tools/dev-tools/buildkite.yaml
+++ b/tools/dev-tools/buildkite.yaml
@@ -1,0 +1,25 @@
+name: Buildkite
+description: Hybrid CI/CD platform that runs jobs on your infrastructure through an open-source agent while hosting the control plane for pipelines, logs, and secrets. Code and artifacts stay in your network with elastic self-hosted runners.
+tagline: Self-hosted CI agents with a hosted pipeline control plane
+
+github_url: https://github.com/buildkite/agent
+website_url: https://buildkite.com
+docs_url: https://buildkite.com/docs
+
+category: Dev Tools
+tags: [ci-cd, self-hosted, agents, pipelines, devops, testing, mlops]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  GPU training jobs and private datasets cannot leave the VPC, but
+  hosted CI runners are off-network and hard to size. Buildkite keeps
+  an open-source agent on your machines (including GPU boxes) while
+  the hosted UI handles pipelines, logs, and secrets, so ML CI stays
+  inside your network without running a full Jenkins cluster.
+
+use_cases:
+  - Run GPU model tests on self-hosted agents while using the Buildkite UI
+  - Keep training data and model artifacts inside the VPC during CI
+  - Scale CI agents on Kubernetes or AWS for bursty ML pipelines
+  - Replace hosted-only runners when compliance requires on-prem builds

--- a/tools/dev-tools/cytoolz.yaml
+++ b/tools/dev-tools/cytoolz.yaml
@@ -1,0 +1,26 @@
+name: cytoolz
+description: Cython implementation of the Toolz functional library for Python. cytoolz offers the same curry, pipe, get-in, and lazy map/filter helpers as toolz, compiled for faster inner loops in data and ML preprocessing pipelines.
+tagline: Fast Cython drop-in for the Toolz functional toolkit
+
+github_url: https://github.com/pytoolz/cytoolz
+docs_url: https://cytoolz.readthedocs.io
+
+category: Dev Tools
+tags: [python, cython, functional, performance, data-processing, pipelines]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install cytoolz
+
+problem_solved: |
+  toolz is convenient for composing lazy transforms, but pure-Python
+  inner loops slow large feature pipelines. cytoolz is a Cython port
+  with the same API, so data and ML code can keep curry, pipe, and
+  get-in while running hot paths at C speed without rewriting helpers.
+
+use_cases:
+  - Speed up toolz-style feature transforms on large tabular datasets
+  - Drop in cytoolz where toolz APIs already compose preprocessing
+  - Curry and pipe record plucks in ingestion jobs with lower CPU cost
+  - Keep a functional toolkit in performance-sensitive Python services

--- a/tools/dev-tools/please.yaml
+++ b/tools/dev-tools/please.yaml
@@ -1,0 +1,28 @@
+name: Please
+description: High-performance hermetic build system for reproducible multi-language builds. Please hashes inputs, runs isolated tasks in parallel, and uses remote caches so only affected targets rebuild across Linux, macOS, and FreeBSD.
+tagline: Fast hermetic builds with hash-based caching
+
+github_url: https://github.com/thought-machine/please
+website_url: https://please.build
+docs_url: https://please.build/quickstart.html
+
+category: Dev Tools
+tags: [build-system, hermetic, caching, multi-language, ci, golang, developer-tools]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: curl -s https://get.please.build | bash
+
+problem_solved: |
+  Multi-language ML repos waste CI time rebuilding unchanged C++, Go, and
+  Python targets because timestamp-based tools cannot tell what actually
+  changed. Please hashes every input, isolates tasks, and shares remote
+  caches so only affected targets rebuild, keeping agent and model builds
+  fast and reproducible.
+
+use_cases:
+  - Build mixed Python, Go, and C++ ML toolchains with hermetic caching
+  - Share remote build caches across CI agents for faster PR checks
+  - Replace ad-hoc Makefiles with declared, parallel Please targets
+  - Reproduce production artifacts from hashed inputs on developer laptops

--- a/tools/dev-tools/semantic-release.yaml
+++ b/tools/dev-tools/semantic-release.yaml
@@ -1,0 +1,27 @@
+name: semantic-release
+description: Fully automated version management and package publishing. semantic-release reads conventional commits, computes the next semver, writes changelog notes, and publishes to npm, GitHub Releases, and other registries without manual version bumps.
+tagline: Automate semver, changelogs, and package publishing from commits
+
+github_url: https://github.com/semantic-release/semantic-release
+website_url: https://semantic-release.org
+docs_url: https://semantic-release.org
+
+category: Dev Tools
+tags: [ci-cd, semver, npm, releases, changelog, automation, javascript]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: npm install --save-dev semantic-release
+
+problem_solved: |
+  Human version bumps mix emotion with numbering and often skip changelog
+  or publish steps. semantic-release inspects conventional commits, picks
+  the next semver, generates notes, and publishes so ML and JS libraries
+  ship consistently from CI without a release manager.
+
+use_cases:
+  - Publish npm packages automatically when conventional commits land on main
+  - Generate GitHub Releases and changelogs from commit history in CI
+  - Enforce semantic versioning for Python and JS SDKs used by ML clients
+  - Remove manual version files from agent-framework and tool-catalog repos

--- a/tools/dev-tools/spinnaker.yaml
+++ b/tools/dev-tools/spinnaker.yaml
@@ -1,0 +1,26 @@
+name: Spinnaker
+description: Open-source multi-cloud continuous delivery platform for releasing software with high velocity and confidence. Spinnaker orchestrates pipelines, canaries, and rollbacks across AWS, GCP, Azure, Kubernetes, and other clouds.
+tagline: Multi-cloud continuous delivery with canaries and rollbacks
+
+github_url: https://github.com/spinnaker/spinnaker
+website_url: https://spinnaker.io
+docs_url: https://spinnaker.io/docs
+
+category: Dev Tools
+tags: [ci-cd, continuous-delivery, kubernetes, multi-cloud, canary, devops, mlops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Shipping model-serving apps across several clouds means stitching
+  Jenkins jobs, kubectl scripts, and ad-hoc canaries with no shared
+  rollback story. Spinnaker gives one delivery plane for pipelines,
+  cluster management, canary analysis, and automated rollback so ML
+  services can ship fast without guessing which cluster is live.
+
+use_cases:
+  - Roll out inference services to Kubernetes with automated canary analysis
+  - Coordinate multi-cloud deployments of feature stores and model APIs
+  - Add approval gates and instant rollback when serving metrics regress
+  - Replace one-off deploy scripts with reusable Spinnaker pipelines


### PR DESCRIPTION
## Summary

Add five Dev Tools catalog entries used in ML/CI pipelines:

- **semantic-release** — automated semver, changelogs, and package publishing from conventional commits (MIT, 24k stars)
- **Please** — hermetic multi-language build system with hash-based caching (Apache-2.0, 2.6k stars)
- **Spinnaker** — multi-cloud continuous delivery with canaries and rollbacks (Apache-2.0, 9.8k stars)
- **Buildkite** — hybrid CI with self-hosted agents and a hosted control plane (agent MIT; SaaS product)
- **cytoolz** — Cython implementation of Toolz for faster functional Python pipelines (BSD-3-Clause, 1.1k stars)

## Validation

Local `npx tsx scripts/validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Buildkite, cytoolz, Please, semantic-release, and Spinnaker.
  * Included descriptions, links, licensing and pricing details, installation guidance, problem statements, and practical use cases for each tool.
  * Added information covering CI/CD, functional programming, build systems, release automation, and multi-cloud deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->