### PR TITLE
Add uv, Pandoc, Gitea, Woodpecker, Bernstein to catalog

### DIFF
--- a/tools/agent-frameworks/bernstein.yaml
+++ b/tools/agent-frameworks/bernstein.yaml
@@ -1,0 +1,27 @@
+name: Bernstein
+description: Open-source governance and orchestration layer for AI agents. Bernstein lets you write rules declaratively, then enforces them and records a verifiable, replayable task graph without putting a model in the coordination loop.
+tagline: Declarative governance for AI agents
+
+github_url: https://github.com/sipyourdrink-ltd/bernstein
+website_url: https://bernstein.run
+docs_url: https://bernstein.readthedocs.io
+
+category: Agents
+tags: [agents, governance, orchestration, replay, python, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+install_command: pip install bernstein
+
+problem_solved: |
+  Multi-agent runs are hard to audit because an LLM sits in the
+  coordination loop and plans do not replay the same way twice.
+  Bernstein enforces declarative rules outside the model and
+  produces a verifiable task graph so you can govern, replay, and
+  debug agent work without trusting the coordinator to improvise.
+
+use_cases:
+  - Enforce allow-listed tools and policies on an agent workflow before execution
+  - Replay a production agent plan and get a byte-identical task graph
+  - Record a verifiable audit trail for regulated agent operations
+  - Orchestrate multi-agent jobs with rules that do not depend on an LLM coordinator

--- a/tools/data/pandoc.yaml
+++ b/tools/data/pandoc.yaml
@@ -1,0 +1,26 @@
+name: Pandoc
+description: Universal document converter that turns Markdown, HTML, LaTeX, Word, EPUB, and dozens of other formats into each other. Pandoc is the default conversion engine for technical docs, papers, and LLM-generated reports.
+tagline: Universal markup converter for documents
+
+github_url: https://github.com/jgm/pandoc
+website_url: https://pandoc.org
+docs_url: https://pandoc.org/MANUAL.html
+
+category: Data
+tags: [documents, markdown, conversion, latex, publishing, open-source]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+install_command: brew install pandoc
+
+problem_solved: |
+  Research, product, and LLM pipelines produce Markdown or HTML that
+  still has to become Word, PDF, or EPUB. Pandoc converts between
+  dozens of document formats with citations, templates, and filters
+  so you do not maintain a one-off exporter for every output type.
+
+use_cases:
+  - Convert LLM-generated Markdown reports into Word or PDF for stakeholders
+  - Turn academic papers between LaTeX, Markdown, and HTML with citations
+  - Batch-convert a docs site into EPUB or reveal.js slides
+  - Pipe Markdown through Pandoc filters as part of a publishing pipeline

--- a/tools/dev-tools/gitea.yaml
+++ b/tools/dev-tools/gitea.yaml
@@ -1,0 +1,25 @@
+name: Gitea
+description: Lightweight self-hosted Git service with code review, package registry, and CI/CD. Gitea gives ML teams a single place to host model repos, review training code, and ship artifacts without a heavyweight GitHub Enterprise stack.
+tagline: Painless self-hosted Git forge
+
+github_url: https://github.com/go-gitea/gitea
+website_url: https://gitea.com
+docs_url: https://docs.gitea.com
+
+category: Dev Tools
+tags: [git, self-hosted, ci-cd, forge, collaboration, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Teams that cannot put training code and model artifacts on GitHub
+  still need pull requests, packages, and actions. Gitea is a small
+  self-hosted forge with review, registry, and CI so ML orgs keep
+  source and artifacts in-house without running a full GitLab stack.
+
+use_cases:
+  - Host private ML training repos with pull-request review on your own servers
+  - Publish internal Python or container packages from a Gitea registry
+  - Run Actions-style CI for data and model pipelines next to the Git repo
+  - Mirror GitHub projects into an air-gapped Gitea instance

--- a/tools/dev-tools/uv.yaml
+++ b/tools/dev-tools/uv.yaml
@@ -1,0 +1,26 @@
+name: uv
+description: Extremely fast Python package and project manager written in Rust. uv installs packages, manages lockfiles, and runs Python tools as a drop-in replacement for pip, pip-tools, pipx, poetry, pyenv, twine, and virtualenv.
+tagline: Fast Rust-based Python package manager
+
+github_url: https://github.com/astral-sh/uv
+website_url: https://docs.astral.sh/uv
+docs_url: https://docs.astral.sh/uv
+
+category: Dev Tools
+tags: [python, packaging, rust, pip, lockfile, tooling, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+install_command: pip install uv
+
+problem_solved: |
+  Python environment setup is slow and fragmented across pip, venv,
+  poetry, and pyenv. uv resolves and installs dependencies in seconds,
+  manages Python versions and lockfiles in one tool, and keeps ML
+  project environments reproducible without a stack of package managers.
+
+use_cases:
+  - Replace pip and venv with a single uv lockfile for an ML project
+  - Install Python tooling via uvx without polluting the global environment
+  - Speed up CI dependency installs compared to pip compile and poetry
+  - Pin a Python version and project dependencies for a training repo

--- a/tools/dev-tools/woodpecker.yaml
+++ b/tools/dev-tools/woodpecker.yaml
@@ -1,0 +1,25 @@
+name: Woodpecker
+description: Simple, extensible CI/CD engine that runs pipelines as containers from a Git forge. Woodpecker is a lightweight Drone fork used to test, train, and deploy ML jobs without a heavy SaaS CI bill.
+tagline: Lightweight container-native CI/CD
+
+github_url: https://github.com/woodpecker-ci/woodpecker
+website_url: https://woodpecker-ci.org
+docs_url: https://woodpecker-ci.org/docs
+
+category: Dev Tools
+tags: [ci-cd, containers, pipelines, self-hosted, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  GitHub Actions and Jenkins are either SaaS-locked or heavy to
+  operate. Woodpecker runs YAML pipelines as containers against
+  Gitea, GitHub, or GitLab so ML teams self-host CI for tests,
+  training jobs, and deploys with a small server footprint.
+
+use_cases:
+  - Run containerized test and lint pipelines on a self-hosted Gitea repo
+  - Trigger GPU training jobs from a Woodpecker workflow on pull request
+  - Execute pipeline YAML locally with woodpecker-cli before pushing
+  - Replace Drone CE with a maintained Apache-2.0 CI server


### PR DESCRIPTION
## Summary

Adds five catalog entries:

- **uv** (Dev Tools) — fast Rust Python package and project manager
- **Pandoc** (Data) — universal document converter
- **Gitea** (Dev Tools) — lightweight self-hosted Git forge
- **Woodpecker** (Dev Tools) — container-native CI/CD engine
- **Bernstein** (Agents) — declarative governance for AI agents

All YAML files passed local `validate-tool.ts`.
