### PR TITLE
Add gevent, paramiko, Supervisor, factory-boy, kombu to catalog

### DIFF
--- a/tools/data/kombu.yaml
+++ b/tools/data/kombu.yaml
@@ -1,0 +1,27 @@
+name: kombu
+description: Messaging library for Python. kombu is the AMQP layer under Celery, speaking RabbitMQ, Redis, SQS, and more so training jobs and agent workers share a broker without writing queue clients by hand.
+tagline: Python messaging for Celery and AMQP
+
+github_url: https://github.com/celery/kombu
+website_url: https://kombu.readthedocs.io
+docs_url: https://kombu.readthedocs.io
+install_command: pip install kombu
+
+category: Data
+tags: [python, messaging, amqp, celery, rabbitmq, redis, queues]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  ML pipelines need durable queues between producers (dataset ready, train
+  this run) and workers. Raw pika or Redis lists are broker-specific and
+  easy to get wrong. kombu gives a single producer/consumer API over
+  RabbitMQ, Redis, SQS, and others, with serialization, retries, and the
+  transport Celery already uses.
+
+use_cases:
+  - Publish training and evaluation jobs to RabbitMQ or Redis from Python
+  - Consume work items in agent workers without depending on the full Celery API
+  - Switch brokers (Redis to SQS) behind one messaging interface
+  - Serialize numpy-adjacent payloads and retry failed publishes in ETL

--- a/tools/dev-tools/factory-boy.yaml
+++ b/tools/dev-tools/factory-boy.yaml
@@ -1,0 +1,27 @@
+name: factory-boy
+description: Test fixtures as Python factories. factory-boy builds ORM and dataclass objects with realistic defaults so ML app tests do not copy-paste nested user, dataset, and experiment rows.
+tagline: Test factories for Python objects
+
+github_url: https://github.com/FactoryBoy/factory_boy
+website_url: https://factoryboy.readthedocs.io
+docs_url: https://factoryboy.readthedocs.io
+install_command: pip install factory-boy
+
+category: Dev Tools
+tags: [python, testing, fixtures, django, sqlalchemy, pytest]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Tests for ML platforms need users, datasets, runs, and API keys in the
+  database. Hand-built fixtures drift and duplicate. factory-boy defines
+  factories that create Django, SQLAlchemy, or plain objects with faked
+  fields and related rows, so pytest suites stay short and data shapes stay
+  in one place.
+
+use_cases:
+  - Generate Django or SQLAlchemy users, projects, and experiment rows in pytest
+  - Build nested related objects for API tests without a giant fixture JSON
+  - Seed demo data for local ML consoles with repeatable factories
+  - Replace brittle copy-pasted model constructors in integration tests

--- a/tools/dev-tools/gevent.yaml
+++ b/tools/dev-tools/gevent.yaml
@@ -1,0 +1,27 @@
+name: gevent
+description: Coroutine-based networking for Python. gevent monkey-patches sockets so blocking DB, HTTP, and Redis clients scale with greenlets, which many ML workers still use instead of a full asyncio rewrite.
+tagline: Coroutine networking for Python
+
+github_url: https://github.com/gevent/gevent
+website_url: http://www.gevent.org
+docs_url: http://www.gevent.org
+install_command: pip install gevent
+
+category: Dev Tools
+tags: [python, concurrency, greenlets, async, networking, gevent]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Blocking Python clients for Postgres, Redis, and HTTP cannot serve many
+  concurrent ML jobs without a thread per connection. gevent uses greenlets
+  plus libev/libuv to multiplex I/O after a one-line monkey patch, so Celery
+  workers, scrapers, and agent backends keep familiar sync code while handling
+  thousands of connections in one process.
+
+use_cases:
+  - Scale Celery and RQ workers that call blocking HTTP and database clients
+  - Scrape or poll APIs concurrently without converting the stack to asyncio
+  - Serve WSGI apps that spend time in blocking model-inference or DB calls
+  - Monkey-patch stdlib sockets in existing ETL jobs to raise concurrency

--- a/tools/dev-tools/paramiko.yaml
+++ b/tools/dev-tools/paramiko.yaml
@@ -1,0 +1,27 @@
+name: paramiko
+description: Native Python SSHv2 client and server. paramiko is the library Fabric, many deploy scripts, and GPU-box provisioners use to run remote commands, SFTP model artifacts, and tunnel ports without shelling out to OpenSSH.
+tagline: Pure-Python SSHv2 library
+
+github_url: https://github.com/paramiko/paramiko
+website_url: https://www.paramiko.org
+docs_url: https://docs.paramiko.org
+install_command: pip install paramiko
+
+category: Dev Tools
+tags: [python, ssh, sftp, devops, remote, security]
+pricing: free
+is_open_source: true
+license: LGPL-2.1
+
+problem_solved: |
+  Training jobs, dataset sync, and GPU host setup still happen over SSH.
+  Shelling out to OpenSSH is brittle in Python (quoting, keys, Windows).
+  paramiko implements SSHv2 and SFTP in Python so deploy tools, Fabric,
+  and ML ops scripts can copy checkpoints, run remote commands, and open
+  tunnels with explicit key handling.
+
+use_cases:
+  - SFTP model checkpoints and datasets to GPU boxes from Python jobs
+  - Run remote training commands with SSH keys inside CI and deploy scripts
+  - Power Fabric-style automation for ML cluster bootstrap
+  - Open SSH tunnels from agent tools that must reach private inference hosts

--- a/tools/dev-tools/supervisor.yaml
+++ b/tools/dev-tools/supervisor.yaml
@@ -1,0 +1,27 @@
+name: Supervisor
+description: Process control system for Unix. supervisord starts, restarts, and logs long-running programs so ML APIs, workers, and agents stay up without a full Kubernetes stack.
+tagline: Unix process control for long-running jobs
+
+github_url: https://github.com/Supervisor/supervisor
+website_url: http://supervisord.org
+docs_url: http://supervisord.org
+install_command: pip install supervisor
+
+category: Dev Tools
+tags: [python, process-manager, devops, unix, supervisord]
+pricing: free
+is_open_source: true
+license: BSD-derived
+
+problem_solved: |
+  Small ML deployments still run FastAPI servers, Celery workers, and Redis
+  on a VM. systemd unit files are heavy for app-level programs, and a crash
+  takes the process down until someone notices. Supervisor watches those
+  programs, restarts on failure, and tails logs from one config file, which
+  is enough process supervision before you need Kubernetes.
+
+use_cases:
+  - Keep model-serving APIs and embedding workers running on a single VM
+  - Restart crashed Celery or RQ workers used by agent backends
+  - Group log tails for local ML stacks without Docker Compose
+  - Bootstrap process supervision on GPU boxes that are not in a cluster


### PR DESCRIPTION
## Add 5 tools to the catalog

Python concurrency, ops, testing, and messaging libraries:

| Tool | Category | Stars | License |
|------|----------|-------|---------|
| gevent | Dev Tools | 6.4k | MIT |
| paramiko | Dev Tools | 9.8k | LGPL-2.1 |
| Supervisor | Dev Tools | 9.1k | BSD-derived |
| factory-boy | Dev Tools | 3.8k | MIT |
| kombu | Data | 3.1k | BSD-3-Clause |

Local validation passed for all five YAML files.
