### PR TITLE
Add Nix, Concourse, vcpkg, Conan, Carthage to catalog

### DIFF
--- a/tools/dev-tools/carthage.yaml
+++ b/tools/dev-tools/carthage.yaml
@@ -1,0 +1,27 @@
+name: Carthage
+description: Decentralized dependency manager for Cocoa that builds GitHub frameworks as xcframeworks instead of a central spec repo. Carthage leaves Xcode project structure alone, so iOS and macOS ML apps can vendor Core ML wrappers and native SDKs without CocoaPods workspace takeover.
+tagline: Decentralized dependency manager for Cocoa
+
+github_url: https://github.com/Carthage/Carthage
+docs_url: https://github.com/Carthage/Carthage#getting-started
+
+install_command: brew install carthage
+
+category: Dev Tools
+tags: [ios, macos, cocoa, swift, dependencies, xcode, package-manager]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  iOS ML apps that ship Core ML models and native SDKs often fight CocoaPods
+  workspaces that rewrite the Xcode project. Carthage checks out Git
+  repositories, builds frameworks, and lets you drag them in, so on-device
+  inference apps keep their project files while still pinning GitHub
+  dependencies in a Cartfile.
+
+use_cases:
+  - Vendor a Core ML helper framework from GitHub without a CocoaPods workspace
+  - Pin iOS SDK versions in a Cartfile.resolved for reproducible App Store builds
+  - Build xcframeworks for an on-device speech or vision model wrapper
+  - Keep an existing Xcode project layout while adding native ML client libraries

