### PR TITLE
Add llm.c, Search-R1, EasyR1, Langroid, Huginn to catalog

### DIFF
--- a/tools/agent-frameworks/huginn.yaml
+++ b/tools/agent-frameworks/huginn.yaml
@@ -1,0 +1,25 @@
+name: Huginn
+description: A self-hosted system for building agents that watch the web and act on your behalf. Connect events, filters, and actions so you can automate monitoring, alerts, and follow-up work without a closed IFTTT-style service.
+tagline: Self-hosted agents that watch and act
+
+github_url: https://github.com/huginn/huginn
+docs_url: https://github.com/huginn/huginn/wiki
+
+category: Agents
+tags: [ruby, agents, automation, self-hosted, monitoring, workflows]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Teams that want always-on agents for RSS, email, weather, or site
+  changes often depend on closed IFTTT-style SaaS. Huginn is a
+  self-hosted agent platform. You chain event sources, filters, and
+  actions so monitoring and follow-up stay on your infrastructure,
+  with full control of credentials and data.
+
+use_cases:
+  - Watch RSS, email, or web pages and trigger actions when they change
+  - Chain agents that filter events and post alerts to chat or email
+  - Self-host IFTTT-style automations without sending data to a vendor
+  - Prototype long-running monitor agents before moving logic into an LLM app

--- a/tools/agent-frameworks/langroid.yaml
+++ b/tools/agent-frameworks/langroid.yaml
@@ -1,0 +1,28 @@
+name: Langroid
+description: A Python framework for multi-agent LLM programming. Agents have typed tools, memory, and message passing so you can compose retrieval, code, and SQL specialists without a giant prompt graph.
+tagline: Multi-agent programming framework for LLMs
+
+github_url: https://github.com/langroid/langroid
+website_url: https://langroid.github.io/langroid/
+docs_url: https://langroid.github.io/langroid/
+
+category: Agents
+tags: [python, agents, multi-agent, tools, rag, llm]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install langroid
+
+problem_solved: |
+  Multi-agent LLM apps often become an untyped mess of prompts and
+  callbacks. Langroid models agents as typed conversational entities
+  with tools, memory, and structured messages, so retrieval, SQL, and
+  code agents can delegate work without a custom orchestration layer
+  for every new task.
+
+use_cases:
+  - Build a multi-agent RAG app where specialists handle search and writing
+  - Give agents typed tools for SQL, code execution, or document chat
+  - Orchestrate agent-to-agent message passing without a custom bus
+  - Prototype LLM workflows in Python with less prompt-graph boilerplate

--- a/tools/fine-tuning/easyr1.yaml
+++ b/tools/fine-tuning/easyr1.yaml
@@ -1,0 +1,25 @@
+name: EasyR1
+description: An efficient scalable multi-modality RL training framework based on veRL, from the LLaMA Factory authors. Run GRPO-style post-training for language and vision-language models without assembling a custom RL stack.
+tagline: Multi-modality RL training on veRL
+
+github_url: https://github.com/hiyouga/EasyR1
+website_url: https://verl.readthedocs.io
+docs_url: https://github.com/hiyouga/EasyR1
+
+category: Fine-tuning
+tags: [python, rl, grpo, multimodal, verl, vlm, llm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  veRL is powerful but heavy to configure for everyday GRPO runs,
+  especially with vision-language models. EasyR1 wraps that stack into
+  a smaller recipe so teams can post-train language and multi-modal
+  models with RL without owning a full distributed RL codebase.
+
+use_cases:
+  - Run GRPO post-training for open LLMs on a veRL-based stack
+  - Fine-tune vision-language models with multi-modality RL
+  - Scale RL rollouts without writing a custom trainer on top of veRL
+  - Share compact EasyR1 recipes instead of a full RL research repo

--- a/tools/fine-tuning/llm-c.yaml
+++ b/tools/fine-tuning/llm-c.yaml
@@ -1,0 +1,25 @@
+name: llm.c
+description: LLM training in simple raw C and CUDA from Andrej Karpathy. Train GPT-2 scale models without a Python training stack, so the hot path is readable C and the GPU kernels stay in one place.
+tagline: LLM training in simple C and CUDA
+
+github_url: https://github.com/karpathy/llm.c
+docs_url: https://github.com/karpathy/llm.c
+
+category: Fine-tuning
+tags: [c, cuda, gpt, training, llm, karpathy, gpu]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Most LLM trainers hide the math behind Python, autograd, and huge
+  frameworks. That is hard to audit and slow to change at the kernel
+  level. llm.c trains GPT-style models in plain C and CUDA so you can
+  read the full training loop, study GPU kernels, and run a serious
+  pretrain or finetune without a PyTorch dependency on the hot path.
+
+use_cases:
+  - Train or finetune GPT-2 class models in C and CUDA without PyTorch
+  - Study a full LLM training loop that fits in a small C codebase
+  - Benchmark CUDA kernels against Python trainer stacks
+  - Teach GPU training internals without a multi-file framework

--- a/tools/fine-tuning/search-r1.yaml
+++ b/tools/fine-tuning/search-r1.yaml
@@ -1,0 +1,26 @@
+name: Search-R1
+description: An RL training framework for reasoning models that call a search engine mid-rollout. Built on veRL, it interleaves LLM generation with retrieval so agents learn when to search, not only how to think.
+tagline: RL training for LLMs that call search
+
+github_url: https://github.com/PeterGriffinJin/Search-R1
+website_url: https://arxiv.org/pdf/2503.09516
+docs_url: https://github.com/PeterGriffinJin/Search-R1
+
+category: Fine-tuning
+tags: [python, rl, search, retrieval, reasoning, verl, llm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Reasoning RL usually trains a model to think in isolation. Real
+  agent tasks need search mid-generation, but most GRPO stacks do not
+  interleave retrieval. Search-R1 extends veRL so rollouts can call a
+  search engine, then keep generating, teaching the model when to look
+  things up instead of hallucinating facts.
+
+use_cases:
+  - Train an LLM with RL to call a search engine during reasoning
+  - Interleave retrieval and generation in veRL-style GRPO rollouts
+  - Evaluate search-augmented reasoning on multi-hop QA tasks
+  - Study when models learn to search versus answer from parameters


### PR DESCRIPTION
## Summary

Add five tools spanning Fine-tuning and Agents:

- **llm.c** — Karpathy LLM training in C/CUDA (30k★, MIT)
- **Search-R1** — RL training for search-calling reasoning models (5.3k★, Apache-2.0)
- **EasyR1** — multi-modality RL training on veRL (5.1k★, Apache-2.0)
- **Langroid** — multi-agent LLM programming framework (4.1k★, MIT)
- **Huginn** — self-hosted agents that monitor and act (49k★, MIT)

Local validation passed for all five YAML files.

## Test plan

- [x] `npx tsx scripts/validate-tool.ts` on each file
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Huginn to the agent frameworks catalog, including monitoring, alerting, and automation use cases.
  - Added Langroid with metadata covering multi-agent LLM development and related project information.
  - Added EasyR1, llm.c, and Search-R1 to the fine-tuning catalog.
  - Included descriptions, links, licensing details, categories, tags, and practical use cases for each newly listed tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->