### PR TITLE
Add Apache Maka, Kilo Code, Codewhale, claude-mem, Wazuh to catalog

### DIFF
--- a/tools/agent-frameworks/apache-maka.yaml
+++ b/tools/agent-frameworks/apache-maka.yaml
@@ -1,0 +1,25 @@
+name: Apache Maka
+description: A local-first AI agent workspace incubating at the Apache Software Foundation. Maka inspects projects, runs tools in a sandbox, and records model messages, tool calls, and permission decisions as an append-only log on your machine.
+tagline: Local-first agent workspace with an audit log
+
+github_url: https://github.com/apache/maka
+docs_url: https://github.com/apache/maka
+
+category: Agents
+tags: [agents, local-first, sandbox, audit-log, desktop, apache]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Agent IDEs often hide tool calls and permission choices in a chat
+  transcript you cannot replay. Apache Maka is a local-first workspace
+  that records model messages, tool results, and termination events as
+  an append-only log, so you can inspect what the agent did, recover
+  runs, and keep execution facts on your machine.
+
+use_cases:
+  - Run a local coding agent with sandboxed tool calls on your machine
+  - Audit model messages, tool results, and permission decisions later
+  - Recover failed agent runs from an append-only execution log
+  - Keep agent workspace data local instead of sending it to a SaaS IDE

--- a/tools/agent-frameworks/claude-mem.yaml
+++ b/tools/agent-frameworks/claude-mem.yaml
@@ -1,0 +1,28 @@
+name: claude-mem
+description: Persistent memory across agent sessions. claude-mem captures what an agent does, compresses it with AI, and injects relevant context into later runs for Claude Code, Codex, Gemini, Copilot, OpenCode, and more.
+tagline: Persistent context across agent sessions
+
+github_url: https://github.com/thedotmack/claude-mem
+website_url: https://claude-mem.ai
+docs_url: https://claude-mem.ai
+
+category: Agents
+tags: [memory, claude-code, agents, context, plugins, npm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: npx claude-mem install
+
+problem_solved: |
+  Coding agents forget everything when a session ends. You re-explain
+  architecture, past decisions, and failed approaches. claude-mem
+  records session activity, compresses it, and injects the useful bits
+  into the next run so Claude Code and other agents keep project
+  context without stuffing the whole history into the prompt.
+
+use_cases:
+  - Keep Claude Code project context across days of sessions
+  - Compress long agent transcripts into memory that future runs can use
+  - Share the same memory plugin across Codex, Gemini, Copilot, and OpenCode
+  - Stop re-explaining repo conventions at the start of every agent chat

--- a/tools/agent-frameworks/codewhale.yaml
+++ b/tools/agent-frameworks/codewhale.yaml
@@ -1,0 +1,27 @@
+name: Codewhale
+description: An open-source coding agent for the terminal, written in Rust. Codewhale works in your repo from the CLI so you can plan, edit, and iterate without opening a separate IDE agent pane.
+tagline: Rust coding agent for the terminal
+
+github_url: https://github.com/Hmbown/Codewhale
+website_url: https://codewhale.net/
+docs_url: https://codewhale.net/
+
+category: Agents
+tags: [rust, agents, coding-agent, cli, terminal, npm]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: npm install -g codewhale
+
+problem_solved: |
+  Many coding agents assume a GUI editor. Terminal-first teams need an
+  agent that lives next to git, tests, and SSH. Codewhale is a Rust
+  CLI agent that works in the repo from the shell, so you can run
+  agentic edits on remote boxes and in tmux without a VS Code session.
+
+use_cases:
+  - Run a coding agent from the terminal on a remote GPU or build box
+  - Edit and iterate on a repo without opening an IDE agent pane
+  - Script agentic coding in tmux, CI, or SSH sessions
+  - Use a Rust CLI agent that installs with npm and stays in the repo

--- a/tools/agent-frameworks/kilo-code.yaml
+++ b/tools/agent-frameworks/kilo-code.yaml
@@ -1,0 +1,28 @@
+name: Kilo Code
+description: An open-source agentic engineering platform with a VS Code extension, JetBrains plugin, and CLI. Kilo plans, edits, and ships code across 500-plus models so teams can run a coding agent inside the editor they already use.
+tagline: Open-source coding agent for VS Code and CLI
+
+github_url: https://github.com/Kilo-Org/kilocode
+website_url: https://kilo.ai/
+docs_url: https://kilo.ai/
+
+category: Agents
+tags: [vscode, agents, coding-agent, cli, jetbrains, open-source]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+install_command: npm install -g @kilocode/cli
+
+problem_solved: |
+  Most coding agents are closed products or editor-only plugins. Kilo
+  Code is an open agentic platform that lives in VS Code, JetBrains,
+  and a CLI, with access to many models at provider pricing. Teams can
+  plan, edit, and iterate in the IDE they already use without locking
+  the agent loop to a single vendor app.
+
+use_cases:
+  - Install the VS Code or JetBrains plugin and let Kilo edit a repo in place
+  - Run the Kilo CLI in CI or a terminal for agentic coding without an IDE
+  - Switch among 500-plus models while keeping the same agent workflow
+  - Wire MCP servers so the coding agent can use internal tools

--- a/tools/monitoring/wazuh.yaml
+++ b/tools/monitoring/wazuh.yaml
@@ -1,0 +1,26 @@
+name: Wazuh
+description: An open-source XDR and SIEM platform for endpoints and cloud workloads. Wazuh collects logs, detects threats, and alerts on file integrity and configuration drift so AI stacks get security monitoring without a closed SIEM.
+tagline: Open-source XDR and SIEM platform
+
+github_url: https://github.com/wazuh/wazuh
+website_url: https://wazuh.com/
+docs_url: https://documentation.wazuh.com/
+
+category: Monitoring
+tags: [siem, xdr, security, logging, endpoints, monitoring]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  AI platforms still run on servers, containers, and cloud accounts
+  that get attacked. Closed SIEMs are expensive and lock telemetry
+  in a vendor console. Wazuh is an open XDR and SIEM that agents
+  report into, with file integrity, log analysis, and alerting, so
+  you can watch model hosts and data nodes with the same stack.
+
+use_cases:
+  - Collect endpoint and cloud logs for AI infra into an open SIEM
+  - Alert on file integrity changes to model weights or secret files
+  - Detect suspicious process and SSH activity on training boxes
+  - Replace a closed SIEM for security monitoring of ML platforms


### PR DESCRIPTION
## Summary

Add five tools spanning Agents and Monitoring:

- **Apache Maka** — local-first agent workspace (4.6k★, Apache-2.0, incubating)
- **Kilo Code** — agentic engineering platform for VS Code/CLI (27k★, MIT)
- **Codewhale** — Rust coding agent for the terminal (40k★, MIT)
- **claude-mem** — persistent memory across agent sessions (93k★, Apache-2.0)
- **Wazuh** — open-source XDR and SIEM (16k★, GPL-2.0)

Local validation passed for all five YAML files.

## Test plan

- [x] `npx tsx scripts/validate-tool.ts` on each file
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Apache Maka, Claude Mem, Codewhale, and Kilo Code, including descriptions, links, licensing, pricing, installation details, and use cases.
  - Added Wazuh monitoring metadata with platform information, security-focused use cases, licensing, and pricing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->