### PR TITLE
Add Molecule, Kopia, Goss, nock to catalog

### DIFF
--- a/tools/dev-tools/goss.yaml
+++ b/tools/dev-tools/goss.yaml
@@ -1,0 +1,27 @@
+name: Goss
+description: Goss is a YAML-based server testing and validation tool. You declare expected packages, ports, files, and processes, then goss validates a host in seconds so GPU boxes and inference nodes can be health-checked after Ansible or image builds.
+tagline: Quick YAML server testing and host validation
+
+github_url: https://github.com/goss-org/goss
+website_url: https://goss.rocks
+docs_url: https://github.com/goss-org/goss#readme
+
+install_command: brew install goss
+
+category: Dev Tools
+tags: [testing, yaml, servers, validation, devops, health-check]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  After provisioning a GPU host, teams still SSH in to check ports,
+  packages, and services. Goss encodes those expectations in YAML
+  and validates in seconds, so image builds and Ansible runs fail
+  fast when an inference node is misconfigured.
+
+use_cases:
+  - Assert CUDA packages, Docker, and an inference port after a host build
+  - Run goss in CI against a container that mirrors a serving image
+  - Auto-add a goss.yaml from the current host and tighten it into a spec
+  - Health-check edge nodes after a config-management converge

--- a/tools/dev-tools/kopia.yaml
+++ b/tools/dev-tools/kopia.yaml
@@ -1,0 +1,27 @@
+name: Kopia
+description: Kopia is a cross-platform backup tool with fast incremental snapshots, client-side encryption, compression, and deduplication. CLI and GUI clients back up datasets, checkpoints, and config to local disks or object storage so ML artifacts can be restored without a heavy backup appliance.
+tagline: Encrypted, deduplicated backups with CLI and GUI clients
+
+github_url: https://github.com/kopia/kopia
+website_url: https://kopia.io
+docs_url: https://kopia.io/docs/
+
+install_command: brew install kopia
+
+category: Dev Tools
+tags: [backup, encryption, deduplication, snapshots, object-storage, cli]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Training checkpoints and datasets are too large for git and too
+  precious to leave on one disk. Kopia takes encrypted, deduplicated
+  snapshots to object storage or a local repo so teams restore model
+  artifacts without running a full enterprise backup stack.
+
+use_cases:
+  - Snapshot model checkpoints to S3-compatible storage with client-side encryption
+  - Deduplicate repeated dataset copies across incremental backups
+  - Restore a training workspace on a new GPU box from a Kopia repository
+  - Schedule CLI backups of experiment configs alongside weights

--- a/tools/dev-tools/molecule.yaml
+++ b/tools/dev-tools/molecule.yaml
@@ -1,0 +1,27 @@
+name: Molecule
+description: Molecule is an Ansible-native testing framework for roles, playbooks, and collections. It runs configurable create-converge-verify-destroy workflows against containers or cloud so infrastructure roles that provision GPU hosts and model-serving boxes stay tested.
+tagline: Ansible-native testing for roles, playbooks, and collections
+
+github_url: https://github.com/ansible/molecule
+website_url: https://ansible.readthedocs.io/projects/molecule/
+docs_url: https://ansible.readthedocs.io/projects/molecule/
+
+install_command: pip install molecule
+
+category: Dev Tools
+tags: [ansible, testing, python, infrastructure, roles, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Ansible roles that install CUDA, Docker, or a model runtime break
+  when run against a fresh host. Molecule creates an instance,
+  converges the role, verifies state, and destroys it so infra
+  playbooks are tested before they touch a GPU box.
+
+use_cases:
+  - Test an Ansible role that installs CUDA and Docker on a container instance
+  - Verify a playbook that configures an inference host before production apply
+  - Run Molecule in CI against a collection that provisions ML workstations
+  - Iterate create-converge-verify locally while editing a serving-stack role

--- a/tools/dev-tools/nock.yaml
+++ b/tools/dev-tools/nock.yaml
@@ -1,0 +1,27 @@
+name: nock
+description: nock is an HTTP server mocking and expectations library for Node.js. It intercepts requests at the HTTP layer so tests can assert method, URL, and body without a real network, which keeps agent SDK and webhook tests fast and deterministic.
+tagline: HTTP mocking and expectations for Node.js tests
+
+github_url: https://github.com/nock/nock
+website_url: https://github.com/nock/nock
+docs_url: https://github.com/nock/nock#readme
+
+install_command: npm install nock
+
+category: Dev Tools
+tags: [nodejs, http, mock, testing, javascript, intercept]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Node agent clients hit real LLM and tool APIs in tests, which is
+  slow, flaky, and billed. nock intercepts HTTP in-process, sets
+  expectations, and returns fixtures so SDK tests stay offline and
+  fail when a request shape drifts.
+
+use_cases:
+  - Mock an OpenAI-compatible chat endpoint in a Node agent SDK test
+  - Assert a webhook client posts the expected JSON body without a server
+  - Record and replay HTTP in tests for a TypeScript tool-calling client
+  - Fail CI when a client starts calling an undeclared model-API path


### PR DESCRIPTION
## Summary
Adds four Dev Tools catalog entries for infra testing, backups, and HTTP mocks:

- **Molecule** (ansible/molecule) — Ansible-native role/playbook testing
- **Kopia** (kopia/kopia) — encrypted deduplicated backups
- **Goss** (goss-org/goss) — YAML server validation
- **nock** (nock/nock) — Node.js HTTP mocking

## Test plan
- [x] Local `npx tsx scripts/validate-tool.ts` passed for all four files
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Goss to the development tools catalog for server health checks.
  - Added Kopia for backups, snapshots, deduplication, and workspace restoration.
  - Added Molecule for testing Ansible roles, playbooks, and collections.
  - Added Nock for mocking and validating Node.js HTTP requests.
  - Each entry includes installation details, documentation links, licensing, pricing, categories, tags, and example use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->