### PR TITLE
Add Nextflow, Snowplow to catalog

### DIFF
--- a/tools/data/nextflow.yaml
+++ b/tools/data/nextflow.yaml
@@ -1,0 +1,29 @@
+name: Nextflow
+description: Workflow system for scalable, portable, reproducible data pipelines using a dataflow DSL. Nextflow runs on laptops, HPC schedulers, Kubernetes, and cloud batch, with Docker, Conda, and Singularity for software environments.
+tagline: Dataflow DSL for portable scientific pipelines
+
+github_url: https://github.com/nextflow-io/nextflow
+website_url: https://www.nextflow.io
+docs_url: https://docs.seqera.io/nextflow/
+
+category: Data
+tags: [workflow, pipelines, hpc, kubernetes, bioinformatics, reproducibility, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+install_command: |
+  curl -fsSL https://get.nextflow.io | bash
+  conda install -c bioconda nextflow
+
+problem_solved: |
+  Scientific and ML pipelines that mix scripts, containers, and cluster
+  jobs are hard to port and resume. Nextflow defines processes as a
+  dataflow graph so the same workflow runs locally, on HPC, Kubernetes,
+  or cloud batch, with checkpoints, Git-backed versions, and per-task
+  software environments.
+
+use_cases:
+  - Run an nf-core RNA-seq or variant-calling pipeline on a local machine or HPC cluster
+  - Resume a failed training-data preprocessing workflow from the last successful step
+  - Deploy the same Nextflow pipeline to AWS Batch, Google Cloud Batch, or Kubernetes
+  - Pin Docker or Conda environments per process for reproducible bioinformatics jobs

--- a/tools/data/snowplow.yaml
+++ b/tools/data/snowplow.yaml
@@ -1,0 +1,27 @@
+name: Snowplow
+description: Customer data infrastructure that collects, validates, and streams behavioral events from web, mobile, and server SDKs into warehouses and lakes. Snowplow gives analytics and AI teams schema-governed event data without building a collector pipeline from scratch.
+tagline: Behavioral event pipeline for analytics and AI context
+
+github_url: https://github.com/snowplow/snowplow
+website_url: https://snowplow.io
+docs_url: https://docs.snowplow.io
+
+category: Data
+tags: [events, tracking, cdi, analytics, warehouse, schemas, open-source]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Product analytics and AI agents need clean, real-time behavioral
+  events, but ad hoc pixels and warehouse ELT lose schema, identity,
+  and lineage. Snowplow collects first-party events through SDKs,
+  validates them against schemas, enriches them, and streams them to
+  warehouses, lakes, or streams so downstream models get governed
+  customer context.
+
+use_cases:
+  - Collect first-party web and mobile events into a warehouse with schema validation
+  - Stream enriched behavioral events to Kafka or a lake for real-time personalization
+  - Power AI agents with governed clickstream and product-usage context
+  - Replace brittle third-party pixels with a self-hosted event pipeline


### PR DESCRIPTION
## Summary

Adds two Data-category tools to the catalog:

- **Nextflow** — dataflow DSL for portable scientific and ML pipelines (HPC, Kubernetes, cloud batch)
- **Snowplow** — customer data infrastructure for schema-governed behavioral events

Both YAML files passed local `validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Nextflow to the tools directory with metadata, categorization, licensing, installation guidance, and workflow use cases.
  - Added Snowplow with descriptive information, links, categorization, pricing, licensing, and representative use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->