### PR TITLE
Add Parcel, Lerna, moonrepo, Icecream to catalog

### DIFF
--- a/tools/dev-tools/icecream.yaml
+++ b/tools/dev-tools/icecream.yaml
@@ -1,0 +1,25 @@
+name: Icecream
+description: A distributed C and C++ compiler (icecc) with a central scheduler that spreads compile jobs across volunteer machines. Icecream is used to cut wall-clock time for native ML library builds by sharing gcc and clang load on a LAN.
+tagline: Distributed compiler with a central scheduler
+
+github_url: https://github.com/icecc/icecream
+docs_url: https://github.com/icecc/icecream#readme
+
+category: Dev Tools
+tags: [cpp, compiler, distributed-builds, gcc, clang, icecc, performance]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Native ML trees spend CI minutes compiling C++ on one worker
+  even when idle desktops sit on the same network. Icecream
+  schedules gcc and clang jobs through a central daemon so
+  compile load is shared, without rewriting the CMake or Make
+  files of llama.cpp-style projects.
+
+use_cases:
+  - Share gcc compile jobs for a C++ inference library across office machines
+  - Cut CI wall time for OpenCV or protobuf rebuilds on a small compile farm
+  - Run an icecc scheduler so laptops donate spare cores to nightly native builds
+  - Combine with ccache so distributed compiles still hit a local object cache

--- a/tools/dev-tools/lerna.yaml
+++ b/tools/dev-tools/lerna.yaml
@@ -1,0 +1,28 @@
+name: Lerna
+description: A build system for JavaScript and TypeScript monorepos that versions, builds, and publishes multiple packages from one repository. Lerna is used when an ML platform splits SDKs, CLI, and web UI into packages that must stay in lockstep.
+tagline: JavaScript/TypeScript monorepo versioning and publish tool
+
+github_url: https://github.com/lerna/lerna
+website_url: https://lerna.js.org
+docs_url: https://lerna.js.org/docs/introduction
+
+install_command: npm install lerna
+
+category: Dev Tools
+tags: [javascript, typescript, monorepo, npm, versioning, build-system]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Agent SDKs, CLIs, and web consoles often live in one git repo but
+  publish as separate npm packages. Hand-bumping versions and
+  publishing in the right order breaks. Lerna versions workspaces,
+  runs package scripts, and publishes changed packages so the JS
+  side of an ML platform stays consistent.
+
+use_cases:
+  - Version and publish an agent SDK plus CLI from one JavaScript monorepo
+  - Run tests across workspace packages that share TypeScript types
+  - Publish only changed packages after a model-client API update
+  - Keep a web console and Node SDK on matching semver from one changelog

--- a/tools/dev-tools/moonrepo.yaml
+++ b/tools/dev-tools/moonrepo.yaml
@@ -1,0 +1,28 @@
+name: moonrepo
+description: A Rust-built build system and monorepo manager for the web ecosystem. moonrepo hashes tasks, caches outputs, and orchestrates JavaScript, Python, and Go projects so mixed ML web apps and SDKs rebuild only what changed.
+tagline: Rust build system and monorepo manager for web stacks
+
+github_url: https://github.com/moonrepo/moon
+website_url: https://moonrepo.dev/moon
+docs_url: https://moonrepo.dev/docs
+
+install_command: npm install -g @moonrepo/cli
+
+category: Dev Tools
+tags: [monorepo, rust, javascript, python, build-system, caching, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Mixed repos with a Python training package and a TypeScript
+  console waste CI time rebuilding everything. moonrepo models
+  tasks and dependencies, caches outputs by hash, and runs only
+  affected projects so ML web apps and SDKs stay fast as the
+  monorepo grows.
+
+use_cases:
+  - Cache TypeScript and Python tasks so CI skips unchanged ML console packages
+  - Orchestrate lint, test, and build across JS SDK and Python client folders
+  - Share a toolchain pin for Node and Python in a mixed agent-platform repo
+  - Run affected tests only when a shared schema package changes

--- a/tools/dev-tools/parcel.yaml
+++ b/tools/dev-tools/parcel.yaml
@@ -1,0 +1,28 @@
+name: Parcel
+description: A zero-configuration web bundler that compiles JavaScript, TypeScript, CSS, and assets with automatic transforms and caching. Parcel is used to ship ML demo UIs, annotation tools, and dashboard frontends without a custom webpack file.
+tagline: Zero-config web bundler for JS, CSS, and assets
+
+github_url: https://github.com/parcel-bundler/parcel
+website_url: https://parceljs.org
+docs_url: https://parceljs.org/docs/
+
+install_command: npm install parcel
+
+category: Dev Tools
+tags: [javascript, bundler, typescript, web, frontend, npm, build]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  ML teams shipping a small web UI for annotation or model demos
+  often stall on webpack and plugin config. Parcel infers loaders
+  from file types, caches builds, and produces a production bundle
+  with one command, so the frontend around an inference API does
+  not need a custom bundler stack.
+
+use_cases:
+  - Bundle a TypeScript UI for an internal model playground without webpack
+  - Ship CSS and image assets for an annotation tool with automatic hashing
+  - Hot-reload a dashboard that calls a local inference server during development
+  - Produce a production build of a RAG demo frontend with npm scripts


### PR DESCRIPTION
## Summary

Adds four web monorepo and distributed-compile tools:

- **Parcel** (parcel-bundler/parcel, 44k, MIT): zero-config web bundler (`npm install parcel`)
- **Lerna** (lerna/lerna, 36k, MIT): JS/TS monorepo versioning and publish (`npm install lerna`)
- **moonrepo** (moonrepo/moon, 4.1k, MIT): Rust build system for mixed web/Python monorepos (`npm install -g @moonrepo/cli`)
- **Icecream** (icecc/icecream, 1.8k, GPL-2.0): distributed C/C++ compiler with a central scheduler (not the Python debug printer)

All files passed local `npx tsx scripts/validate-tool.ts`.

## Category

Dev Tools


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Icecream to the developer tools catalog, highlighting distributed C/C++ compilation across networked machines.
  - Added Lerna, with information about managing, testing, versioning, and publishing JavaScript and TypeScript monorepos.
  - Added moonrepo, covering monorepo orchestration, caching, toolchain management, and affected-test execution.
  - Added Parcel, featuring zero-configuration bundling for JavaScript, TypeScript, CSS, and other assets, including hot reload and production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->