### PR TITLE
Add cibuildwheel, greenlet, charset-normalizer, tomli to catalog

### DIFF
--- a/tools/dev-tools/charset-normalizer.yaml
+++ b/tools/dev-tools/charset-normalizer.yaml
@@ -1,0 +1,27 @@
+name: charset-normalizer
+description: Universal character-encoding detector in pure Python. charset-normalizer is the encoding backend for Requests and HTTPX, so crawlers and RAG ingest can decode messy web bytes without chardet.
+tagline: Universal encoding detector for Python
+
+github_url: https://github.com/jawah/charset_normalizer
+website_url: https://charset-normalizer.readthedocs.io
+docs_url: https://charset-normalizer.readthedocs.io/en/latest/
+install_command: pip install charset-normalizer
+
+category: Dev Tools
+tags: [python, encoding, unicode, http, parsing, requests]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Web crawls, PDF extracts, and email dumps arrive as bytes with wrong or
+  missing charset headers. chardet is slow and unmaintained. charset-normalizer
+  detects encodings in pure Python with better accuracy and is what Requests
+  and HTTPX already use, so RAG ingest and scraping pipelines decode text
+  without a native chardet dependency.
+
+use_cases:
+  - Decode crawled HTML and API bodies before chunking for RAG
+  - Replace chardet in scraping and ETL jobs that ingest mixed encodings
+  - Inspect encoding guesses when training data looks garbled after download
+  - Normalize charset handling in HTTP clients built on Requests or HTTPX

--- a/tools/dev-tools/cibuildwheel.yaml
+++ b/tools/dev-tools/cibuildwheel.yaml
@@ -1,0 +1,27 @@
+name: cibuildwheel
+description: Build Python wheels for every platform from one CI job. cibuildwheel runs manylinux, musllinux, macOS, Windows, and iOS builds so native ML extensions ship on PyPI without a matrix of hand-written Dockerfiles.
+tagline: Python wheels for every platform from CI
+
+github_url: https://github.com/pypa/cibuildwheel
+website_url: https://cibuildwheel.pypa.io
+docs_url: https://cibuildwheel.pypa.io
+install_command: pip install cibuildwheel
+
+category: Dev Tools
+tags: [python, packaging, wheels, ci, manylinux, pypa, build]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+problem_solved: |
+  Native Python extensions for tokenizers, CUDA bindings, and numerics must
+  ship wheels for Linux, macOS, and Windows or pip falls back to compiling
+  from source. Maintaining that matrix by hand is fragile. cibuildwheel is
+  the PyPA tool that builds manylinux, musllinux, macOS, Windows, and
+  PyPy wheels from GitHub Actions, Azure, or other CI with minimal config.
+
+use_cases:
+  - Build manylinux and musllinux wheels for C/Rust ML extensions in GitHub Actions
+  - Publish macOS universal2 and Windows wheels from a single CI workflow
+  - Stop maintaining custom Dockerfiles for PyPI native package releases
+  - Test compiled extensions on CPython and PyPy before uploading to PyPI

--- a/tools/dev-tools/greenlet.yaml
+++ b/tools/dev-tools/greenlet.yaml
@@ -1,0 +1,28 @@
+name: greenlet
+description: Lightweight in-process concurrent programming for Python. greenlet provides micro-threads that gevent, SQLAlchemy, and many async DB adapters use so blocking I/O can yield without a full OS thread per connection.
+tagline: Lightweight coroutines for Python
+
+github_url: https://github.com/python-greenlet/greenlet
+website_url: https://greenlet.readthedocs.io
+docs_url: https://greenlet.readthedocs.io
+install_command: pip install greenlet
+
+category: Dev Tools
+tags: [python, concurrency, coroutines, gevent, threading]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Thread-per-connection models blow up memory when ML services talk to
+  Postgres, Redis, or HTTP at high concurrency. greenlet is a C extension
+  that switches Python stacks cooperatively, which gevent and SQLAlchemy
+  use so blocking drivers can multiplex work inside one OS thread. Agent
+  backends and ETL workers get concurrency without rewriting everything
+  as asyncio.
+
+use_cases:
+  - Power gevent monkey-patching so blocking HTTP and DB clients scale in one process
+  - Let SQLAlchemy connection pools yield during I/O instead of occupying OS threads
+  - Run cooperative workers for scraping and feature-store writes without asyncio rewrites
+  - Debug stack switching in services that mix greenlets with native extensions

--- a/tools/dev-tools/tomli.yaml
+++ b/tools/dev-tools/tomli.yaml
@@ -1,0 +1,27 @@
+name: tomli
+description: A small, fast TOML parser for Python. tomli is the stdlib tomllib implementation vendored into CPython 3.11+, used to read pyproject.toml in packaging, training configs, and agent tool manifests.
+tagline: Minimal TOML parser for Python
+
+github_url: https://github.com/hukkin/tomli
+website_url: https://github.com/hukkin/tomli
+docs_url: https://github.com/hukkin/tomli
+install_command: pip install tomli
+
+category: Dev Tools
+tags: [python, toml, parsing, packaging, pyproject, config]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Python packaging and ML configs live in TOML (pyproject.toml, tool
+  settings, experiment files) but older runtimes have no stdlib parser.
+  tomli is a pure-Python TOML parser that became CPython's tomllib, so
+  build backends, linters, and training launchers can read TOML on 3.8+
+  without installing a large config library.
+
+use_cases:
+  - Parse pyproject.toml in custom build backends and packaging scripts
+  - Load TOML experiment and agent-tool configs on Python versions before 3.11
+  - Read Cargo-style and PEP 621 metadata in CI without a heavy TOML stack
+  - Vendor a stdlib-compatible TOML parser in CLI tools that must stay small


### PR DESCRIPTION
## Add 4 tools to the catalog

Python packaging and runtime libraries:

| Tool | Category | Stars | License |
|------|----------|-------|---------|
| cibuildwheel | Dev Tools | 2.3k | BSD-2-Clause |
| greenlet | Dev Tools | 1.8k | MIT |
| charset-normalizer | Dev Tools | 793 | MIT |
| tomli | Dev Tools | 570 | MIT |

- cibuildwheel: PyPA multi-platform wheel builder for CI
- greenlet: cooperative micro-threads used by gevent and SQLAlchemy
- charset-normalizer: encoding detector behind Requests and HTTPX
- tomli: TOML parser that became CPython tomllib

Local validation passed for all four YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for four Python development tools: charset-normalizer, cibuildwheel, greenlet, and tomli.
  * Included installation instructions, project metadata, documentation links, licensing details, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->