### PR TITLE
Add watchfiles, xmltodict, JMESPath, httptools, yarl to catalog

### DIFF
--- a/tools/data/xmltodict.yaml
+++ b/tools/data/xmltodict.yaml
@@ -1,0 +1,27 @@
+name: xmltodict
+description: Python module that makes working with XML feel like working with JSON. xmltodict parses XML into nested dicts and dumps dicts back to XML, which is useful for older ML data feeds and enterprise APIs that still speak XML.
+tagline: XML in, nested Python dicts out
+
+github_url: https://github.com/martinblech/xmltodict
+docs_url: https://github.com/martinblech/xmltodict
+
+category: Data
+tags: [python, xml, json, parsing, data-ingestion, etl]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install xmltodict
+
+problem_solved: |
+  Many enterprise and scientific feeds still ship XML, but ML pipelines
+  expect dicts and JSON. ElementTree is verbose for nested records.
+  xmltodict converts XML to ordered dicts and back, so ingestion jobs
+  can normalize SOAP, RSS, and vendor dumps without hand-written tree
+  walking.
+
+use_cases:
+  - Convert XML vendor feeds into dicts for feature extraction
+  - Round-trip nested Python dicts to XML for legacy model APIs
+  - Stream-parse large XML dumps into records for training datasets
+  - Normalize SOAP responses before loading them into a warehouse

--- a/tools/dev-tools/httptools.yaml
+++ b/tools/dev-tools/httptools.yaml
@@ -1,0 +1,25 @@
+name: httptools
+description: Fast HTTP parser for Python built on Node.js http-parser / llhttp. httptools is used by uvicorn and other ASGI servers to parse HTTP requests quickly, which matters when serving many model inference connections.
+tagline: Fast HTTP parser used by uvicorn and ASGI stacks
+
+github_url: https://github.com/MagicStack/httptools
+
+category: Dev Tools
+tags: [python, http, parser, uvicorn, asgi, performance]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install httptools
+
+problem_solved: |
+  Pure-Python HTTP parsing becomes a bottleneck when an inference
+  server handles thousands of short requests. httptools wraps a C HTTP
+  parser so uvicorn and similar ASGI servers can decode headers and
+  bodies quickly without writing parser code in each serving stack.
+
+use_cases:
+  - Speed up uvicorn HTTP parsing for model-serving APIs
+  - Parse HTTP/1.x requests in custom Python inference gateways
+  - Replace slow pure-Python header parsing in high-QPS agent backends
+  - Build ASGI servers that share a battle-tested C HTTP parser

--- a/tools/dev-tools/jmespath.yaml
+++ b/tools/dev-tools/jmespath.yaml
@@ -1,0 +1,28 @@
+name: JMESPath
+description: Query language for JSON with a Python implementation. JMESPath extracts and transforms nested JSON with a compact expression syntax used by AWS CLI, so ML pipelines can pull fields from API payloads without custom parsers.
+tagline: JSON query language with a Python runtime
+
+github_url: https://github.com/jmespath/jmespath.py
+website_url: https://jmespath.org
+docs_url: https://jmespath.org
+
+category: Dev Tools
+tags: [python, json, query, aws, data-extraction, etl]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install jmespath
+
+problem_solved: |
+  Nested JSON from cloud APIs and model endpoints is painful to walk
+  with chained get() calls. JMESPath lets you declare projections,
+  filters, and slices in one expression, the same language AWS CLI
+  uses, so feature jobs and agent tools can extract fields consistently
+  across services.
+
+use_cases:
+  - Extract nested fields from AWS and model API JSON responses
+  - Filter lists of job records in data pipelines with one expression
+  - Share the same JSON queries between CLI scripts and Python agents
+  - Project large payloads down to the keys a training job actually needs

--- a/tools/dev-tools/watchfiles.yaml
+++ b/tools/dev-tools/watchfiles.yaml
@@ -1,0 +1,28 @@
+name: watchfiles
+description: Simple, modern, and fast file watching and code reload for Python, written in Rust. watchfiles notifies you when source or data files change so ML training loops, dev servers, and data pipelines can reload without polling.
+tagline: Fast Rust-backed file watching for Python
+
+github_url: https://github.com/samuelcolvin/watchfiles
+website_url: https://watchfiles.helpmanual.io
+docs_url: https://watchfiles.helpmanual.io
+
+category: Dev Tools
+tags: [python, rust, file-watching, reload, asyncio, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install watchfiles
+
+problem_solved: |
+  Python file watchers based on polling waste CPU and miss bursts of
+  writes from dataset dumps or generated code. watchfiles uses native
+  OS notifications via a Rust core, so training jobs, uvicorn reloads,
+  and feature-pipeline watchers wake only on real changes with low
+  overhead on large trees.
+
+use_cases:
+  - Reload a local model API server when Python source files change
+  - Watch dataset directories and trigger preprocessing on new files
+  - Drive asyncio callbacks when config or prompt templates are edited
+  - Replace polling loops in ML experiment tooling with native watchers

--- a/tools/dev-tools/yarl.yaml
+++ b/tools/dev-tools/yarl.yaml
@@ -1,0 +1,28 @@
+name: yarl
+description: URL parsing and building library for Python used by aiohttp. yarl gives an immutable URL type with encoded path, query, and user parts so async ML clients construct and inspect endpoints without string concatenation bugs.
+tagline: Immutable URL objects for Python HTTP clients
+
+github_url: https://github.com/aio-libs/yarl
+website_url: https://yarl.aio-libs.org
+docs_url: https://yarl.aio-libs.org
+
+category: Dev Tools
+tags: [python, url, aiohttp, asyncio, http, networking]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install yarl
+
+problem_solved: |
+  Building URLs with f-strings mishandles encoding, query maps, and
+  path joins, which breaks signed cloud URLs and model endpoints.
+  yarl provides an immutable URL object with safe updates, so aiohttp
+  and agent HTTP clients can compose endpoints without leaking
+  encoding bugs.
+
+use_cases:
+  - Build and update inference endpoint URLs with encoded query params
+  - Parse webhook and dataset URLs into path, host, and query parts
+  - Share immutable URL objects across aiohttp client sessions
+  - Join relative paths onto a model-gateway base URL safely


### PR DESCRIPTION
## Summary

Add five catalog entries used in Python ML/HTTP stacks:

- **watchfiles** — Rust-backed file watching and reload for Python (MIT, 2.5k stars)
- **xmltodict** — XML to nested dict conversion for data ingestion (MIT, 5.7k stars)
- **JMESPath** — JSON query language with a Python runtime (MIT, 2.4k stars)
- **httptools** — fast HTTP parser used by uvicorn (MIT, 1.3k stars)
- **yarl** — immutable URL objects for aiohttp clients (Apache-2.0, 1.5k stars)

## Validation

Local `npx tsx scripts/validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for five Python development tools: `xmltodict`, `httptools`, `JMESPath`, `watchfiles`, and `yarl`.
  * Entries include descriptions, documentation and repository links, installation commands, licensing and pricing details, supported categories, and practical use cases.
  * Catalog now highlights capabilities for XML conversion, HTTP parsing, JSON querying, file watching, and URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->