### PR TITLE
Add AWS SAM, Chalice, Atlantis, mitmproxy, Mockoon to catalog

### DIFF
--- a/tools/dev-tools/atlantis.yaml
+++ b/tools/dev-tools/atlantis.yaml
@@ -1,0 +1,25 @@
+name: Atlantis
+description: Atlantis automates Terraform pull-request workflows. It plans on PR open and applies on comment so infrastructure changes for GPU clusters, vector stores, and model-serving stacks are reviewed in Git instead of run from a laptop.
+tagline: Terraform pull-request automation for GitOps workflows
+
+github_url: https://github.com/runatlantis/atlantis
+website_url: https://www.runatlantis.io
+docs_url: https://www.runatlantis.io/docs
+
+category: Dev Tools
+tags: [terraform, gitops, pull-request, iac, automation, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Terraform apply from a laptop skips review and drifts from what Git
+  shows. Atlantis runs plan on each pull request and apply after
+  approval, so GPU, VPC, and serving-stack changes land through the
+  same PR process as application code.
+
+use_cases:
+  - Post Terraform plan output on a PR that adds SageMaker or GPU nodes
+  - Apply approved infra changes from a PR comment instead of a local CLI
+  - Lock state per project so two ML platform PRs cannot apply at once
+  - Require plan success in CI-adjacent Git workflows before merge

--- a/tools/dev-tools/aws-sam.yaml
+++ b/tools/dev-tools/aws-sam.yaml
@@ -1,0 +1,27 @@
+name: AWS SAM
+description: AWS SAM is a CLI and template model for building, testing, and deploying serverless applications on AWS. It local-invokes Lambda, starts API Gateway, and packages CloudFormation so agent webhooks and inference APIs can be developed without a full cloud deploy on every change.
+tagline: Build, test, and deploy AWS serverless apps from the CLI
+
+github_url: https://github.com/aws/aws-sam-cli
+website_url: https://aws.amazon.com/serverless/sam/
+docs_url: https://docs.aws.amazon.com/serverless-application-model/
+
+install_command: pip install aws-sam-cli
+
+category: Dev Tools
+tags: [aws, lambda, serverless, sam, cloudformation, cli, local-dev]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Debugging a Lambda agent webhook against real AWS is slow and costs
+  money on every save. SAM local-invokes functions, emulates API Gateway,
+  and deploys from a SAM template so teams iterate on serverless
+  inference APIs before promoting the same template to an account.
+
+use_cases:
+  - Local-invoke a Python Lambda that handles an agent webhook
+  - Start a local API Gateway to test an embedding HTTP function
+  - Package and deploy a SAM template with Lambda, IAM, and DynamoDB
+  - Validate a serverless.yml-style SAM template in CI before prod deploy

--- a/tools/dev-tools/chalice.yaml
+++ b/tools/dev-tools/chalice.yaml
@@ -1,0 +1,27 @@
+name: Chalice
+description: Chalice is a Python microframework for AWS Lambda and API Gateway. You write decorated Python functions and Chalice packages routes, IAM, and events so small agent APIs and automation endpoints deploy without a separate SAM or Terraform project.
+tagline: Python microframework for AWS Lambda APIs
+
+github_url: https://github.com/aws/chalice
+website_url: https://aws.github.io/chalice/
+docs_url: https://aws.github.io/chalice/api.html
+
+install_command: pip install chalice
+
+category: Dev Tools
+tags: [python, aws, lambda, api-gateway, serverless, microframework]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  A small Python agent endpoint should not need a full SAM or CDK
+  project. Chalice maps decorated functions to API Gateway and Lambda,
+  generates IAM, and deploys from the CLI so teams ship Python
+  webhooks with almost no extra infrastructure files.
+
+use_cases:
+  - Deploy a Python REST API for an agent callback on Lambda
+  - Attach an S3 or SQS event to a Chalice function that indexes documents
+  - Generate IAM from Python annotations instead of hand-written policies
+  - Local-test a Chalice app before deploying to an AWS account

--- a/tools/dev-tools/mitmproxy.yaml
+++ b/tools/dev-tools/mitmproxy.yaml
@@ -1,0 +1,27 @@
+name: mitmproxy
+description: mitmproxy is an interactive TLS-capable intercepting HTTP proxy for developers and testers. It records, replays, and edits HTTP/1, HTTP/2, and WebSocket traffic so teams can inspect LLM API calls, debug agent tool traffic, and script flows in Python.
+tagline: Interactive TLS intercepting HTTP proxy for debugging APIs
+
+github_url: https://github.com/mitmproxy/mitmproxy
+website_url: https://mitmproxy.org
+docs_url: https://docs.mitmproxy.org
+
+install_command: pip install mitmproxy
+
+category: Dev Tools
+tags: [http, proxy, tls, debugging, python, websocket, testing]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  LLM SDKs and agent tool calls hide request bodies behind HTTPS, so
+  failures are opaque. mitmproxy intercepts TLS, shows headers and
+  payloads, and lets you replay or script traffic so teams debug
+  model APIs without scattering print statements through clients.
+
+use_cases:
+  - Inspect OpenAI-compatible chat payloads from a local agent client
+  - Replay a failing tool-call HTTP request after editing headers
+  - Script a Python addon that logs token usage from intercepted traffic
+  - Debug WebSocket streams used by a realtime voice or agent session

--- a/tools/dev-tools/mockoon.yaml
+++ b/tools/dev-tools/mockoon.yaml
@@ -1,0 +1,27 @@
+name: Mockoon
+description: Mockoon is an open-source tool for running mock REST APIs locally with no account and no remote deploy. You design routes in a desktop or CLI app and serve them so agent clients and frontends can develop against stable fixtures when the real model API is slow or unavailable.
+tagline: Local mock REST APIs with no account and no remote deploy
+
+github_url: https://github.com/mockoon/mockoon
+website_url: https://mockoon.com
+docs_url: https://mockoon.com/docs/latest/about/
+
+install_command: npm install -g @mockoon/cli
+
+category: Dev Tools
+tags: [api, mock, rest, local-dev, testing, cli, desktop]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Frontends and agents stall when the real LLM or backend API is down,
+  rate-limited, or still unwritten. Mockoon serves local mock routes
+  from a desktop or CLI environment so teams keep building against
+  fixtures without a remote mock server or cloud account.
+
+use_cases:
+  - Mock a chat-completions endpoint while the real model API is rate-limited
+  - Run Mockoon CLI in CI to serve fixtures for agent integration tests
+  - Design CRUD routes for a vector-store admin UI before the backend exists
+  - Share an environment file so the team hits the same local mock API


### PR DESCRIPTION
## Summary
Adds five Dev Tools catalog entries for serverless local-dev, Terraform GitOps, and API debugging:

- **AWS SAM** (aws/aws-sam-cli) — serverless build/test/deploy CLI
- **Chalice** (aws/chalice) — Python Lambda microframework
- **Atlantis** (runatlantis/atlantis) — Terraform pull-request automation
- **mitmproxy** (mitmproxy/mitmproxy) — intercepting HTTP/TLS proxy
- **Mockoon** (mockoon/mockoon) — local mock REST APIs

## Test plan
- [x] Local `npx tsx scripts/validate-tool.ts` passed for all five files
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Atlantis, AWS SAM, Chalice, mitmproxy, and Mockoon.
  - Added metadata, documentation links, installation details, licensing, pricing, categories, and tags for each tool.
  - Added practical use cases covering infrastructure automation, serverless development, traffic inspection, and local API mocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->