### PR TITLE
Add jenv, goenv, vfox to catalog

### DIFF
--- a/tools/dev-tools/goenv.yaml
+++ b/tools/dev-tools/goenv.yaml
@@ -1,0 +1,26 @@
+name: goenv
+description: Go version manager modeled on pyenv and rbenv. goenv installs multiple Go toolchains per user and switches them with a .go-version file so ML services written in Go pin the compiler without a single system-wide install.
+tagline: Per-project Go version manager like pyenv
+
+github_url: https://github.com/go-nv/goenv
+website_url: https://github.com/go-nv/goenv
+docs_url: https://github.com/go-nv/goenv#installation
+install_command: brew install goenv
+
+category: Dev Tools
+tags: [go, golang, version-manager, pyenv, cli, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Go ML services and inference sidecars pin a Go version that the
+  OS package or a single /usr/local/go cannot match. goenv installs
+  isolated toolchains and switches by shell or .go-version so each
+  repo builds with the compiler it was tested against.
+
+use_cases:
+  - Pin Go per repo with a .go-version file for an inference sidecar
+  - Install multiple Go versions on a laptop without replacing /usr/local/go
+  - Match CI Go to local goenv so module builds stay reproducible
+  - Switch Go quickly when testing toolchain changes across services

--- a/tools/dev-tools/jenv.yaml
+++ b/tools/dev-tools/jenv.yaml
@@ -1,0 +1,26 @@
+name: jenv
+description: Java environment manager that switches JDKs per user, shell, or project with a .java-version file. jenv is the rbenv-style manager for Java so Spark jobs and JVM model servers pin a JDK without replacing the OS Java.
+tagline: Per-project JDK switcher in the rbenv style
+
+github_url: https://github.com/jenv/jenv
+website_url: https://www.jenv.be
+docs_url: https://github.com/jenv/jenv#install
+install_command: brew install jenv
+
+category: Dev Tools
+tags: [java, jdk, version-manager, jvm, rbenv, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  JVM ML services and Spark jobs pin a JDK that macOS and Linux
+  system Java do not match. jenv registers existing JDKs and
+  switches by shell or .java-version so each repo uses the
+  interpreter it was tested on without sudo or a single global JAVA_HOME.
+
+use_cases:
+  - Pin a JDK per Spark or model-serving repo with a .java-version file
+  - Switch JAVA_HOME in the shell when testing across LTS JDKs
+  - Keep macOS system Java off the PATH for Gradle ML services
+  - Match CI JDK to local jenv so Maven builds stay reproducible

--- a/tools/dev-tools/vfox.yaml
+++ b/tools/dev-tools/vfox.yaml
@@ -1,0 +1,26 @@
+name: vfox
+description: Cross-platform version manager written in Go. vfox installs and switches Java, Node.js, Go, Python, Flutter, .NET, and more through plugins, so ML laptops pin several language toolchains with one CLI instead of a stack of nvm, pyenv, and sdkman.
+tagline: Cross-platform multi-language version manager
+
+github_url: https://github.com/version-fox/vfox
+website_url: https://vfox.dev
+docs_url: https://vfox.dev
+install_command: brew install vfox
+
+category: Dev Tools
+tags: [version-manager, cross-platform, node, java, python, golang, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Polyglot ML repos mix Node UIs, Python training, and JVM services,
+  which usually means nvm plus pyenv plus SDKMAN. vfox is one plugin
+  based manager that installs those SDKs on Windows, macOS, and Linux
+  so a laptop can pin several languages without a pile of shell hooks.
+
+use_cases:
+  - Pin Node, Python, and JDK in one CLI for a polyglot ML repo
+  - Replace nvm plus pyenv on a Windows ML workstation
+  - Switch SDKs per directory with vfox plugins for Go and Flutter
+  - Keep CI images on the same version-manager CLI as local development


### PR DESCRIPTION
## Summary

Adds 3 Dev Tools entries to the Agentic AI For Good catalog:

- **jenv** (jenv/jenv, MIT) — rbenv-style JDK switcher
- **goenv** (go-nv/goenv, MIT) — pyenv-style Go version manager
- **vfox** (version-fox/vfox, Apache-2.0) — cross-platform multi-language version manager

All files passed local `npx tsx scripts/validate-tool.ts`.

## Test plan

- [x] Local YAML validation
- [ ] CI "Validate tool YAML files" check
