### PR TITLE
Add pluggy, pexpect, AsyncSSH, markdown-it-py, typing-extensions to catalog

### DIFF
--- a/tools/dev-tools/asyncssh.yaml
+++ b/tools/dev-tools/asyncssh.yaml
@@ -1,0 +1,27 @@
+name: AsyncSSH
+description: An asynchronous SSHv2 client and server for Python asyncio. Open sessions, SFTP, and port forwards without blocking the event loop, so agent runtimes can talk to remote hosts while serving other work.
+tagline: Asyncio SSHv2 client and server for Python
+
+github_url: https://github.com/ronf/asyncssh
+docs_url: https://asyncssh.readthedocs.io/en/latest/
+
+category: Dev Tools
+tags: [python, ssh, asyncio, sftp, remote, agents]
+pricing: free
+is_open_source: true
+license: EPL-2.0
+
+install_command: pip install asyncssh
+
+problem_solved: |
+  Agent runtimes and data jobs often need SSH, SFTP, and port forwards
+  without blocking an asyncio event loop. Paramiko and subprocess SSH
+  are synchronous and stall concurrent work. AsyncSSH implements SSHv2
+  natively on asyncio so you can open many remote sessions, stream
+  files, and keep serving other tasks at the same time.
+
+use_cases:
+  - Run remote training or eval commands over SSH from an asyncio agent
+  - Stream checkpoints and datasets with SFTP without blocking the loop
+  - Open SSH port forwards to reach private model or database endpoints
+  - Build an asyncio SSH server for controlled remote access in labs

--- a/tools/dev-tools/markdown-it-py.yaml
+++ b/tools/dev-tools/markdown-it-py.yaml
@@ -1,0 +1,28 @@
+name: markdown-it-py
+description: A fast Python Markdown parser with full CommonMark support, syntax plugins, and a markdown-it compatible API. Convert Markdown to tokens or HTML for docs, RAG chunking, and agent message pipelines.
+tagline: CommonMark Markdown parser for Python
+
+github_url: https://github.com/executablebooks/markdown-it-py
+website_url: https://markdown-it-py.readthedocs.io
+docs_url: https://markdown-it-py.readthedocs.io
+
+category: Dev Tools
+tags: [python, markdown, commonmark, parsing, docs, rag]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install markdown-it-py
+
+problem_solved: |
+  Python Markdown libraries often diverge from CommonMark or hide a
+  token stream you need for RAG chunking and docs pipelines. markdown-it-py
+  is a Python port of markdown-it with 100% CommonMark, plugins, and
+  a token API so you can parse Markdown once and render HTML or walk
+  headings, code, and tables without a second parser.
+
+use_cases:
+  - Parse README and docs Markdown into tokens for RAG chunking
+  - Render CommonMark to HTML in Python docs and agent UIs
+  - Enable syntax plugins for tables, fences, and custom directives
+  - Share markdown-it plugin ideas between JS frontends and Python backends

--- a/tools/dev-tools/pexpect.yaml
+++ b/tools/dev-tools/pexpect.yaml
@@ -1,0 +1,28 @@
+name: pexpect
+description: A Python module for driving interactive programs in a pseudo-terminal. Spawn shells, CLIs, and SSH sessions, then expect patterns and send input as if a human were at the keyboard.
+tagline: Automate interactive terminal programs from Python
+
+github_url: https://github.com/pexpect/pexpect
+website_url: https://pexpect.readthedocs.io/
+docs_url: https://pexpect.readthedocs.io/
+
+category: Dev Tools
+tags: [python, pty, cli, automation, ssh, testing]
+pricing: free
+is_open_source: true
+license: ISC
+
+install_command: pip install pexpect
+
+problem_solved: |
+  Many developer and ML tools only expose an interactive CLI, not a
+  clean API. Subprocess pipes deadlock on prompts and pagers. pexpect
+  talks to programs through a pseudo-terminal, waits for expected
+  output, and sends replies, so agents and CI jobs can drive installers,
+  REPLs, and remote shells without a human at the keyboard.
+
+use_cases:
+  - Drive interactive installers and CLIs that wait for yes/no prompts
+  - Automate SSH logins and remote commands from Python agent scripts
+  - Test REPL tools by spawning them and asserting on expected output
+  - Script gdb, pdb, or model CLIs that only work in a real terminal

