### PR TITLE
Add Graphviz, CircleCI, Forgejo to catalog

### DIFF
--- a/tools/dev-tools/circleci.yaml
+++ b/tools/dev-tools/circleci.yaml
@@ -1,0 +1,23 @@
+name: CircleCI
+description: Cloud CI/CD platform that runs tests, builds, and deploys from GitHub, GitLab, and Bitbucket. CircleCI is used to validate ML apps, GPU jobs, and agent workflows with orbs, Docker, and an MCP server for AI-assisted debugging.
+tagline: Cloud CI for tests, GPU jobs, and deploys
+
+website_url: https://circleci.com
+docs_url: https://circleci.com/docs/
+
+category: Dev Tools
+tags: [ci-cd, pipelines, docker, github, testing, saas]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  ML and agent code needs parallel tests, GPU runners, and fast
+  rollback without standing up Jenkins. CircleCI runs YAML pipelines
+  in the cloud with caches, orbs, and an MCP server so teams validate
+  every push and let coding agents inspect failed jobs.
+
+use_cases:
+  - Run pytest and lint on every pull request with Docker executors
+  - Train or evaluate a model on GPU resource classes from a config.yml
+  - Connect an IDE agent to CircleCI logs via the MCP server
+  - Roll back a failed ML service deploy with a CircleCI rollback pipeline

--- a/tools/dev-tools/forgejo.yaml
+++ b/tools/dev-tools/forgejo.yaml
@@ -1,0 +1,24 @@
+name: Forgejo
+description: Community-run, self-hosted Git forge focused on privacy, federation, and guaranteed free software. Forgejo is a Gitea hard fork under Codeberg that hosts code, packages, and Actions-style CI without a corporate owner.
+tagline: Community-run self-hosted software forge
+
+website_url: https://forgejo.org
+docs_url: https://forgejo.org/docs/latest/
+
+category: Dev Tools
+tags: [git, self-hosted, forge, federation, open-source]
+pricing: free
+is_open_source: true
+license: GPL-3.0-or-later
+
+problem_solved: |
+  Teams that want a GitHub-like forge without a corporate steward
+  still need pull requests, packages, and CI. Forgejo is a Gitea
+  hard fork governed by Codeberg so you self-host code and ML
+  artifacts under a copyleft license with federation on the roadmap.
+
+use_cases:
+  - Self-host ML training repos on a Forgejo instance instead of GitHub
+  - Run Actions-compatible CI next to private model and data repos
+  - Publish internal packages from a community-governed forge
+  - Migrate from Gitea to a hard fork with independent release governance

--- a/tools/other/graphviz.yaml
+++ b/tools/other/graphviz.yaml
@@ -1,0 +1,25 @@
+name: Graphviz
+description: Open-source graph visualization toolkit that lays out DOT graphs as diagrams. Graphviz is the engine behind architecture charts, dependency maps, and knowledge-graph pictures that ML teams render from text.
+tagline: DOT language graph layout engine
+
+website_url: https://graphviz.org
+docs_url: https://graphviz.org/documentation/
+
+category: Other
+tags: [diagrams, visualization, graphs, dot, documentation, open-source]
+pricing: free
+is_open_source: true
+license: EPL-1.0
+install_command: brew install graphviz
+
+problem_solved: |
+  Model graphs, pipeline DAGs, and org charts need layout, not just
+  drawing. Graphviz takes DOT text and produces deterministic SVG,
+  PNG, or PDF diagrams so architecture and knowledge-graph pictures
+  stay in version control instead of in a slide tool.
+
+use_cases:
+  - Render a training-pipeline DAG from DOT into SVG for documentation
+  - Visualize a knowledge graph or citation network as a Graphviz layout
+  - Generate architecture diagrams from code-emitted DOT in CI
+  - Convert dependency graphs into printable PDF for design reviews


### PR DESCRIPTION
## Summary

Adds three catalog entries:

- **Graphviz** (Other) — DOT graph layout and visualization engine
- **CircleCI** (Dev Tools) — cloud CI/CD for tests, GPU jobs, and deploys
- **Forgejo** (Dev Tools) — community-run self-hosted Git forge

All YAML files passed local `validate-tool.ts`.