--- a/tools/dev-tools/conan.yaml
+++ b/tools/dev-tools/conan.yaml
@@ -1,0 +1,28 @@
+name: Conan
+description: Open-source C and C++ package manager that caches prebuilt binaries by compiler, architecture, and options. Conan recipes and lockfiles let native ML projects reuse OpenBLAS, CUDA, and protobuf artifacts across CI instead of rebuilding the world on every commit.
+tagline: C and C++ package manager with binary caching
+
+github_url: https://github.com/conan-io/conan
+website_url: https://conan.io
+docs_url: https://docs.conan.io
+
+install_command: pip install conan
+
+category: Dev Tools
+tags: [cpp, package-manager, cmake, binaries, dependencies, python, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Native ML libraries spend most of CI time compiling Boost, protobuf, and
+  BLAS for each compiler and CUDA version. Conan stores prebuilt packages
+  keyed by settings and options, so a lockfile can pull the same OpenBLAS
+  and CUDA-aware artifacts on every agent instead of compiling from source
+  on each pull request.
+
+use_cases:
+  - Cache prebuilt protobuf and OpenBLAS packages for llama.cpp-style CMake projects
+  - Lock compiler, libcxx, and CUDA options so Linux CI matches a developer laptop
+  - Publish an internal CUDA kernel package to a private Conan remote
+  - Generate CMakeDeps and CMakeToolchain files from a conanfile.py for IDE and CI

--- a/tools/dev-tools/concourse.yaml
+++ b/tools/dev-tools/concourse.yaml
@@ -1,0 +1,26 @@
+name: Concourse
+description: Container-based CI/CD written in Go that models pipelines as resources, jobs, and tasks. Each task runs in a fresh container so builds stay isolated, and YAML pipelines can compile native ML libraries, run tests, and ship images without a long-lived Jenkins master.
+tagline: Container-native CI that treats pipelines as first-class
+
+github_url: https://github.com/concourse/concourse
+website_url: https://concourse-ci.org
+docs_url: https://concourse-ci.org/docs.html
+
+category: Dev Tools
+tags: [ci-cd, pipelines, containers, golang, devops, testing, automation]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Long-lived CI agents accumulate CUDA toolkits, Python caches, and leftover
+  credentials, so the next job inherits a dirty workspace. Concourse runs every
+  task in a fresh container with explicit inputs and outputs, so GPU builds,
+  pytest suites, and image publishes stay reproducible and easy to reason about
+  from a single pipeline YAML.
+
+use_cases:
+  - Compile CUDA kernels and run pytest in isolated Concourse tasks per pull request
+  - Promote a trained model artifact from test to staging with resource versions
+  - Build and publish Docker images for inference services without a sticky worker
+  - Fan out matrix builds across Python and CUDA versions using parallel jobs

--- a/tools/dev-tools/nix.yaml
+++ b/tools/dev-tools/nix.yaml
@@ -1,0 +1,28 @@
+name: Nix
+description: A purely functional package manager that builds software in isolated, bit-reproducible environments. Packages live in a content-addressed nix store so multiple versions coexist without conflicts, and CI, GPU, and ML stacks can be reproduced from a flake or nix-shell.
+tagline: Purely functional package manager for reproducible environments
+
+github_url: https://github.com/NixOS/nix
+website_url: https://nixos.org
+docs_url: https://nix.dev
+
+install_command: curl -L https://nixos.org/nix/install | sh
+
+category: Dev Tools
+tags: [package-manager, nix, reproducibility, flakes, linux, macos, devops, environments]
+pricing: free
+is_open_source: true
+license: LGPL-2.1
+
+problem_solved: |
+  Python venvs, Docker images, and ad-hoc apt installs still drift across laptops and CI,
+  so GPU drivers, CUDA, and Python wheels fail on one machine and pass on another. Nix
+  builds every package in isolation and stores it by content hash, so a flake.lock pins
+  compilers, CUDA, and Python together. Teams share one declaration instead of a pile of
+  Dockerfiles and README install steps.
+
+use_cases:
+  - Pin a CUDA, Python, and compiler toolchain with a flake.lock for identical training boxes
+  - Drop into a nix-shell that provides llama.cpp build deps without polluting the host
+  - Reproduce a CI job locally with the same nixpkgs revision the pipeline used
+  - Coexist multiple Python and Node versions without pyenv or nvm path fights

--- a/tools/dev-tools/vcpkg.yaml
+++ b/tools/dev-tools/vcpkg.yaml
@@ -1,0 +1,26 @@
+name: vcpkg
+description: Microsoft's C++ library manager for Windows, Linux, and macOS. vcpkg builds and installs ports from source with triplets that encode architecture, linkage, and CRT, so native ML libraries can pull OpenCV, ONNX Runtime, and CUDA helpers without hand-written Find modules.
+tagline: C++ library manager for Windows, Linux, and macOS
+
+github_url: https://github.com/microsoft/vcpkg
+website_url: https://vcpkg.io
+docs_url: https://learn.microsoft.com/vcpkg/
+
+category: Dev Tools
+tags: [cpp, package-manager, cmake, windows, linux, macos, dependencies, microsoft]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  C++ AI stacks need OpenCV, protobuf, ONNX Runtime, and CUDA bindings that
+  differ by OS, compiler, and static vs shared linkage. Hand-copying binaries
+  or writing Find modules per platform is brittle. vcpkg builds ports from
+  source with triplets and emits CMake toolchain files so llama.cpp-style
+  projects resolve native deps the same way on Windows and Linux.
+
+use_cases:
+  - Install OpenCV and ONNX Runtime for a C++ inference binary via a vcpkg.json manifest
+  - Share a CMake toolchain file so Windows and Linux CI use the same port versions
+  - Pin static vs dynamic CRT and architecture with triplets for GPU-capable builds
+  - Overlay a custom port for an internal CUDA kernel library without forking the registry


### PR DESCRIPTION
## Summary

Adds five package-manager / CI tools used in native ML and mobile inference stacks:

- **Nix** (NixOS/nix, 17.6k, LGPL-2.1): purely functional package manager for bit-reproducible environments
- **Concourse** (concourse/concourse, 7.9k, Apache-2.0): container-native CI/CD written in Go
- **vcpkg** (microsoft/vcpkg, 27.4k, MIT): C++ library manager for Windows, Linux, and macOS
- **Conan** (conan-io/conan, 9.5k, MIT): C/C++ package manager with binary caching (`pip install conan`)
- **Carthage** (Carthage/Carthage, 15.2k, MIT): decentralized Cocoa dependency manager

All files passed local `npx tsx scripts/validate-tool.ts`.

## Category

Dev Tools


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Carthage, Conan, Concourse, Nix, and vcpkg.
  - Included tool descriptions, installation guidance, project links, licensing, pricing, categories, and tags.
  - Added practical use cases covering dependency management, reproducible builds, CI/CD workflows, package caching, and native machine-learning development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->