### PR TITLE
Add jiter, loky, honcho, slime, Open-R1 to catalog

### DIFF
--- a/tools/dev-tools/honcho.yaml
+++ b/tools/dev-tools/honcho.yaml
@@ -1,0 +1,28 @@
+name: honcho
+description: A Python clone of Foreman for Procfile-based apps. Start API servers, workers, and sidecar processes from one file so local ML stacks run the same process set as production.
+tagline: Procfile process manager for Python apps
+
+github_url: https://github.com/nickstenning/honcho
+website_url: https://pypi.org/project/honcho/
+docs_url: https://honcho.readthedocs.io/
+
+category: Dev Tools
+tags: [python, procfile, process-manager, local-dev, workers, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install honcho
+
+problem_solved: |
+  Local AI apps often need an API, a queue worker, a frontend, and a
+  model server at once. Running each in a separate terminal drifts from
+  production. honcho reads a Procfile and starts every process with
+  colored logs, so a FastAPI plus worker plus sidecar stack matches
+  what you ship without a full container compose file.
+
+use_cases:
+  - Start an API, Celery or RQ worker, and frontend from one Procfile
+  - Match Heroku-style process types in local ML app development
+  - Color-code logs from several processes while debugging agent stacks
+  - Run a model server beside a web app without writing a compose file

--- a/tools/dev-tools/jiter.yaml
+++ b/tools/dev-tools/jiter.yaml
@@ -1,0 +1,28 @@
+name: jiter
+description: A fast iterable JSON parser from the Pydantic team, with a Python package and a Rust crate. Parse JSON into Python objects or iterate tokens without loading the whole document, which speeds up LLM API payloads.
+tagline: Fast iterable JSON parser for Python and Rust
+
+github_url: https://github.com/pydantic/jiter
+website_url: https://crates.io/crates/jiter
+docs_url: https://docs.rs/jiter
+
+category: Dev Tools
+tags: [python, rust, json, parsing, pydantic, performance]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install jiter
+
+problem_solved: |
+  LLM APIs and agent tools move large JSON payloads. Python's json
+  module loads the whole document and is slow on hot paths. jiter
+  parses JSON quickly, can iterate tokens, and is the engine behind
+  Pydantic v2 validation, so typed model SDKs spend less time in
+  JSON decode before the actual work starts.
+
+use_cases:
+  - Speed up JSON decode in Pydantic models and LLM SDK response parsing
+  - Iterate JSON tokens from large tool-call payloads without full loads
+  - Parse streaming or partial JSON from model APIs in Python services
+  - Share a fast parser between Rust inference services and Python agents

--- a/tools/dev-tools/loky.yaml
+++ b/tools/dev-tools/loky.yaml
@@ -1,0 +1,28 @@
+name: loky
+description: A robust reusable process-pool executor used by joblib. Spawn workers that survive crashes, reuse processes across calls, and run CPU-heavy Python work without the pitfalls of multiprocessing.Pool.
+tagline: Robust process pool executor for Python
+
+github_url: https://github.com/joblib/loky
+website_url: https://loky.readthedocs.io/en/stable/
+docs_url: https://loky.readthedocs.io/en/stable/
+
+category: Dev Tools
+tags: [python, multiprocessing, joblib, parallelism, executor, cpu]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install loky
+
+problem_solved: |
+  Python multiprocessing.Pool deadlocks, leaks workers, and cannot
+  reuse processes cleanly across joblib calls. loky is a reusable
+  ProcessPoolExecutor with crash isolation, cloudpickle serialization,
+  and memory management so feature jobs and sklearn-style pipelines
+  can run CPU work in parallel without hanging the parent process.
+
+use_cases:
+  - Parallelize CPU-bound feature transforms behind joblib or sklearn
+  - Reuse a process pool across sequential ML jobs instead of respawning
+  - Isolate worker crashes so one bad transform does not kill the parent
+  - Run nested parallel calls that standard multiprocessing.Pool cannot handle

--- a/tools/fine-tuning/open-r1.yaml
+++ b/tools/fine-tuning/open-r1.yaml
@@ -1,0 +1,25 @@
+name: Open-R1
+description: A fully open reproduction of DeepSeek-R1 from Hugging Face. Train reasoning models with SFT and GRPO, evaluate on math and code, and inspect the recipes instead of treating R1-style post-training as a closed pipeline.
+tagline: Open reproduction of DeepSeek-R1 post-training
+
+github_url: https://github.com/huggingface/open-r1
+docs_url: https://github.com/huggingface/open-r1
+
+category: Fine-tuning
+tags: [python, reasoning, grpo, r1, huggingface, post-training, llm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  DeepSeek-R1 showed that RL can produce strong reasoning models, but
+  the original stack is not fully open. Teams that want R1-style SFT
+  and GRPO have to reverse-engineer recipes. Open-R1 publishes training
+  code, configs, and evaluation so researchers can reproduce reasoning
+  post-training and adapt it to their own models and datasets.
+
+use_cases:
+  - Reproduce DeepSeek-R1 style SFT and GRPO on open base models
+  - Evaluate reasoning checkpoints on math and code benchmarks
+  - Adapt R1 post-training recipes to a custom domain dataset
+  - Study GRPO training dynamics with public configs instead of a closed stack

--- a/tools/fine-tuning/slime.yaml
+++ b/tools/fine-tuning/slime.yaml
@@ -1,0 +1,27 @@
+name: slime
+description: An LLM post-training framework for RL scaling from THUDM. It pairs Megatron training with SGLang rollouts so teams can run large-scale RL, tool use, and agentic reward loops without wrapping another training stack.
+tagline: LLM post-training framework for RL scaling
+
+github_url: https://github.com/THUDM/slime
+website_url: https://thudm.github.io/slime
+docs_url: https://thudm.github.io/slime
+
+category: Fine-tuning
+tags: [python, rl, post-training, megatron, sglang, agents, llm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Large-scale RL for LLMs usually means gluing a trainer, an inference
+  engine, and a reward loop with custom shims. slime keeps Megatron
+  and SGLang arguments native, so new training and serving features
+  pass through instead of hiding behind a wrapper. Data generation,
+  tools, sandboxes, and multi-agent rewards plug in without forking
+  the training kernel.
+
+use_cases:
+  - Run RL post-training for LLMs with Megatron plus SGLang rollouts
+  - Plug math, code, search, or sandbox verifiers into the reward loop
+  - Scale multi-agent and long-horizon tool-use RL without a custom trainer
+  - Pass through new Megatron and SGLang flags without rewriting slime


### PR DESCRIPTION
## Summary

Add five tools spanning Dev Tools and Fine-tuning:

- **jiter** — Pydantic fast JSON parser (547★, MIT)
- **loky** — robust process-pool executor used by joblib (627★, BSD-3-Clause)
- **honcho** — Python Foreman/Procfile process manager (1.7k★, MIT)
- **slime** — THUDM LLM post-training framework for RL scaling (8.3k★, Apache-2.0)
- **Open-R1** — Hugging Face open reproduction of DeepSeek-R1 (26k★, Apache-2.0)

Local validation passed for all five YAML files.

## Test plan

- [x] `npx tsx scripts/validate-tool.ts` on each file
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Honcho, Jiter, and Loky to the development tools catalog, including installation guidance, project links, licensing, and key use cases.
  - Added Open-R1 and Slime to the fine-tuning catalog with project details, setup information, licensing, and supported training or post-training workflows.
  - Expanded discoverability for process management, JSON parsing, parallel Python execution, LLM fine-tuning, evaluation, and reinforcement-learning workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->