--- a/tools/dev-tools/pluggy.yaml
+++ b/tools/dev-tools/pluggy.yaml
@@ -1,0 +1,29 @@
+name: pluggy
+description: A minimalist production-ready plugin system used by pytest and other Python tools. Register hook specs, implement plugins, and compose extensions without a heavy plugin framework.
+tagline: Minimalist plugin system for Python tools
+
+github_url: https://github.com/pytest-dev/pluggy
+website_url: https://pluggy.readthedocs.io/en/latest/
+docs_url: https://pluggy.readthedocs.io/en/latest/
+
+category: Dev Tools
+tags: [python, plugins, hooks, pytest, extensibility, testing]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install pluggy
+
+problem_solved: |
+  Python tools need a way for third parties to extend behavior without
+  forking the core. Ad-hoc import hooks and monkey-patching are brittle
+  and hard to compose. pluggy provides named hook specs, first-result
+  and historic calling, and plugin registration so pytest-style
+  ecosystems can grow extensions that stay compatible as the host tool
+  evolves.
+
+use_cases:
+  - Add pytest-style plugins to an internal CLI or ML experiment runner
+  - Let teams register custom hooks for data validation or model eval
+  - Compose first-result and historic hook calls without custom dispatch
+  - Ship a public SDK that third parties can extend without forking

--- a/tools/dev-tools/typing-extensions.yaml
+++ b/tools/dev-tools/typing-extensions.yaml
@@ -1,0 +1,27 @@
+name: typing-extensions
+description: Backported and experimental type hints for Python. Use TypedDict, ParamSpec, TypeGuard, and other typing features on older interpreters so libraries stay typed across the versions ML stacks actually run.
+tagline: Backported typing features for Python
+
+github_url: https://github.com/python/typing_extensions
+docs_url: https://typing-extensions.readthedocs.io/en/latest/
+
+category: Dev Tools
+tags: [python, typing, type-hints, mypy, pydantic, libraries]
+pricing: free
+is_open_source: true
+license: PSF-2.0
+
+install_command: pip install typing_extensions
+
+problem_solved: |
+  New typing constructs land in CPython years before every ML
+  environment can upgrade. Libraries that import them from typing
+  break on older Pythons. typing-extensions backports TypedDict,
+  ParamSpec, TypeGuard, and experimental PEPs so Pydantic, FastAPI,
+  and model SDKs can ship one typed API across Python versions.
+
+use_cases:
+  - Use TypedDict, ParamSpec, and TypeGuard on Python versions that lack them
+  - Keep Pydantic, FastAPI, and LLM SDK type hints working on older runtimes
+  - Prototype experimental PEP typing features before they ship in CPython
+  - Write mypy-clean library APIs that support a wide Python version range


### PR DESCRIPTION
## Summary

Add five Python developer libraries used daily in AI/ML stacks:

- **pluggy** — pytest-dev plugin system (1.6k★, MIT)
- **pexpect** — drive interactive programs via a pseudo-terminal (2.8k★, ISC)
- **AsyncSSH** — asyncio SSHv2 client and server (1.7k★, EPL-2.0)
- **markdown-it-py** — CommonMark Markdown parser (1.3k★, MIT)
- **typing-extensions** — backported Python typing features (583★, PSF-2.0)

Local validation passed for all five YAML files.

## Test plan

- [x] `npx tsx scripts/validate-tool.ts` on each file
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for five developer tools: AsyncSSH, markdown-it-py, Pexpect, Pluggy, and typing-extensions.
  * Included descriptions, installation commands, documentation links, licensing details, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->