### PR TITLE
Add prometheus-client, Hatch, Pygments, eventlet to catalog

### DIFF
--- a/tools/dev-tools/eventlet.yaml
+++ b/tools/dev-tools/eventlet.yaml
@@ -1,0 +1,27 @@
+name: eventlet
+description: Concurrent networking library for Python using green threads. eventlet monkey-patches I/O so OpenStack-era and some ML services can handle many sockets without asyncio, overlapping with gevent but with a different hub.
+tagline: Green-thread networking for Python
+
+github_url: https://github.com/eventlet/eventlet
+website_url: https://eventlet.readthedocs.io
+docs_url: https://eventlet.readthedocs.io
+install_command: pip install eventlet
+
+category: Dev Tools
+tags: [python, concurrency, greenthreads, networking, async]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Some production stacks (OpenStack, older WSGI servers, a few Celery
+  pools) still use eventlet instead of asyncio or gevent. eventlet
+  provides greenthreads and monkey-patched sockets so blocking clients
+  multiplex I/O. Teams inheriting those services need the library on
+  the catalog even when new agent code prefers asyncio.
+
+use_cases:
+  - Run Celery or WSGI workers configured for the eventlet pool
+  - Monkey-patch blocking HTTP and DB clients in legacy Python services
+  - Serve many concurrent sockets on OpenStack-related control planes
+  - Debug greenthread hubs when a dependency still imports eventlet

--- a/tools/dev-tools/hatch.yaml
+++ b/tools/dev-tools/hatch.yaml
@@ -1,0 +1,27 @@
+name: Hatch
+description: Modern Python project manager from PyPA. Hatch handles environments, versioning, and builds with hatchling so ML libraries get reproducible pyproject.toml workflows without a pile of tox.ini files.
+tagline: PyPA project manager for Python packages
+
+github_url: https://github.com/pypa/hatch
+website_url: https://hatch.pypa.io
+docs_url: https://hatch.pypa.io/latest/
+install_command: pip install hatch
+
+category: Dev Tools
+tags: [python, packaging, pypa, build, environments, hatchling]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Python ML packages juggle venv, setuptools, bumpversion, and tox with
+  overlapping config. Hatch is an extensible project manager that creates
+  environments, runs tests, and builds wheels via hatchling, the PEP 517
+  backend. Teams publishing tokenizers or clients get one tool for env and
+  release instead of five.
+
+use_cases:
+  - Create isolated test and docs environments for a Python ML library
+  - Build and publish wheels with the hatchling PEP 517 backend
+  - Version and tag package releases from pyproject.toml
+  - Replace ad-hoc tox plus setuptools scripts in package CI

--- a/tools/dev-tools/pygments.yaml
+++ b/tools/dev-tools/pygments.yaml
@@ -1,0 +1,27 @@
+name: Pygments
+description: Generic syntax highlighter in Python. Pygments tokenizes code for Sphinx, Jupyter, and Markdown pipelines so docs, RAG snippets, and agent UIs get language-aware highlighting without a browser.
+tagline: Python syntax highlighting library
+
+github_url: https://github.com/pygments/pygments
+website_url: https://pygments.org
+docs_url: https://pygments.org/docs/
+install_command: pip install Pygments
+
+category: Dev Tools
+tags: [python, syntax-highlighting, docs, sphinx, jupyter, markdown]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+problem_solved: |
+  Docs sites, notebooks, and agent chat UIs need highlighted code blocks
+  for dozens of languages. Rolling a highlighter is a non-goal. Pygments
+  is the library Sphinx, Jupyter, and Markdown-it stacks already use to
+  lex Python, CUDA, YAML, and more into HTML or ANSI, including in
+  headless RAG preview pipelines.
+
+use_cases:
+  - Highlight code blocks in Sphinx and MkDocs sites for ML libraries
+  - Render notebook and agent-chat snippets with language-aware colors
+  - Tokenize source for search and RAG chunking that should respect syntax
+  - Emit ANSI-colored traces in CLI tools that dump Python or SQL

--- a/tools/monitoring/prometheus-client.yaml
+++ b/tools/monitoring/prometheus-client.yaml
@@ -1,0 +1,27 @@
+name: prometheus-client
+description: Official Prometheus instrumentation library for Python. prometheus-client exposes counters, histograms, and /metrics so model servers, agent workers, and training jobs can be scraped without a sidecar.
+tagline: Prometheus metrics for Python apps
+
+github_url: https://github.com/prometheus/client_python
+website_url: https://prometheus.github.io/client_python/
+docs_url: https://prometheus.github.io/client_python/
+install_command: pip install prometheus-client
+
+category: Monitoring
+tags: [python, prometheus, metrics, observability, monitoring, instrumentation]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Model APIs and agent workers need request counts, latency histograms, and
+  GPU-adjacent gauges, but shipping a sidecar for every process is heavy.
+  prometheus-client is the official Python library that records metrics in
+  process and serves Prometheus text format, which Grafana and Alertmanager
+  already know how to scrape.
+
+use_cases:
+  - Expose request latency histograms on FastAPI model-serving endpoints
+  - Count agent tool calls, queue depth, and error rates for Prometheus scrapes
+  - Instrument training loops with gauges for step time and loss without a vendor APM
+  - Push gateway metrics from short-lived batch jobs that cannot be scraped


### PR DESCRIPTION
## Add 4 tools to the catalog

Python metrics, packaging, highlighting, and concurrency libraries:

| Tool | Category | Stars | License |
|------|----------|-------|---------|
| prometheus-client | Monitoring | 4.4k | Apache-2.0 |
| Hatch | Dev Tools | 7.2k | MIT |
| Pygments | Dev Tools | 2.2k | BSD-2-Clause |
| eventlet | Dev Tools | 1.3k | MIT |

Local validation passed for all four YAML files.
