### PR TITLE
Add Serverless Framework, SST, Encore, microk8s to catalog

### DIFF
--- a/tools/dev-tools/encore.yaml
+++ b/tools/dev-tools/encore.yaml
@@ -1,0 +1,27 @@
+name: Encore
+description: Encore is a backend framework that infers infrastructure from application code. You write TypeScript or Go APIs, and Encore provisions APIs, Pub/Sub, databases, and tracing so agent backends ship without a separate Terraform or YAML layer.
+tagline: Backend framework that provisions infra from your code
+
+github_url: https://github.com/encoredev/encore
+website_url: https://github.com/encoredev/encore
+docs_url: https://github.com/encoredev/encore#readme
+
+install_command: brew install encoredev/tap/encore
+
+category: Dev Tools
+tags: [go, typescript, backend, infrastructure, tracing, api, framework]
+pricing: freemium
+is_open_source: true
+license: MPL-2.0
+
+problem_solved: |
+  Agent backends need APIs, queues, databases, and tracing, then a
+  second pile of Terraform to run them. Encore infers that infra from
+  Go or TypeScript code, provisions it, and adds tracing so teams
+  ship services without a parallel IaC project.
+
+use_cases:
+  - Define a Go API plus Postgres for an agent control plane without Terraform
+  - Add Pub/Sub between a worker and an HTTP service from application code
+  - Trace request paths across an inference backend without a separate APM setup
+  - Spin up preview environments that match production infra from the same code

--- a/tools/dev-tools/microk8s.yaml
+++ b/tools/dev-tools/microk8s.yaml
@@ -1,0 +1,27 @@
+name: microk8s
+description: MicroK8s is Canonical's small, single-package Kubernetes for workstations, datacenters, and the edge. One snap installs a conformant cluster with optional addons for GPU, registry, and observability so ML teams can run local or edge inference without a full kubeadm install.
+tagline: Small, single-package Kubernetes for laptops and the edge
+
+github_url: https://github.com/canonical/microk8s
+website_url: https://microk8s.io
+docs_url: https://microk8s.io/docs
+
+install_command: snap install microk8s --classic
+
+category: Dev Tools
+tags: [kubernetes, canonical, edge, snap, cluster, gpu, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Full kubeadm or managed Kubernetes is heavy for a laptop GPU box or
+  an edge inference node. MicroK8s installs a conformant cluster from
+  one snap, with addons for GPU, DNS, and registries, so teams run
+  the same manifests locally and at the edge without a control-plane team.
+
+use_cases:
+  - Run a local Kubernetes cluster on an Ubuntu GPU workstation for model serving
+  - Enable the GPU addon to schedule inference pods on an edge box
+  - Mirror production manifests on a laptop before promoting to EKS or GKE
+  - Deploy a registry and observability addons alongside a small cluster

--- a/tools/dev-tools/serverless.yaml
+++ b/tools/dev-tools/serverless.yaml
@@ -1,0 +1,27 @@
+name: Serverless Framework
+description: Serverless Framework deploys auto-scaling apps on AWS Lambda and other managed cloud services from a YAML service file. It packages functions, wires API Gateway and events, and incurs no cost when idle, so inference APIs and agent webhooks can ship without managing servers.
+tagline: Deploy auto-scaling Lambda apps from a YAML service file
+
+github_url: https://github.com/serverless/serverless
+website_url: https://serverless.com
+docs_url: https://www.serverless.com/framework/docs
+
+install_command: npm install -g serverless
+
+category: Dev Tools
+tags: [aws, lambda, serverless, faas, yaml, nodejs, cloud]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Standing up an inference webhook or agent callback usually means
+  servers, autoscaling groups, and idle cost. Serverless Framework
+  packages functions, events, and APIs from one service file and
+  deploys them to Lambda so the endpoint scales to zero when unused.
+
+use_cases:
+  - Deploy an agent webhook as AWS Lambda behind API Gateway
+  - Package a Python embedding function with events from S3 or SQS
+  - Share one serverless.yml across staging and production stages
+  - Add DynamoDB and IAM from the same service file as the function code

--- a/tools/dev-tools/sst.yaml
+++ b/tools/dev-tools/sst.yaml
@@ -1,0 +1,27 @@
+name: SST
+description: SST is a framework for building full-stack apps on your own AWS infrastructure with TypeScript. It binds Live Lambda Dev, Pulumi-backed resources, and web UIs so teams iterate on agent APIs and consoles without a separate local emulator.
+tagline: Full-stack apps on your own AWS infrastructure
+
+github_url: https://github.com/anomalyco/sst
+website_url: https://github.com/anomalyco/sst
+docs_url: https://github.com/anomalyco/sst#readme
+
+install_command: npm install -g sst
+
+category: Dev Tools
+tags: [aws, typescript, serverless, iac, lambda, fullstack, pulumi]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Local emulators drift from real AWS IAM, queues, and Lambda behavior,
+  so agent backends fail only after deploy. SST defines infrastructure
+  in TypeScript and runs Live Lambda against your AWS account, so
+  functions, frontends, and linked resources share one real cloud stack.
+
+use_cases:
+  - Iterate on a TypeScript agent API with Live Lambda against real AWS
+  - Bind a Next.js console to Lambda functions and an S3 bucket in one app
+  - Share resource links across frontend and backend without manual IAM wiring
+  - Deploy a GPU-adjacent AWS stack as TypeScript instead of raw CloudFormation


### PR DESCRIPTION
## Summary
Adds four Dev Tools catalog entries for serverless and cluster workflows:

- **Serverless Framework** (serverless/serverless) — Lambda/YAML deploy framework
- **SST** (anomalyco/sst) — full-stack apps on your own AWS infrastructure
- **Encore** (encoredev/encore) — backend framework that infers infra from code
- **microk8s** (canonical/microk8s) — single-package Kubernetes for laptops and edge

## Test plan
- [x] Local `npx tsx scripts/validate-tool.ts` passed for all four files
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Encore, MicroK8s, Serverless Framework, and SST to the Dev Tools catalog.
  - Each entry includes installation instructions, project links, technology tags, pricing and licensing details, and practical use cases.
  - Added descriptions highlighting infrastructure provisioning, Kubernetes development, serverless deployments, and full-stack cloud infrastructure workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->