### PR TITLE
Add asyncpg, Maturin, SortedContainers, nanobind, Psycopg to catalog

### DIFF
--- a/tools/data/asyncpg.yaml
+++ b/tools/data/asyncpg.yaml
@@ -1,0 +1,28 @@
+name: asyncpg
+description: A high-performance PostgreSQL client for Python asyncio. asyncpg speaks the Postgres binary protocol directly so feature stores, RAG metadata, and agent memory backends get low-latency queries without blocking the event loop.
+tagline: Fast asyncio PostgreSQL client for Python
+
+github_url: https://github.com/MagicStack/asyncpg
+website_url: https://magicstack.github.io/asyncpg/
+docs_url: https://magicstack.github.io/asyncpg/current/
+install_command: pip install asyncpg
+
+category: Data
+tags: [python, postgresql, asyncio, database, async, data-access]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Async Python services that store embeddings, experiment metadata, or agent
+  state in PostgreSQL cannot afford a blocking DB driver. Thread pools waste
+  connections and add latency under concurrent RAG and training jobs. asyncpg
+  is a pure-asyncio client that uses the Postgres binary protocol, prepared
+  statements, and COPY for bulk loads, so event-loop apps keep high throughput
+  without ORM overhead.
+
+use_cases:
+  - Query and write feature-store or experiment tables from FastAPI and asyncio workers without blocking
+  - Bulk-load training labels and embeddings into PostgreSQL with COPY at native driver speed
+  - Back agent memory, tool-call logs, and conversation state on Postgres from async agent runtimes
+  - Replace blocking psycopg2 calls in async ETL and RAG ingestion pipelines

--- a/tools/data/psycopg.yaml
+++ b/tools/data/psycopg.yaml
@@ -1,0 +1,28 @@
+name: Psycopg
+description: Next-generation PostgreSQL adapter for Python. Psycopg 3 adds async I/O, COPY, and connection pooling so ML pipelines and agent backends can talk to Postgres without the psycopg2 binary-build tax.
+tagline: PostgreSQL adapter for Python 3
+
+github_url: https://github.com/psycopg/psycopg
+website_url: https://www.psycopg.org/psycopg3/
+docs_url: https://www.psycopg.org/psycopg3/docs/
+install_command: pip install psycopg
+
+category: Data
+tags: [python, postgresql, database, async, data-access, sql]
+pricing: free
+is_open_source: true
+license: LGPL-3.0
+
+problem_solved: |
+  Most Python data stacks still use psycopg2, which is sync-only and often
+  needs a compiler or a binary wheel that fights the platform. Psycopg 3 is
+  the supported PostgreSQL adapter with sync and asyncio clients, server-side
+  bindings, COPY, and optional C acceleration. Feature stores, RAG metadata,
+  and agent memory on Postgres get a modern driver without rewriting SQLAlchemy
+  or dropping to raw libpq.
+
+use_cases:
+  - Connect SQLAlchemy, FastAPI, and batch ETL jobs to PostgreSQL with a maintained driver
+  - Run async Postgres queries from agent backends and streaming ingestion workers
+  - Bulk-load training rows with COPY instead of row-by-row INSERTs
+  - Replace psycopg2 in Docker images that cannot compile C extensions

--- a/tools/dev-tools/maturin.yaml
+++ b/tools/dev-tools/maturin.yaml
@@ -1,0 +1,27 @@
+name: Maturin
+description: Build and publish Python packages from Rust. Maturin compiles PyO3, cffi, and uniffi crates plus Rust binaries into wheels so ML teams can ship native extensions on PyPI without writing setuptools glue.
+tagline: Build Python wheels from Rust crates
+
+github_url: https://github.com/PyO3/maturin
+website_url: https://maturin.rs
+docs_url: https://www.maturin.rs
+install_command: pip install maturin
+
+category: Dev Tools
+tags: [python, rust, packaging, pyo3, wheels, bindings, build]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  High-performance ML libraries often live in Rust, but publishing them as
+  Python packages means fighting setuptools, manylinux, and cross-compilation.
+  Maturin builds PyO3, cffi, and uniffi projects into pip-installable wheels,
+  including Rust binaries, so teams can develop in Cargo and ship a single
+  `pip install` artifact for CUDA-adjacent kernels, tokenizers, and CLI tools.
+
+use_cases:
+  - Publish a PyO3 tokenizer or vector kernel as a Python wheel on PyPI
+  - Cross-compile manylinux and musllinux wheels for ML libraries in CI
+  - Ship a Rust CLI next to a Python package from one Cargo project
+  - Replace fragile setuptools-rust glue in native Python extension builds

