### PR TITLE
Add Flagger, Chocolatey, Scoop, rbenv, fnm to catalog

### DIFF
--- a/tools/dev-tools/chocolatey.yaml
+++ b/tools/dev-tools/chocolatey.yaml
@@ -1,0 +1,27 @@
+name: Chocolatey
+description: Package manager for Windows that installs, upgrades, and pins software from a large community repository. Chocolatey wraps installers into versioned packages so ML laptops and Windows CI agents get CUDA toolkits, CLIs, and runtimes without clicking through GUI setups.
+tagline: The package manager for Windows
+
+github_url: https://github.com/chocolatey/choco
+website_url: https://chocolatey.org
+docs_url: https://docs.chocolatey.org
+
+category: Dev Tools
+tags: [windows, package-manager, cli, devops, chocolatey]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+install_command: Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+problem_solved: |
+  Windows ML workstations and CI agents still install tools with
+  click-through installers, which drift across machines and break
+  CUDA or Python setups. Chocolatey installs and upgrades software
+  from versioned packages so teams pin compilers, CLIs, and SDKs
+  the same way Homebrew does on macOS.
+
+use_cases:
+  - Bootstrap a Windows ML laptop with git, Python, and CUDA tooling via choco install
+  - Pin CLI versions on Windows GitHub Actions runners for reproducible CI
+  - Upgrade developer tools across a Windows fleet without GUI installers
+  - Script a new Windows agent image with a Chocolatey packages.config list

