### PR TITLE
Add decorator, Wheel, h11 to catalog

### DIFF
--- a/tools/dev-tools/decorator.yaml
+++ b/tools/dev-tools/decorator.yaml
@@ -1,0 +1,27 @@
+name: decorator
+description: Python library that preserves function signatures when writing decorators. decorator makes it easy to wrap callables without breaking help(), inspect, and type-aware tooling used in ML libraries and APIs.
+tagline: Signature-preserving decorators for Python
+
+github_url: https://github.com/micheles/decorator
+docs_url: https://github.com/micheles/decorator/blob/master/docs/documentation.md
+
+category: Dev Tools
+tags: [python, decorators, metaprogramming, inspect, libraries]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+install_command: pip install decorator
+
+problem_solved: |
+  Naive Python decorators hide the wrapped function's name, docstring,
+  and signature, which breaks inspect, Sphinx, and IDE help for ML APIs.
+  The decorator package rewrites wrappers so signatures stay intact,
+  letting libraries add tracing, retry, and cache layers without leaking
+  wrapper metadata to callers.
+
+use_cases:
+  - Add retry or timeout wrappers to model-client methods without losing signatures
+  - Preserve inspect.signature on decorated training and serving helpers
+  - Keep Sphinx and IDE docs accurate for wrapped public APIs
+  - Implement memoization decorators that still show original arguments

--- a/tools/dev-tools/h11.yaml
+++ b/tools/dev-tools/h11.yaml
@@ -1,0 +1,28 @@
+name: h11
+description: Pure-Python, bring-your-own-I/O implementation of HTTP/1.1. h11 is the protocol engine behind HTTPX and many ASGI stacks, so Python ML services can speak HTTP without binding to a particular socket library.
+tagline: Sans-I/O HTTP/1.1 protocol library for Python
+
+github_url: https://github.com/python-hyper/h11
+website_url: https://h11.readthedocs.io
+docs_url: https://h11.readthedocs.io
+
+category: Dev Tools
+tags: [python, http, http11, sans-io, networking, httpx]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install h11
+
+problem_solved: |
+  Most HTTP clients couple parsing to sockets, which makes it hard to
+  reuse protocol logic across asyncio, Trio, or custom transports in
+  model-serving code. h11 implements HTTP/1.1 as a state machine with
+  no I/O, so HTTPX and similar stacks can share a correct parser while
+  plugging in their own event loop.
+
+use_cases:
+  - Power HTTP/1.1 parsing in HTTPX-based model API clients
+  - Build custom ASGI or proxy transports without rewriting HTTP framing
+  - Test HTTP state machines in unit tests with no real sockets
+  - Embed a small HTTP/1.1 engine in Python inference sidecars

--- a/tools/dev-tools/wheel.yaml
+++ b/tools/dev-tools/wheel.yaml
@@ -1,0 +1,28 @@
+name: Wheel
+description: Official binary distribution format for Python. Wheel builds and installs .whl packages so compiled extensions, CUDA wheels, and data files install without running setup.py on every machine.
+tagline: Python's official binary package format
+
+github_url: https://github.com/pypa/wheel
+website_url: https://wheel.readthedocs.io
+docs_url: https://wheel.readthedocs.io
+
+category: Dev Tools
+tags: [python, packaging, pip, wheels, build, pypa]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install wheel
+
+problem_solved: |
+  Installing scientific and ML packages from source is slow and fails
+  without compilers. Wheel is the standard binary format pip uses to
+  ship prebuilt artifacts, including native extensions, so teams can
+  publish CUDA or C-extension packages once and install them quickly
+  in training images.
+
+use_cases:
+  - Build .whl artifacts for Python ML libraries in CI
+  - Install prebuilt native extensions without compiling on every GPU node
+  - Package data files and compiled code for reproducible pip installs
+  - Convert setup.py projects to wheels for faster Docker image builds


### PR DESCRIPTION
## Summary

Add three Python Dev Tools catalog entries:

- **decorator** — signature-preserving decorators (BSD-2-Clause, 905 stars)
- **Wheel** — official Python binary distribution format (MIT, 572 stars)
- **h11** — sans-I/O HTTP/1.1 protocol library used by HTTPX (MIT, 567 stars)

## Validation

Local `npx tsx scripts/validate-tool.ts` passed for all three files.
