### PR TITLE
Add Rush, Taskfile, Capistrano, Salt, AWS CDK to catalog

### DIFF
--- a/tools/dev-tools/aws-cdk.yaml
+++ b/tools/dev-tools/aws-cdk.yaml
@@ -1,0 +1,27 @@
+name: AWS CDK
+description: The AWS Cloud Development Kit defines cloud infrastructure in TypeScript, Python, Java, C#, Go, or JavaScript and synthesizes it to CloudFormation. Teams model GPU training stacks, SageMaker endpoints, and vector-store VPCs as code instead of JSON templates.
+tagline: Define AWS infrastructure in real programming languages
+
+github_url: https://github.com/aws/aws-cdk
+website_url: https://aws.amazon.com/cdk
+docs_url: https://docs.aws.amazon.com/cdk/
+
+install_command: npm install -g aws-cdk
+
+category: Dev Tools
+tags: [aws, iac, cloudformation, typescript, python, infrastructure, cdk]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Hand-written CloudFormation JSON is verbose and hard to reuse across GPU
+  training, SageMaker, and VPC layouts. CDK lets teams write constructs in
+  TypeScript or Python, share libraries, and synth to CloudFormation so ML
+  stacks are reviewed and tested like application code.
+
+use_cases:
+  - Model a SageMaker training job, endpoint, and IAM roles as Python CDK stacks
+  - Share a VPC and GPU instance construct library across ML product teams
+  - Synth and diff CloudFormation before deploying a vector-store cluster
+  - Unit-test infrastructure constructs that provision Bedrock or Lambda agents

--- a/tools/dev-tools/capistrano.yaml
+++ b/tools/dev-tools/capistrano.yaml
@@ -1,0 +1,27 @@
+name: Capistrano
+description: Capistrano is a remote server automation and deployment tool built on Ruby, Rake, and SSH. It ships code over SSH, runs named tasks, and rolls back releases so model APIs, worker boxes, and web UIs can be deployed without ad-hoc shell scripts.
+tagline: SSH-based deployment automation built on Ruby and Rake
+
+github_url: https://github.com/capistrano/capistrano
+website_url: https://capistranorb.com
+docs_url: https://capistranorb.com/documentation/getting-started/installation/
+
+install_command: gem install capistrano
+
+category: Dev Tools
+tags: [ruby, deployment, ssh, rake, devops, automation]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Shipping a model API or worker to several hosts with hand-written SSH
+  scripts loses rollback, shared releases, and a single deploy command.
+  Capistrano uses Rake tasks over SSH to publish a release directory,
+  symlink current, and roll back, so inference hosts update the same way.
+
+use_cases:
+  - Deploy a Rails or Sinatra model-serving app to multiple SSH hosts
+  - Roll back a bad inference-API release by relinking the previous directory
+  - Run remote rake or shell tasks after shipping a new embedding worker
+  - Keep web UI and API boxes on matching releases from one Capfile

--- a/tools/dev-tools/rush.yaml
+++ b/tools/dev-tools/rush.yaml
@@ -1,0 +1,27 @@
+name: Rush
+description: Microsoft Rush is a scalable monorepo manager for JavaScript and TypeScript. It installs, builds, and publishes many packages from one Git repository using a shared install, phased builds, and change files so large agent SDKs, CLIs, and web consoles stay fast as the repo grows.
+tagline: Scalable JavaScript and TypeScript monorepo build orchestrator
+
+github_url: https://github.com/microsoft/rushstack
+website_url: https://rushstack.io
+docs_url: https://rushjs.io
+
+install_command: npm install -g @microsoft/rush
+
+category: Dev Tools
+tags: [javascript, typescript, monorepo, npm, build-system, microsoft]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Large JS/TS platforms split SDKs, CLIs, and UIs into many packages. Naive npm
+  workspaces reinstall the world and rebuild everything on each change. Rush
+  shares one install, phases builds, and tracks change files so only affected
+  packages rebuild and publish, keeping agent and ML web monorepos fast.
+
+use_cases:
+  - Orchestrate builds across an agent SDK, CLI, and dashboard in one Git repo
+  - Publish only changed TypeScript packages after a model-client API bump
+  - Share one install cache across CI jobs for a large JS ML console monorepo
+  - Enforce change files so every package version bump has a reviewable note