--- a/tools/dev-tools/flagger.yaml
+++ b/tools/dev-tools/flagger.yaml
@@ -1,0 +1,29 @@
+name: Flagger
+description: Progressive delivery Kubernetes operator for canary, A/B, and blue/green releases. Flagger shifts traffic using mesh or ingress metrics and rolls back automatically when analysis fails, so ML inference and API deploys avoid all-or-nothing cutovers.
+tagline: Progressive delivery for Kubernetes canaries and rollbacks
+
+github_url: https://github.com/fluxcd/flagger
+website_url: https://docs.flagger.app
+docs_url: https://docs.flagger.app
+
+category: Dev Tools
+tags: [kubernetes, progressive-delivery, canary, gitops, devops, mlops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+install_command: |
+  helm repo add flagger https://flagger.app
+  helm upgrade -i flagger flagger/flagger -n flagger-system --create-namespace
+
+problem_solved: |
+  Shipping a new model server or API to Kubernetes as a full cutover
+  either works or takes production down. Flagger automates canary,
+  A/B, and blue/green traffic shifts against Prometheus or mesh
+  metrics and rolls back when error rate or latency breaches the
+  analysis window, so ML inference releases can fail safely.
+
+use_cases:
+  - Canary a new model-serving Deployment and promote only if latency stays in SLO
+  - Blue/green an embedding API behind Istio or NGINX without a hard cutover
+  - A/B test inference images using header routing and metric analysis
+  - Auto-rollback GPU inference pods when error rate spikes after a chart upgrade

--- a/tools/dev-tools/fnm.yaml
+++ b/tools/dev-tools/fnm.yaml
@@ -1,0 +1,27 @@
+name: fnm
+description: Fast Node.js version manager written in Rust. fnm installs and switches Node versions per directory with .node-version or .nvmrc, so Next.js AI apps and MCP servers pin Node without the slower shell-heavy nvm workflow.
+tagline: Fast Rust-based Node.js version manager
+
+github_url: https://github.com/Schniz/fnm
+website_url: https://github.com/Schniz/fnm
+docs_url: https://github.com/Schniz/fnm#installation
+install_command: brew install fnm
+
+category: Dev Tools
+tags: [node, javascript, version-manager, rust, nvm, devops]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Node-based AI UIs and MCP servers pin different LTS lines, and
+  nvm's shell hooks are slow to start. fnm is a Rust binary that
+  installs Node versions and switches from .nvmrc or .node-version
+  with a fast shell integration, so each project uses the Node it
+  was tested on without a heavy POSIX script manager.
+
+use_cases:
+  - Pin Node for a Next.js AI dashboard with .node-version
+  - Switch Node quickly when testing MCP servers across LTS lines
+  - Replace nvm on laptops where shell startup time matters
+  - Install Node in CI without baking a single global version into the image

--- a/tools/dev-tools/rbenv.yaml
+++ b/tools/dev-tools/rbenv.yaml
@@ -1,0 +1,27 @@
+name: rbenv
+description: Lightweight Ruby version manager that installs multiple Rubies per user and switches them with a .ruby-version file. rbenv keeps Jekyll sites, Fastlane, and Ruby CLIs on the interpreter each repo expects without replacing system Ruby.
+tagline: Per-project Ruby version manager
+
+github_url: https://github.com/rbenv/rbenv
+website_url: https://rbenv.org
+docs_url: https://github.com/rbenv/rbenv#installation
+install_command: brew install rbenv
+
+category: Dev Tools
+tags: [ruby, version-manager, rbenv, cli, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Ruby CLIs and static-site or mobile-release tooling pin a Ruby
+  that macOS system Ruby does not match, so gems fail or need sudo.
+  rbenv installs isolated Rubies and switches by shell or
+  .ruby-version so each repo, including docs and Fastlane around
+  ML apps, runs the interpreter it was tested on.
+
+use_cases:
+  - Pin Ruby per repo with a .ruby-version file for Jekyll docs sites
+  - Isolate Fastlane and CocoaPods Rubies from macOS system Ruby
+  - Install multiple Rubies on a laptop without replacing /usr/bin/ruby
+  - Match CI Ruby to local rbenv so gem installs stay reproducible

--- a/tools/dev-tools/scoop.yaml
+++ b/tools/dev-tools/scoop.yaml
@@ -1,0 +1,27 @@
+name: Scoop
+description: Command-line installer for Windows that puts developer tools in your home directory without UAC prompts or PATH fights. Scoop installs portable packages into isolated buckets so Python, Node, and CUDA CLIs stay user-scoped on ML workstations.
+tagline: Command-line installer for Windows
+
+github_url: https://github.com/ScoopInstaller/Scoop
+website_url: https://scoop.sh
+docs_url: https://github.com/ScoopInstaller/Scoop/wiki
+
+category: Dev Tools
+tags: [windows, package-manager, cli, scoop, devops]
+pricing: free
+is_open_source: true
+license: Unlicense
+install_command: irm get.scoop.sh | iex
+
+problem_solved: |
+  Windows developer setups scatter installers, Program Files, and
+  admin prompts, so PATH and versions drift across ML laptops.
+  Scoop installs portable packages into a user directory, shims
+  binaries onto PATH, and updates from buckets without UAC, so
+  CLI toolchains stay reproducible per user.
+
+use_cases:
+  - Install git, Python, and Node on a Windows ML laptop without admin rights
+  - Keep CLI shims in a user Scoop prefix instead of Program Files
+  - Add extras or versions buckets for CUDA-adjacent Windows developer tools
+  - Script a portable Windows toolchain for CI agents with scoop install


### PR DESCRIPTION
## Summary

Adds 5 Dev Tools entries to the Agentic AI For Good catalog:

- **Flagger** (fluxcd/flagger, Apache-2.0) — progressive delivery Kubernetes operator for canary, A/B, and blue/green releases
- **Chocolatey** (chocolatey/choco) — Windows package manager
- **Scoop** (ScoopInstaller/Scoop, Unlicense) — command-line installer for Windows
- **rbenv** (rbenv/rbenv, MIT) — per-project Ruby version manager
- **fnm** (Schniz/fnm, GPL-3.0) — fast Rust-based Node.js version manager

All files passed local `npx tsx scripts/validate-tool.ts`.

## Test plan

- [x] Local YAML validation
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Chocolatey and Scoop, providing Windows package management options.
  * Added Flagger for progressive Kubernetes delivery, including canary, A/B, and blue/green deployments.
  * Added fnm and rbenv for managing Node.js and Ruby versions.
  * Included installation commands, licensing, links, tags, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->