### PR TITLE
Add Swift Package Manager, Premake, Buildbot, Bear, distcc to catalog

### DIFF
--- a/tools/dev-tools/bear.yaml
+++ b/tools/dev-tools/bear.yaml
@@ -1,0 +1,27 @@
+name: Bear
+description: A tool that generates compile_commands.json by intercepting C and C++ compiler invocations. Bear lets clangd, clang-tidy, and other LLVM tools understand llama.cpp-style trees even when the build system is Make, SCons, or a custom script.
+tagline: Generate compile_commands.json from any C/C++ build
+
+github_url: https://github.com/rizsotto/Bear
+docs_url: https://github.com/rizsotto/Bear#readme
+
+install_command: brew install bear
+
+category: Dev Tools
+tags: [cpp, clangd, compile-commands, llvm, tooling, developer-tools]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  clangd and clang-tidy need compile_commands.json, but many native
+  ML trees still build with Make or SCons and never emit that file.
+  Bear wraps the build, records every compiler invocation, and writes
+  the compilation database so IDE navigation and static analysis work
+  on CUDA and C++ inference code.
+
+use_cases:
+  - Generate compile_commands.json for a Make-based llama.cpp checkout
+  - Feed clang-tidy checks in CI from a Bear-produced compilation database
+  - Enable clangd jump-to-definition in a SCons scientific C++ tree
+  - Capture compiler flags for a custom CUDA kernel build script

--- a/tools/dev-tools/buildbot.yaml
+++ b/tools/dev-tools/buildbot.yaml
@@ -1,0 +1,28 @@
+name: Buildbot
+description: A Python continuous integration framework that runs builders, schedulers, and workers as code. Buildbot is used to compile native ML libraries, run pytest, and gate CUDA jobs on self-hosted workers without locking the team into a SaaS YAML product.
+tagline: Python CI framework with builders, schedulers, and workers
+
+github_url: https://github.com/buildbot/buildbot
+website_url: https://www.buildbot.net
+docs_url: https://docs.buildbot.net
+
+install_command: pip install buildbot
+
+category: Dev Tools
+tags: [ci-cd, python, testing, automation, self-hosted, pipelines]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Teams with GPU workers and custom compile steps often outgrow
+  GitHub Actions minutes and still do not want Jenkins XML. Buildbot
+  describes builders and schedulers in Python, so CUDA compiles,
+  pytest, and artifact uploads run on self-hosted workers with
+  the same language the rest of the ML stack already uses.
+
+use_cases:
+  - Compile CUDA extensions on self-hosted GPU workers after every push
+  - Gate a model-serving image on pytest plus a smoke inference job
+  - Schedule nightly rebuilds of native ML wheels across Python versions
+  - Fan out builders for Linux and macOS from one master.cfg

--- a/tools/dev-tools/distcc.yaml
+++ b/tools/dev-tools/distcc.yaml
@@ -1,0 +1,25 @@
+name: distcc
+description: A distributed C, C++, and Objective-C compiler that farms preprocessor output to volunteer machines. distcc speeds up native ML library builds by spreading gcc and clang compile jobs across a LAN instead of waiting on a single laptop or CI worker.
+tagline: Distributed C and C++ compilation across a LAN
+
+github_url: https://github.com/distcc/distcc
+docs_url: https://github.com/distcc/distcc#readme
+
+category: Dev Tools
+tags: [cpp, compiler, distributed-builds, gcc, clang, ci, performance]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Compiling CUDA-adjacent C++ trees like llama.cpp or OpenCV on one
+  CI worker can take tens of minutes. distcc sends preprocess output
+  to other machines on the network so gcc and clang jobs run in
+  parallel, cutting wall-clock time for native ML library builds
+  without changing the source tree.
+
+use_cases:
+  - Spread gcc compile jobs for a native ML library across office workstations
+  - Speed up CI rebuilds of C++ inference code when a single runner is too slow
+  - Combine distcc with ccache so repeated header-heavy builds stay fast
+  - Compile Objective-C and C++ SDKs on a small Mac fleet from one driver

--- a/tools/dev-tools/premake.yaml
+++ b/tools/dev-tools/premake.yaml
@@ -1,0 +1,26 @@
+name: Premake
+description: A Lua-based build configuration tool that generates Visual Studio, Xcode, Makefile, and Ninja projects from one premake5.lua script. Premake lets native ML libraries keep a single project description while each platform still uses its preferred IDE or Ninja backend.
+tagline: Lua scripts that generate native IDE and Make projects
+
+github_url: https://github.com/premake/premake-core
+website_url: https://premake.github.io
+docs_url: https://premake.github.io/docs/
+
+category: Dev Tools
+tags: [build-system, lua, cpp, visual-studio, xcode, ninja, cross-platform]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  C++ ML libraries that still ship Visual Studio solutions and Xcode
+  projects drift when each file is edited by hand. Premake generates
+  those native project files from one Lua script, so CUDA kernels,
+  tests, and shared libraries stay in sync across Windows, macOS,
+  and Linux without maintaining three project trees.
+
+use_cases:
+  - Generate Visual Studio and Makefile projects for a C++ inference library from one Lua file
+  - Keep CUDA and CPU targets in the same premake5.lua for Windows and Linux CI
+  - Emit Ninja files for faster incremental builds of native ML extensions
+  - Share one project description across Xcode and MSVC without CMake

--- a/tools/dev-tools/swift-package-manager.yaml
+++ b/tools/dev-tools/swift-package-manager.yaml
@@ -1,0 +1,26 @@
+name: Swift Package Manager
+description: Apple's official package manager for the Swift language. SwiftPM resolves Git dependencies, builds libraries and executables from Package.swift, and ships with the Swift toolchain so iOS and server Swift ML apps share one graph for Core ML wrappers and native SDKs.
+tagline: Official package manager for the Swift language
+
+github_url: https://github.com/apple/swift-package-manager
+website_url: https://www.swift.org/documentation/package-manager/
+docs_url: https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/
+
+category: Dev Tools
+tags: [swift, ios, macos, package-manager, apple, dependencies, xcode]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  iOS and server Swift projects that wrap Core ML models need a
+  dependency graph that Xcode and CI both understand. Swift Package
+  Manager pins Git packages in Package.swift and Package.resolved,
+  so on-device inference apps and Vapor services share the same
+  resolved versions without a CocoaPods workspace.
+
+use_cases:
+  - Pin a Core ML helper library in Package.swift for an iOS inference app
+  - Share the same Package.resolved between Xcode and Linux CI for a Vapor service
+  - Publish a native Swift SDK that other ML apps consume as a Git package
+  - Build a command-line tokenizer or dataset tool with swift build


### PR DESCRIPTION
## Summary

Adds five build, CI, and compiler-tooling entries:

- **Swift Package Manager** (apple/swift-package-manager, 10.2k, Apache-2.0): official Swift dependency and build tool
- **Premake** (premake/premake-core, 3.6k, BSD-3-Clause): Lua scripts that generate native IDE and Make projects
- **Buildbot** (buildbot/buildbot, 5.5k, GPL-2.0): Python CI framework (`pip install buildbot`)
- **Bear** (rizsotto/Bear, 6.5k, GPL-3.0): generate compile_commands.json from any C/C++ build
- **distcc** (distcc/distcc, 2.3k, GPL-2.0): distributed C/C++ compilation across a LAN

All files passed local `npx tsx scripts/validate-tool.ts`.

## Category

Dev Tools


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Bear, Buildbot, distcc, Premake, and Swift Package Manager.
  * Included descriptions, links, installation details, licensing, pricing, categories, tags, and practical use cases for each development tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->