--- a/tools/dev-tools/nanobind.yaml
+++ b/tools/dev-tools/nanobind.yaml
@@ -1,0 +1,27 @@
+name: nanobind
+description: Tiny, efficient C++/Python bindings by the pybind11 author. nanobind compiles faster, produces smaller binaries, and binds NumPy, Eigen, and CUDA kernels for high-performance ML extensions.
+tagline: Tiny high-performance C++/Python bindings
+
+github_url: https://github.com/wjakob/nanobind
+website_url: https://nanobind.readthedocs.io
+docs_url: https://nanobind.readthedocs.io
+install_command: pip install nanobind
+
+category: Dev Tools
+tags: [python, cpp, bindings, numpy, cuda, pybind11, developer-tools]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  pybind11 bindings for large C++ ML libraries compile slowly and produce
+  bulky extension modules. nanobind is a from-scratch successor with a
+  similar API, much faster compile times, and smaller binaries, plus first-class
+  NumPy, Eigen, and CUDA interop. Teams wrapping custom ops, physics, or
+  inference kernels get native speed without the pybind11 compile-time tax.
+
+use_cases:
+  - Bind custom C++/CUDA kernels as Python extensions for PyTorch or JAX
+  - Wrap Eigen and NumPy-heavy numerical code with lower compile time than pybind11
+  - Ship smaller native wheels for inference libraries used in production agents
+  - Port existing pybind11 modules to a faster, leaner binding layer

--- a/tools/dev-tools/sortedcontainers.yaml
+++ b/tools/dev-tools/sortedcontainers.yaml
@@ -1,0 +1,28 @@
+name: SortedContainers
+description: Pure-Python sorted list, dict, and set types with C-extension speed. SortedContainers keeps ordered indexes for streaming logs, token vocabularies, and feature maps without a C compiler or tree-map boilerplate.
+tagline: Fast sorted list, dict, and set for Python
+
+github_url: https://github.com/grantjenks/python-sortedcontainers
+website_url: http://www.grantjenks.com/docs/sortedcontainers/
+docs_url: http://www.grantjenks.com/docs/sortedcontainers/
+install_command: pip install sortedcontainers
+
+category: Dev Tools
+tags: [python, data-structures, sorted, collections, performance]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Python's built-in dict and set are unordered (or insertion-ordered) and
+  bisect on a list is easy to get wrong under mutation. SortedContainers
+  provides SortedList, SortedDict, and SortedSet in pure Python with
+  performance close to C extensions, so ranking, sliding windows, and
+  ordered indexes work without compiling native code in constrained
+  training images.
+
+use_cases:
+  - Maintain a ranked leaderboard or top-k feature index while streaming events
+  - Keep token vocabularies and ID maps in sorted order for deterministic encoding
+  - Implement sliding-window stats over time-ordered logs without a database
+  - Drop in sorted dict/set types when bisect plus list mutation becomes error-prone


### PR DESCRIPTION
## Add 5 tools to the catalog

Python data and packaging libraries used in ML pipelines:

| Tool | Category | Stars | License |
|------|----------|-------|---------|
| asyncpg | Data | 8.1k | Apache-2.0 |
| Maturin | Dev Tools | 5.8k | Apache-2.0 |
| SortedContainers | Dev Tools | 4.0k | Apache-2.0 |
| nanobind | Dev Tools | 3.7k | BSD-3-Clause |
| Psycopg | Data | 2.5k | LGPL-3.0 |

- asyncpg: asyncio PostgreSQL client (binary protocol)
- Maturin: build Python wheels from Rust/PyO3 crates
- SortedContainers: pure-Python sorted list/dict/set
- nanobind: compact C++/Python bindings (pybind11 successor)
- Psycopg: PostgreSQL adapter for Python 3 (sync + async)

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for asyncpg and Psycopg, highlighting Python PostgreSQL connectivity options.
  * Added Maturin and nanobind entries for Rust/Python packaging and native extension development.
  * Added a SortedContainers entry for efficient sorted data structures.
  * Included installation details, documentation links, licensing, pricing, tags, and common use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->