### PR TITLE
Add rustup, Spack, Devbox, Flox, Flatpak to catalog

### DIFF
--- a/tools/dev-tools/devbox.yaml
+++ b/tools/dev-tools/devbox.yaml
@@ -1,0 +1,26 @@
+name: Devbox
+description: Nix-powered tool that creates isolated, shareable development environments from a JSON config. Devbox pins packages per repo so ML services get the same Python, Node, and CLIs on every laptop and CI runner without a global Nix profile.
+tagline: Isolated Nix-powered dev environments from a JSON file
+
+github_url: https://github.com/jetify-com/devbox
+website_url: https://www.jetify.com/devbox/
+docs_url: https://www.jetify.com/docs/devbox/
+install_command: curl -fsSL https://get.jetify.com/devbox | bash
+
+category: Dev Tools
+tags: [nix, environments, devops, reproducible, cli, jetify]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  ML repos depend on Python, Node, and CLIs that drift across laptops
+  and CI. Devbox wraps Nix packages in a per-project JSON file so
+  teammates enter the same shell without writing Nix, and CI can
+  reproduce the toolchain from the committed config.
+
+use_cases:
+  - Pin Python and CLI versions for an ML service with a committed devbox.json
+  - Share a Nix-backed shell with teammates who do not write Nix
+  - Run the same Devbox environment in GitHub Actions as on a laptop
+  - Isolate CUDA-adjacent CLIs per repo without a global Nix profile

--- a/tools/dev-tools/flatpak.yaml
+++ b/tools/dev-tools/flatpak.yaml
@@ -1,0 +1,26 @@
+name: Flatpak
+description: Linux application sandboxing and distribution framework. Flatpak installs desktop apps in isolated runtimes with explicit permissions, so ML workstations can ship GUI tools and IDEs without fighting distro package versions.
+tagline: Sandboxed Linux app distribution with runtimes
+
+github_url: https://github.com/flatpak/flatpak
+website_url: https://flatpak.org
+docs_url: https://docs.flatpak.org
+
+category: Dev Tools
+tags: [linux, packaging, sandbox, desktop, distribution, devops]
+pricing: free
+is_open_source: true
+license: LGPL-2.1
+
+problem_solved: |
+  Linux desktop ML tools and IDEs lag or conflict with distro
+  packages. Flatpak ships apps with their own runtime and sandbox
+  permissions so a GUI editor, notebook helper, or vendor tool
+  installs the same way on Fedora, Ubuntu, and immutable OS images
+  without replacing system libraries.
+
+use_cases:
+  - Install a sandboxed IDE on an ML workstation without distro package fights
+  - Ship an internal Linux GUI tool as a Flatpak with a pinned runtime
+  - Run Flathub apps on immutable Linux images used for research laptops
+  - Limit filesystem and device access for untrusted desktop ML utilities

--- a/tools/dev-tools/flox.yaml
+++ b/tools/dev-tools/flox.yaml
@@ -1,0 +1,27 @@
+name: Flox
+description: Nix-based environment manager that creates portable, deterministic developer environments. Flox layers packages into an environment you can activate like a venv, so ML teams share the same compilers, CLIs, and runtimes across laptops and CI.
+tagline: Deterministic Nix environments you activate like a venv
+
+github_url: https://github.com/flox/flox
+website_url: https://flox.dev
+docs_url: https://flox.dev/docs
+install_command: brew install flox
+
+category: Dev Tools
+tags: [nix, environments, devops, reproducible, cli]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Reproducible ML toolchains usually mean either a heavy Nix flake or
+  a drifting Dockerfile. Flox builds Nix-backed environments you
+  activate like a virtualenv, so compilers, CLIs, and language
+  runtimes stay pinned across laptops and CI without authoring Nix
+  from scratch.
+
+use_cases:
+  - Activate a pinned compiler and Python stack for an ML repo like a venv
+  - Share a Flox environment manifest so CI matches local CLIs
+  - Layer extra packages onto a base environment without rebuilding a container
+  - Keep GPU-adjacent Unix tools consistent across macOS and Linux laptops

--- a/tools/dev-tools/rustup.yaml
+++ b/tools/dev-tools/rustup.yaml
@@ -1,0 +1,26 @@
+name: rustup
+description: Official Rust toolchain installer and version manager. rustup installs rustc, cargo, and rustfmt per user, switches channels and targets, and keeps ML crates and inference binaries on a pinned Rust without a system-wide compiler.
+tagline: Official Rust toolchain installer and version manager
+
+github_url: https://github.com/rust-lang/rustup
+website_url: https://rustup.rs
+docs_url: https://rust-lang.github.io/rustup/
+install_command: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+category: Dev Tools
+tags: [rust, toolchain, version-manager, cargo, cli, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Rust ML crates, tokenizers, and inference binaries pin a rustc that
+  OS packages lag or overshoot. rustup installs isolated toolchains
+  per user, switches stable/beta/nightly and compilation targets, and
+  keeps cargo on the channel the project rust-toolchain.toml expects.
+
+use_cases:
+  - Pin a Rust toolchain for a tokenizer or inference crate with rust-toolchain.toml
+  - Add wasm or musl targets for shipping ML CLI binaries
+  - Switch nightly vs stable when a crate needs unstable features
+  - Install rustc on CI without baking a distro Rust package into the image

--- a/tools/dev-tools/spack.yaml
+++ b/tools/dev-tools/spack.yaml
@@ -1,0 +1,26 @@
+name: Spack
+description: HPC package manager that builds multiple versions, compilers, and configurations of scientific software from one spec language. Spack is used on clusters to install CUDA-aware MPI, BLAS, and Python stacks without a single global prefix.
+tagline: HPC package manager for multi-version scientific stacks
+
+github_url: https://github.com/spack/spack
+website_url: https://spack.io
+docs_url: https://spack.readthedocs.io
+
+category: Dev Tools
+tags: [hpc, package-manager, scientific-computing, compilers, cuda, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Cluster ML stacks need several compilers, MPI builds, and CUDA
+  variants at once, which distro packages cannot express. Spack
+  builds packages from specs that encode version, compiler, and
+  variants into unique hashes, so training nodes can coexist many
+  scientific stacks without a single /usr prefix.
+
+use_cases:
+  - Install CUDA-aware MPI and BLAS variants for a cluster training job
+  - Coexist multiple compiler and library versions on one HPC login node
+  - Replicate an environment.yaml-style Spack environment on a new cluster
+  - Build Python scientific stacks against a pinned MPI without conda


### PR DESCRIPTION
## Summary

Adds 5 Dev Tools entries to the Agentic AI For Good catalog:

- **rustup** (rust-lang/rustup, Apache-2.0) — official Rust toolchain installer
- **Spack** (spack/spack, Apache-2.0) — HPC package manager for multi-version scientific stacks
- **Devbox** (jetify-com/devbox, Apache-2.0) — Nix-powered isolated dev environments
- **Flox** (flox/flox, GPL-2.0) — deterministic Nix environments activated like a venv
- **Flatpak** (flatpak/flatpak, LGPL-2.1) — sandboxed Linux app distribution

All files passed local `npx tsx scripts/validate-tool.ts`.

## Test plan

- [x] Local YAML validation
- [ ] CI "Validate tool YAML files" check
