### PR TITLE
Add Zeek, Tetragon, Suricata, Tracee, osquery to catalog

### DIFF
--- a/tools/monitoring/osquery.yaml
+++ b/tools/monitoring/osquery.yaml
@@ -1,0 +1,26 @@
+name: osquery
+description: SQL-powered operating system instrumentation that exposes processes, sockets, files, and packages as queryable tables. osquery lets ML ops teams inventory hosts and hunt for drift with scheduled SQL queries.
+tagline: SQL-powered OS instrumentation and host monitoring
+
+github_url: https://github.com/osquery/osquery
+website_url: https://osquery.io
+docs_url: https://osquery.readthedocs.io
+
+category: Monitoring
+tags: [osquery, sql, endpoint, security, inventory, linux, macos]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Host inventory and incident hunts usually mean custom scripts per
+  OS. osquery exposes the operating system as SQL tables so you can
+  query processes, listening ports, packages, and file hashes the
+  same way on Linux, macOS, and Windows, including scheduled queries
+  that watch training boxes for unexpected software or listeners.
+
+use_cases:
+  - Inventory packages and running processes on GPU training hosts with SQL
+  - Hunt for unexpected listening ports on model serving machines
+  - Schedule queries that alert when a new binary appears in a model directory
+  - Compare host state across a fleet before and after a training job

--- a/tools/monitoring/suricata.yaml
+++ b/tools/monitoring/suricata.yaml
@@ -1,0 +1,26 @@
+name: Suricata
+description: High-performance network IDS, IPS, and network security monitoring engine from OISF. Suricata inspects traffic with multi-threaded protocol parsing and rules so AI platforms can detect malicious east-west and ingress flows.
+tagline: Multi-threaded network IDS, IPS, and NSM engine
+
+github_url: https://github.com/OISF/suricata
+website_url: https://suricata.io
+docs_url: https://docs.suricata.io
+
+category: Monitoring
+tags: [ids, ips, nsm, network, security, rules, open-source]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Single-threaded IDS engines drop packets under load, and generic
+  firewalls do not parse application protocols. Suricata is a
+  multi-threaded IDS/IPS/NSM engine with protocol parsing and a
+  large rule ecosystem, so you can inspect traffic to model APIs
+  and data stores at line rate and alert on known attack patterns.
+
+use_cases:
+  - Run Suricata as IDS on the network path in front of model serving
+  - Match Emerging Threats or custom rules against east-west cluster traffic
+  - Extract protocol metadata and files for later incident review
+  - Deploy inline IPS mode to drop known exploit traffic to ML endpoints

--- a/tools/monitoring/tetragon.yaml
+++ b/tools/monitoring/tetragon.yaml
@@ -1,0 +1,26 @@
+name: Tetragon
+description: eBPF-based Kubernetes runtime security from Cilium that observes process, file, and network events in the kernel and can enforce policies. Tetragon gives ML clusters syscall-level observability without sidecar agents.
+tagline: eBPF runtime security and enforcement for Kubernetes
+
+github_url: https://github.com/cilium/tetragon
+website_url: https://tetragon.io
+docs_url: https://tetragon.io/docs/
+
+category: Monitoring
+tags: [ebpf, kubernetes, security, runtime, cilium, observability, cncf]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Sidecar agents miss kernel events and add overhead on GPU nodes.
+  Tetragon hooks eBPF in the kernel to watch process exec, file access,
+  and network activity, then optionally enforces policies, so you can
+  see and block unexpected binaries or data access on training and
+  inference pods without instrumenting each container.
+
+use_cases:
+  - Alert when an inference pod execs a shell or unexpected binary
+  - Trace file access to model weights and secret mounts in Kubernetes
+  - Enforce runtime policies that kill processes matching a tracing rule
+  - Stream kernel process and network events into an ML ops security pipeline

--- a/tools/monitoring/tracee.yaml
+++ b/tools/monitoring/tracee.yaml
@@ -1,0 +1,26 @@
+name: Tracee
+description: Linux runtime security and forensics tool from Aqua that uses eBPF to capture syscalls and kernel events. Tracee helps detect suspicious behavior on GPU nodes and training hosts with low overhead.
+tagline: Linux runtime security and forensics with eBPF
+
+github_url: https://github.com/aquasecurity/tracee
+website_url: https://aquasecurity.github.io/tracee/latest/
+docs_url: https://aquasecurity.github.io/tracee/latest/
+
+category: Monitoring
+tags: [ebpf, linux, security, forensics, runtime, aqua, observability]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Auditd and user-space agents miss short-lived processes and add
+  load on busy GPU hosts. Tracee uses eBPF to capture syscalls,
+  signatures, and forensic events with low overhead so you can
+  detect crypto miners, unexpected network binds, and file access
+  on Linux nodes running training or inference.
+
+use_cases:
+  - Detect unexpected process trees on Linux GPU training hosts
+  - Capture syscall traces after a suspected compromise for forensics
+  - Alert on signatures for miners, reverse shells, or container escapes
+  - Stream Tracee events into a SIEM for runtime monitoring of ML nodes

--- a/tools/monitoring/zeek.yaml
+++ b/tools/monitoring/zeek.yaml
@@ -1,0 +1,26 @@
+name: Zeek
+description: Open-source network analysis framework that turns packet streams into structured logs and protocol events. Zeek is used as network security monitoring rather than a classic signature IDS, giving ML and infra teams high-fidelity traffic telemetry.
+tagline: Network analysis framework for security monitoring
+
+github_url: https://github.com/zeek/zeek
+website_url: https://www.zeek.org
+docs_url: https://docs.zeek.org
+
+category: Monitoring
+tags: [network, security, nsm, ids, observability, logs, open-source]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Packet captures and signature IDS alerts do not explain what happened on
+  the wire in a form you can query. Zeek parses protocols into structured
+  logs (HTTP, DNS, TLS, files) so you can hunt, feed detections, and
+  reconstruct sessions around training clusters and model APIs without
+  writing custom packet parsers.
+
+use_cases:
+  - Log DNS, HTTP, and TLS metadata around GPU clusters for later hunt queries
+  - Detect data exfil from training nodes by tracking unusual long-lived connections
+  - Feed Zeek logs into a SIEM or lake as structured network telemetry
+  - Reconstruct file transfers and protocol events after a model-host incident


### PR DESCRIPTION
## Add Zeek, Tetragon, Suricata, Tracee, osquery to catalog

Five open-source runtime and network security monitoring tools for AI infrastructure:

- **Zeek** (zeek/zeek, ~7.9k★) — network analysis framework / NSM
- **Tetragon** (cilium/tetragon, ~5.0k★) — eBPF Kubernetes runtime security
- **Suricata** (OISF/suricata, ~6.6k★) — IDS/IPS/NSM engine
- **Tracee** (aquasecurity/tracee, ~4.6k★) — Linux eBPF runtime security
- **osquery** (osquery/osquery, ~23.5k★) — SQL-powered OS instrumentation

All files validated locally with `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for five monitoring and security tools: osquery, Suricata, Tetragon, Tracee, and Zeek.
  - Included descriptions, use cases, pricing, licensing, open-source status, categories, tags, and links to relevant resources.
  - Added monitoring options for host inventory, network analysis, runtime security, threat detection, and forensic investigations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->