### PR TITLE
Add xmake, snapd, SCons to catalog

### DIFF
--- a/tools/dev-tools/scons.yaml
+++ b/tools/dev-tools/scons.yaml
@@ -1,0 +1,28 @@
+name: SCons
+description: A Python-based software construction tool that replaces Make with scripts you can import, test, and extend. SCons scans C/C++ dependencies automatically and is still used to build scientific and ML native extensions that predate CMake-only workflows.
+tagline: Python-based software construction tool
+
+github_url: https://github.com/SCons/scons
+website_url: https://scons.org
+docs_url: https://scons.org/documentation.html
+
+install_command: pip install scons
+
+category: Dev Tools
+tags: [build-system, python, cpp, make-alternative, compilation, scientific-computing]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Some scientific and ML native trees still cannot express their
+  dependency graph in CMake without a rewrite. SCons lets those
+  projects describe builds in Python, auto-scan headers, and keep
+  custom compilers or CUDA steps in ordinary Python functions
+  instead of Make macros that break on every platform.
+
+use_cases:
+  - Build a legacy scientific C++ library that still ships SConstruct files
+  - Auto-scan C/C++ headers so incremental rebuilds of CUDA extensions stay correct
+  - Call custom Python logic during the build to generate protobuf or kernel stubs
+  - Keep a Python-native build for labs that already script everything in Python

--- a/tools/dev-tools/snapd.yaml
+++ b/tools/dev-tools/snapd.yaml
@@ -1,0 +1,26 @@
+name: snapd
+description: Canonical's daemon and CLI for installing confined Linux packages from the Snap Store. snapd mounts squashfs snaps with automatic updates and strict confinement, so ML CLIs, CUDA runtimes, and desktop tools can ship one artifact across Ubuntu and other distros.
+tagline: Daemon and CLI for confined Linux snap packages
+
+github_url: https://github.com/canonical/snapd
+website_url: https://snapcraft.io
+docs_url: https://snapcraft.io/docs
+
+category: Dev Tools
+tags: [linux, packaging, ubuntu, canonical, confinement, distribution, devops]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Shipping an ML CLI or CUDA helper to Ubuntu, Fedora, and IoT boxes
+  usually means a different package per distro. snapd installs a
+  single confined snap with automatic refreshes, so teams publish
+  one squashfs artifact instead of maintaining deb, rpm, and
+  AppImage channels for the same inference tool.
+
+use_cases:
+  - Distribute a Linux inference CLI as a confined snap with automatic updates
+  - Pin a CUDA-related toolkit snap on Ubuntu workstations without apt version fights
+  - Run strictly confined data-prep utilities on IoT or edge Linux boxes
+  - Publish one Snap Store artifact instead of distro-specific packages

--- a/tools/dev-tools/xmake.yaml
+++ b/tools/dev-tools/xmake.yaml
@@ -1,0 +1,28 @@
+name: xmake
+description: A Lua-based cross-platform build utility that describes C/C++ and CUDA projects in xmake.lua instead of generated Makefiles. xmake resolves packages, toolchains, and targets in one file, so native ML libraries can build on Windows, Linux, and macOS without a CMake generator step.
+tagline: Lua-based cross-platform build utility
+
+github_url: https://github.com/xmake-io/xmake
+website_url: https://xmake.io
+docs_url: https://xmake.io/#/getting_started
+
+install_command: curl -fsSL https://xmake.io/shget.text | bash
+
+category: Dev Tools
+tags: [build-system, cpp, lua, cuda, cross-platform, cmake-alternative, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  C++ and CUDA ML libraries often juggle CMake generators, vcpkg
+  toolchains, and per-OS compiler flags. xmake keeps the project
+  description, package deps, and toolchain selection in one Lua
+  file, so llama.cpp-style code builds on Windows, Linux, and macOS
+  from the same xmake.lua without generating IDE projects first.
+
+use_cases:
+  - Build a CUDA inference library on Linux and Windows from one xmake.lua
+  - Pull OpenCV or protobuf via xmake packages instead of a separate CMake FetchContent
+  - Switch GCC, Clang, and MSVC toolchains without regenerating build files
+  - Package a native ML SDK as a shared library for Python wheels


### PR DESCRIPTION
## Summary

Adds three build and Linux packaging tools used in native ML stacks:

- **xmake** (xmake-io/xmake, 12.2k, Apache-2.0): Lua-based cross-platform build utility
- **snapd** (canonical/snapd, 2.0k, GPL-3.0): Canonical daemon and CLI for confined Linux snaps
- **SCons** (SCons/scons, 2.4k, MIT): Python-based software construction tool (`pip install scons`)

All files passed local `npx tsx scripts/validate-tool.ts`.

## Category

Dev Tools


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog metadata for SCons, snapd, and xmake.
  - Included descriptions, project links, installation commands, categories, tags, licensing, pricing, problem statements, and use cases for each tool.
  - Documented scenarios including cross-platform C/C++ and CUDA builds, confined Linux package distribution, and Python-based build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->