### PR TITLE
Add TeamCity, MacPorts, SDKMAN, WinGet to catalog

### DIFF
--- a/tools/dev-tools/macports.yaml
+++ b/tools/dev-tools/macports.yaml
@@ -1,0 +1,26 @@
+name: MacPorts
+description: Package manager for macOS that compiles and installs Unix software from Portfiles. MacPorts keeps scientific libraries, compilers, and CLI tools in /opt/local so ML laptops can pin Unix dependencies without mixing them into Homebrew or system paths.
+tagline: Unix package manager for macOS via Portfiles
+
+github_url: https://github.com/macports/macports-base
+website_url: https://www.macports.org
+docs_url: https://guide.macports.org
+
+category: Dev Tools
+tags: [macos, package-manager, ports, unix, cli, devops]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  macOS system paths and Homebrew formulae do not always match the
+  Unix library versions scientific and ML stacks need. MacPorts
+  builds software from Portfiles into /opt/local with its own prefix,
+  so compilers, headers, and CLIs stay isolated from Apple's userland
+  and from brew, which reduces version fights on research laptops.
+
+use_cases:
+  - Install scientific Unix libraries into /opt/local without touching Homebrew
+  - Pin a compiler or CLI version for an ML repo that Homebrew rolled forward
+  - Keep macOS research machines on a Portfile-managed toolchain
+  - Build native dependencies for Python scientific stacks from MacPorts

--- a/tools/dev-tools/sdkman.yaml
+++ b/tools/dev-tools/sdkman.yaml
@@ -1,0 +1,27 @@
+name: SDKMAN
+description: Command-line manager for SDKs on Unix shells. SDKMAN installs and switches JDK, Gradle, Maven, Kotlin, and other JVM tools per user so Java ML services and Android-adjacent CLIs pin the toolchain without colliding system packages.
+tagline: SDK version manager for JVM and related tools
+
+github_url: https://github.com/sdkman/sdkman-cli
+website_url: https://sdkman.io
+docs_url: https://sdkman.io/install
+install_command: curl -s "https://get.sdkman.io" | bash
+
+category: Dev Tools
+tags: [java, jvm, version-manager, sdk, gradle, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  JVM services pin a JDK and Gradle that the OS package manager does
+  not match, so CI and laptops drift. SDKMAN installs candidate SDKs
+  into a user directory and switches with sdk use, so Java ML APIs,
+  Spark jobs, and Kotlin CLIs run the exact JDK and build tool they
+  were tested against.
+
+use_cases:
+  - Pin JDK and Gradle versions for a Java model-serving service
+  - Switch JDKs per shell when testing Spark jobs across LTS lines
+  - Install Maven or Kotlin without replacing the OS Java package
+  - Match CI JDK to local SDKMAN so Gradle builds stay reproducible

--- a/tools/dev-tools/teamcity.yaml
+++ b/tools/dev-tools/teamcity.yaml
@@ -1,0 +1,24 @@
+name: TeamCity
+description: JetBrains CI/CD server for pipelines that build, test, and deploy from Git. TeamCity runs on-prem or in JetBrains Cloud with a Kotlin DSL, so ML services and agent backends get gated builds without living only in GitHub Actions YAML.
+tagline: JetBrains CI for on-prem and cloud pipelines
+
+website_url: https://www.jetbrains.com/teamcity/
+docs_url: https://www.jetbrains.com/help/teamcity/
+
+category: Dev Tools
+tags: [ci-cd, jetbrains, pipelines, testing, devops, saas]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Teams that need self-hosted CI with rich test reporting often outgrow
+  a pile of GitHub Actions YAML and do not want to operate Jenkins
+  plugins. TeamCity runs pipelines on-prem or in JetBrains Cloud with
+  a Kotlin DSL, build chains, and agent pools so ML services can gate
+  tests and deploys on owned hardware or a managed server.
+
+use_cases:
+  - Gate pytest and Docker image builds for an ML API on a TeamCity agent pool
+  - Model build chains so a training image job feeds a deploy job
+  - Run CI on-prem when model weights cannot leave the company network
+  - Use the Kotlin DSL to version pipeline logic next to the service repo

--- a/tools/dev-tools/winget.yaml
+++ b/tools/dev-tools/winget.yaml
@@ -1,0 +1,26 @@
+name: WinGet
+description: Windows Package Manager CLI from Microsoft. WinGet searches, installs, upgrades, and pins apps from the community repository and Microsoft Store so Windows ML workstations script CUDA-adjacent tools and CLIs without GUI installers.
+tagline: Windows Package Manager CLI from Microsoft
+
+github_url: https://github.com/microsoft/winget-cli
+website_url: https://learn.microsoft.com/windows/package-manager/
+docs_url: https://learn.microsoft.com/windows/package-manager/winget/
+
+category: Dev Tools
+tags: [windows, package-manager, cli, microsoft, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Windows developer machines still click through Store and vendor
+  installers, so CLIs and runtimes drift across ML laptops and CI
+  agents. WinGet installs and upgrades packages from a manifest
+  repository with winget install and export, so teams script Windows
+  toolchains the way brew install works on macOS.
+
+use_cases:
+  - Script git, Python, and VS Build Tools onto a Windows ML laptop
+  - Export a winget package list so a new Windows agent matches the team
+  - Upgrade CLIs on Windows CI images without GUI installers
+  - Pin a Windows runtime version in a winget configure or install command


### PR DESCRIPTION
## Summary

Adds 4 Dev Tools entries to the Agentic AI For Good catalog:

- **TeamCity** (JetBrains, freemium SaaS/on-prem) — CI/CD server with Kotlin DSL
- **MacPorts** (macports/macports-base, BSD-3-Clause) — Unix package manager for macOS
- **SDKMAN** (sdkman/sdkman-cli, Apache-2.0) — SDK version manager for JVM toolchains
- **WinGet** (microsoft/winget-cli, MIT) — Windows Package Manager CLI

All files passed local `npx tsx scripts/validate-tool.ts`.

## Test plan

- [x] Local YAML validation
- [ ] CI "Validate tool YAML files" check
