### PR TITLE
Add PrettyTable, platformdirs, humanize, httpcore to catalog

### DIFF
--- a/tools/dev-tools/httpcore.yaml
+++ b/tools/dev-tools/httpcore.yaml
@@ -1,0 +1,28 @@
+name: httpcore
+description: Minimal HTTP client that powers HTTPX. httpcore provides a low-level, transport-agnostic HTTP/1.1 and HTTP/2 core so Python ML clients can share connection pooling, timeouts, and proxies without depending on requests.
+tagline: Low-level HTTP/1.1 and HTTP/2 core for HTTPX
+
+github_url: https://github.com/encode/httpcore
+website_url: https://www.encode.io/httpcore/
+docs_url: https://www.encode.io/httpcore/
+
+category: Dev Tools
+tags: [python, http, httpx, http2, networking, async]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install httpcore
+
+problem_solved: |
+  High-level HTTP libraries hide transports, which makes it hard to
+  plug custom connection pools or HTTP/2 into model API clients.
+  httpcore is a small core with sync and async transports that HTTPX
+  uses, so teams can control pooling, proxies, and HTTP versions
+  without rewriting request APIs.
+
+use_cases:
+  - Tune HTTP/2 and connection pooling under HTTPX model-API clients
+  - Share a transport layer between sync and async inference callers
+  - Add custom proxies or timeouts at the transport layer for agents
+  - Build thin HTTP clients that do not depend on the full requests stack

--- a/tools/dev-tools/humanize.yaml
+++ b/tools/dev-tools/humanize.yaml
@@ -1,0 +1,27 @@
+name: humanize
+description: Python helpers that turn numbers, file sizes, dates, and timedeltas into human-readable strings. humanize is useful in ML CLIs and dashboards for showing dataset size, ETA, and parameter counts without raw integers.
+tagline: Human-readable numbers, dates, and file sizes in Python
+
+github_url: https://github.com/python-humanize/humanize
+website_url: https://humanize.readthedocs.io
+docs_url: https://humanize.readthedocs.io
+
+category: Dev Tools
+tags: [python, formatting, cli, dates, numbers, ux]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install humanize
+
+problem_solved: |
+  Training logs dump raw byte counts, epoch seconds, and 1e9-scale
+  parameter numbers that humans cannot scan quickly. humanize formats
+  sizes, relative times, and integers into readable strings so CLIs,
+  agent status lines, and reports stay understandable.
+
+use_cases:
+  - Show dataset and checkpoint sizes as MB or GB in training logs
+  - Print relative times for job start and ETA in experiment CLIs
+  - Format parameter counts and step numbers for human-readable reports
+  - Display file sizes in agent download and cache status messages

--- a/tools/dev-tools/platformdirs.yaml
+++ b/tools/dev-tools/platformdirs.yaml
@@ -1,0 +1,27 @@
+name: platformdirs
+description: Python package for determining platform-specific directories such as user data, config, cache, and logs. platformdirs handles macOS, Windows, Linux, and Android so ML apps store caches and configs in the right place.
+tagline: Correct user data, config, and cache paths on every OS
+
+github_url: https://github.com/tox-dev/platformdirs
+website_url: https://platformdirs.readthedocs.io
+docs_url: https://platformdirs.readthedocs.io
+
+category: Dev Tools
+tags: [python, paths, xdg, cache, config, cross-platform]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install platformdirs
+
+problem_solved: |
+  Hard-coded ~/.cache or AppData paths break on other operating
+  systems and ignore XDG conventions. platformdirs returns the right
+  user data, config, cache, and log directories so model caches,
+  tokenizer files, and CLI configs land where each OS expects.
+
+use_cases:
+  - Store Hugging Face-style model caches in the OS cache directory
+  - Save CLI config for agent tools under the platform config path
+  - Keep experiment logs in the user log directory on macOS and Linux
+  - Share path logic across Windows and Unix training scripts

--- a/tools/dev-tools/prettytable.yaml
+++ b/tools/dev-tools/prettytable.yaml
@@ -1,0 +1,28 @@
+name: PrettyTable
+description: Display tabular data in a visually appealing ASCII table format. PrettyTable helps CLI tools and notebooks print aligned tables for metrics, eval results, and dataset previews without a heavyweight dataframe UI.
+tagline: Pretty ASCII tables for Python CLIs and notebooks
+
+github_url: https://github.com/prettytable/prettytable
+website_url: https://pypi.org/project/prettytable/
+docs_url: https://github.com/prettytable/prettytable
+
+category: Dev Tools
+tags: [python, tables, cli, ascii, formatting, notebooks]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install prettytable
+
+problem_solved: |
+  Printing eval metrics or sample rows with print() produces ragged
+  columns that are hard to scan in logs and terminals. PrettyTable
+  builds aligned ASCII tables with sorting and field selection so ML
+  CLIs and training logs can show structured results without depending
+  on a notebook widget.
+
+use_cases:
+  - Print model eval metrics as aligned tables in CI logs
+  - Preview dataset sample rows in a terminal training script
+  - Format agent tool output as readable ASCII tables
+  - Sort and select columns when dumping experiment comparison tables


### PR DESCRIPTION
## Summary

Add four Python Dev Tools catalog entries:

- **PrettyTable** — ASCII tables for CLIs and notebooks (BSD-3-Clause, 1.7k stars)
- **platformdirs** — OS-correct user data, config, and cache paths (MIT, 981 stars)
- **humanize** — human-readable numbers, dates, and file sizes (MIT, 753 stars)
- **httpcore** — low-level HTTP/1.1 and HTTP/2 core used by HTTPX (BSD-3-Clause, 547 stars)

## Validation

Local `npx tsx scripts/validate-tool.ts` passed for all four files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for four Python development tools: httpcore, humanize, platformdirs, and PrettyTable.
  * Included descriptions, links, licensing and pricing details, installation commands, categories, tags, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->