### PR TITLE
Add Stanford HELM, Highlight.io, GROBID, Bytewax, Snakemake to catalog

### DIFF
--- a/tools/data/bytewax.yaml
+++ b/tools/data/bytewax.yaml
@@ -1,0 +1,27 @@
+name: Bytewax
+description: Python stream processing framework for stateful dataflows with operators for map, filter, window, and join. Bytewax lets teams process event streams in Python, including feature updates and model scores, without switching to JVM streaming stacks.
+tagline: Python-native stateful stream processing
+
+github_url: https://github.com/bytewax/bytewax
+website_url: https://bytewax.io
+docs_url: https://docs.bytewax.io
+
+category: Data
+tags: [streaming, python, dataflow, kafka, features, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+install_command: pip install bytewax
+
+problem_solved: |
+  Streaming feature pipelines often force Python ML teams onto JVM
+  engines. Bytewax runs stateful dataflows in Python with windows,
+  joins, and recovery so you can transform Kafka or other event
+  streams, update features, and score events without leaving the
+  language the models are written in.
+
+use_cases:
+  - Build a Python dataflow that windows clickstream events into features
+  - Join model scores with live events for online inference pipelines
+  - Process Kafka topics with stateful operators instead of batch jobs
+  - Recover stream state after a worker restart in a production dataflow

--- a/tools/data/grobid.yaml
+++ b/tools/data/grobid.yaml
@@ -1,0 +1,26 @@
+name: GROBID
+description: Machine learning library and service that extracts structured metadata, citations, and full text from scholarly PDFs. GROBID turns papers into TEI XML so RAG and research pipelines can index authors, abstracts, and references instead of raw PDF text.
+tagline: ML extraction of structure from scholarly PDFs
+
+github_url: https://github.com/grobidOrg/grobid
+website_url: https://grobid.readthedocs.io
+docs_url: https://grobid.readthedocs.io
+
+category: Data
+tags: [pdf, scholarly, nlp, extraction, tei, java, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Research PDFs mix columns, headers, and citations that generic
+  parsers flatten into noisy text. GROBID uses ML models to recover
+  title, authors, abstract, sections, and bibliography as structured
+  TEI, so literature RAG and bibliometric pipelines get clean fields
+  instead of dumped page text.
+
+use_cases:
+  - Extract titles, abstracts, and citations from arXiv PDFs for a paper index
+  - Build a RAG corpus of sectioned scholarly text instead of raw PDF dumps
+  - Parse bibliographies to construct a citation graph from a paper collection
+  - Run GROBID as a service in a document ingestion pipeline for research data

--- a/tools/data/snakemake.yaml
+++ b/tools/data/snakemake.yaml
@@ -1,0 +1,27 @@
+name: Snakemake
+description: Workflow management system that scales data analysis from laptops to clusters with Python-based rules, conda or container environments, and automatic provenance. Snakemake is widely used for reproducible bioinformatics and ML experiment pipelines.
+tagline: Reproducible workflow engine for data analysis
+
+github_url: https://github.com/snakemake/snakemake
+website_url: https://snakemake.github.io
+docs_url: https://snakemake.readthedocs.io
+
+category: Data
+tags: [workflow, reproducibility, python, pipelines, bioinformatics, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+install_command: pip install snakemake
+
+problem_solved: |
+  Ad hoc scripts for preprocessing, training, and evaluation do not
+  rerun cleanly when inputs change. Snakemake defines pipelines as
+  rules with file dependencies, environments, and cluster backends
+  so scientific and ML workflows stay reproducible from a laptop
+  to a cluster without rewriting the DAG.
+
+use_cases:
+  - Define a preprocessing and training pipeline as Snakemake rules
+  - Rerun only the steps whose inputs changed after a data update
+  - Pin conda or container environments per rule for reproducible ML jobs
+  - Submit a scientific workflow to a cluster from the same Snakefile

--- a/tools/monitoring/highlight-io.yaml
+++ b/tools/monitoring/highlight-io.yaml
@@ -1,0 +1,27 @@
+name: Highlight.io
+description: Open-source full-stack monitoring platform with error tracking, session replay, logs, and distributed tracing. Highlight.io correlates frontend sessions with backend traces so AI product teams can debug agent UIs and APIs in one place.
+tagline: Open-source error, session, log, and trace monitoring
+
+github_url: https://github.com/highlight/highlight
+website_url: https://www.highlight.io
+docs_url: https://www.highlight.io/docs
+
+category: Monitoring
+tags: [observability, session-replay, errors, tracing, logs, open-source]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+install_command: npm install @highlight-run/node
+
+problem_solved: |
+  Errors, logs, and session replay usually live in separate products,
+  so reproducing a failed agent UI or API call means hopping tools.
+  Highlight.io unifies session replay, errors, logs, and traces so
+  you can click from a user session to the backend stack that served
+  an LLM or agent request.
+
+use_cases:
+  - Replay a user session that hit a failed agent or chat UI
+  - Correlate frontend errors with backend traces for model API calls
+  - Collect logs and exceptions from inference services in one dashboard
+  - Self-host full-stack monitoring instead of a closed APM suite

--- a/tools/monitoring/stanford-helm.yaml
+++ b/tools/monitoring/stanford-helm.yaml
@@ -1,0 +1,26 @@
+name: Stanford HELM
+description: Open-source Python framework from Stanford CRFM for holistic, reproducible evaluation of foundation models. HELM runs standardized scenarios across accuracy, robustness, fairness, and efficiency so teams can compare LLMs and multimodal models on the same terms.
+tagline: Holistic evaluation of language and foundation models
+
+github_url: https://github.com/stanford-crfm/helm
+website_url: https://crfm.stanford.edu/helm
+docs_url: https://crfm-helm.readthedocs.io
+
+category: Monitoring
+tags: [llm, evaluation, benchmark, stanford, crfm, python, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+install_command: pip install crfm-helm
+
+problem_solved: |
+  LLM leaderboards report one accuracy number and hide robustness,
+  fairness, and efficiency. HELM runs a shared suite of scenarios
+  and metrics so you can compare foundation models holistically and
+  reproduce results instead of trusting a single vendor score.
+
+use_cases:
+  - Compare candidate LLMs on the same HELM scenarios before production
+  - Report robustness and fairness metrics alongside accuracy for a model card
+  - Reproduce published HELM results for a new model checkpoint
+  - Track evaluation scores across model versions in an ML monitoring workflow


### PR DESCRIPTION
## Add Stanford HELM, Highlight.io, GROBID, Bytewax, Snakemake to catalog

- **Stanford HELM** (stanford-crfm/helm, ~2.9k★) — holistic LLM evaluation (pip install crfm-helm)
- **Highlight.io** (highlight/highlight, ~9.4k★) — open-source full-stack monitoring
- **GROBID** (grobidOrg/grobid, ~5.1k★) — scholarly PDF structure extraction
- **Bytewax** (bytewax/bytewax, ~2.0k★) — Python stream processing
- **Snakemake** (snakemake/snakemake, ~2.9k★) — reproducible workflow engine

All files validated locally with `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Bytewax, GROBID, and Snakemake, including descriptions, links, installation details, licensing, and practical use cases.
  - Added monitoring catalog entries for Highlight.io and Stanford HELM, covering observability, model evaluation, integrations, and common workflows.
  - Expanded discoverability of tools for stream processing, document extraction, data pipelines, application monitoring, and foundation model evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->