--- a/tools/dev-tools/salt.yaml
+++ b/tools/dev-tools/salt.yaml
@@ -1,0 +1,27 @@
+name: Salt
+description: Salt is a remote execution and configuration management system that automates infrastructure at scale. A master pushes state or commands to minions over a high-speed event bus, so GPU nodes, inference hosts, and data services stay consistently configured.
+tagline: Fast remote execution and config management at scale
+
+github_url: https://github.com/saltstack/salt
+website_url: https://saltproject.io
+docs_url: https://docs.saltproject.io
+
+install_command: pip install salt
+
+category: Dev Tools
+tags: [configuration-management, remote-execution, python, devops, infrastructure, saltstack]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  GPU boxes, inference hosts, and data services drift when each is patched
+  by hand. Salt applies declarative states and runs ad-hoc commands across
+  thousands of minions over a high-speed bus, so CUDA drivers, runtimes, and
+  model-serving packages stay the same fleet-wide.
+
+use_cases:
+  - Apply a Salt state that installs CUDA, Docker, and a model runtime on GPU nodes
+  - Run a remote command across inference minions to restart a serving process
+  - Keep data-pipeline hosts on matching Python and system packages
+  - React to events on the Salt bus to reconfigure nodes after a deploy

--- a/tools/dev-tools/taskfile.yaml
+++ b/tools/dev-tools/taskfile.yaml
@@ -1,0 +1,27 @@
+name: Taskfile
+description: Task is a fast, cross-platform task runner that reads a Taskfile YAML and runs commands, dependencies, and watchers. Teams use it as a Make replacement to standardize lint, test, train, and deploy steps for ML repos on Linux, macOS, and Windows.
+tagline: Fast YAML task runner, a Make replacement for modern repos
+
+github_url: https://github.com/go-task/task
+website_url: https://github.com/go-task/task
+docs_url: https://github.com/go-task/task#readme
+
+install_command: npm install -g @go-task/cli
+
+category: Dev Tools
+tags: [task-runner, yaml, go, make, build, cli, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  README copy-paste and Makefile dialect fights make lint, train, and deploy
+  steps drift across laptops and CI. Taskfile declares named tasks with
+  dependencies, vars, and watchers in YAML that runs the same on Linux, macOS,
+  and Windows, so ML repos share one command surface without Make syntax.
+
+use_cases:
+  - Standardize lint, unit test, and embedding-index rebuild as named tasks
+  - Watch Python files and re-run evals when a prompt template changes
+  - Chain data-prep, train, and export steps with Taskfile dependencies
+  - Share one Taskfile across local shells and CI without Makefile portability issues


### PR DESCRIPTION
## Summary
Adds five Dev Tools catalog entries used in ML platform and infra workflows:

- **Rush** (microsoft/rushstack) — scalable JS/TS monorepo manager
- **Taskfile** (go-task/task) — YAML task runner / Make replacement
- **Capistrano** (capistrano/capistrano) — SSH deployment automation
- **Salt** (saltstack/salt) — remote execution and config management
- **AWS CDK** (aws/aws-cdk) — AWS infrastructure as TypeScript/Python code

## Test plan
- [x] Local `npx tsx scripts/validate-tool.ts` passed for all five files
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWS CDK, Capistrano, Microsoft Rush, Salt, and Task to the development-tools catalog.
  * Added metadata for each tool, including descriptions, links, installation instructions, licensing, pricing, and categories.
  * Added practical use cases covering infrastructure provisioning, deployment automation, monorepo orchestration, configuration management, and task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->