### PR TITLE
Add InSpec, Testkube, OpenEBS, Borg, Duplicati to catalog

### DIFF
--- a/tools/data/openebs.yaml
+++ b/tools/data/openebs.yaml
@@ -1,0 +1,22 @@
+name: OpenEBS
+description: OpenEBS is cloud-native storage for Kubernetes that provisions local and replicated persistent volumes for stateful apps. It offers HostPath, ZFS, LVM, and Mayastor engines so GPU clusters can attach fast, resilient disks for model caches, vector databases, and training checkpoints.
+tagline: Cloud-native persistent storage for Kubernetes stateful apps
+github_url: https://github.com/openebs/openebs
+website_url: https://openebs.io
+docs_url: https://openebs.io/docs
+category: Data
+tags: [kubernetes, storage, persistent-volume, csi, nvme, zfs, data-platform]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Stateful AI workloads on Kubernetes need local NVMe speed and replicated
+  durability, but cloud disks are slow or expensive and hostPath volumes are
+  not portable. OpenEBS provisions CSI volumes from HostPath, ZFS, LVM, or
+  Mayastor so vector databases, feature stores, and checkpoint caches get
+  dynamic PVs with snapshots and optional n-way replication across nodes.
+use_cases:
+  - Attach local NVMe persistent volumes to vector database pods without managing raw hostPath mounts
+  - Replicate model-checkpoint volumes across Kubernetes nodes with Mayastor for training job failover
+  - Provision ZFS-backed PVs with snapshots for experiment workspaces on GPU worker nodes
+  - Give inference caches and feature-store StatefulSets dynamic storage that follows the pod

--- a/tools/dev-tools/borg.yaml
+++ b/tools/dev-tools/borg.yaml
@@ -1,0 +1,23 @@
+name: Borg
+description: Borg is a deduplicating backup program with compression and authenticated encryption. It stores space-efficient snapshots of datasets, checkpoints, and experiment artifacts on local disks or remote repos so ML teams can restore failed runs without re-uploading unchanged chunks.
+tagline: Deduplicating encrypted backups for datasets and checkpoints
+github_url: https://github.com/borgbackup/borg
+website_url: https://www.borgbackup.org
+docs_url: https://borgbackup.readthedocs.io
+install_command: pip install borgbackup
+category: Dev Tools
+tags: [backup, deduplication, encryption, python, snapshots, storage, devops]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: |
+  Training checkpoints and datasets change a little each day but cost a lot
+  to copy in full. Borg chunks, compresses, and encrypts data client-side,
+  then only stores new chunks in a local or remote repository so labs can
+  keep many snapshots of models and experiment dirs without paying full
+  object-storage prices or sending plaintext artifacts off-box.
+use_cases:
+  - Keep incremental encrypted backups of model checkpoints so only changed tensor chunks are stored
+  - Snapshot experiment directories to a remote Borg repo and restore a prior run after a failed training job
+  - Deduplicate daily backups of shared datasets across workstations that hold overlapping files
+  - Append-only backup of configs and notebooks with authenticated encryption before pushing to object storage

--- a/tools/dev-tools/duplicati.yaml
+++ b/tools/dev-tools/duplicati.yaml
@@ -1,0 +1,23 @@
+name: Duplicati
+description: Duplicati is a client-side encrypted backup tool that stores snapshots in S3, Azure, Google Drive, SFTP, and other backends. It incrementally backs up workstations and servers so training configs, notebooks, and small artifact stores stay recoverable without trusting the cloud provider with plaintext.
+tagline: Encrypted cloud backups from the client, not the provider
+github_url: https://github.com/duplicati/duplicati
+website_url: https://duplicati.com
+docs_url: https://docs.duplicati.com
+install_command: brew install --cask duplicati
+category: Dev Tools
+tags: [backup, encryption, s3, cloud, windows, macos, devops]
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: |
+  Researchers store notebooks, API keys, and small artifacts on laptops that
+  get lost or wiped, while cloud backup products see files in plaintext.
+  Duplicati encrypts on the client, then ships incremental snapshots to S3,
+  Azure, Google Drive, or SFTP so teams recover workstations without giving
+  the storage provider readable copies of prompts, weights, or secrets.
+use_cases:
+  - Schedule encrypted incremental backups of laptop experiment folders to S3 or Backblaze B2
+  - Restore a research workstation from a Duplicati snapshot after disk failure without re-cloning datasets
+  - Back up on-prem GPU jump hosts to SFTP with client-side encryption and retention policies
+  - Keep versioned backups of notebooks and config files across Google Drive without storing plaintext

--- a/tools/dev-tools/inspec.yaml
+++ b/tools/dev-tools/inspec.yaml
@@ -1,0 +1,23 @@
+name: InSpec
+description: Chef InSpec is an open-source infrastructure testing framework with a readable DSL for compliance, security, and policy checks. Run the same profiles locally, over SSH, WinRM, or Docker to audit GPU hosts, Kubernetes nodes, and ML serving stacks.
+tagline: Compliance-as-code tests for infrastructure and ML hosts
+github_url: https://github.com/inspec/inspec
+website_url: https://www.inspec.io
+docs_url: https://docs.chef.io/inspec/
+install_command: gem install inspec-bin
+category: Dev Tools
+tags: [compliance, testing, infrastructure, security, ruby, devops, audit]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  ML clusters drift: CUDA drivers, SSH configs, container runtimes, and CIS
+  baselines differ across GPU nodes and break training or leak credentials.
+  InSpec encodes those checks as versioned profiles you run locally or over
+  SSH/WinRM/Docker, so platform teams catch misconfigured hosts before jobs
+  schedule onto them instead of discovering policy failures after a run dies.
+use_cases:
+  - Audit GPU worker images for CUDA, NVIDIA driver, and container runtime versions before a training job lands
+  - Encode CIS and internal security baselines as InSpec profiles and run them over SSH against model-serving VMs
+  - Test Kubernetes node configuration and kubelet settings as part of a cluster bootstrap pipeline
+  - Verify Docker containers used for inference do not ship with insecure packages or open ports

--- a/tools/dev-tools/testkube.yaml
+++ b/tools/dev-tools/testkube.yaml
@@ -1,0 +1,23 @@
+name: Testkube
+description: Testkube is a Kubernetes-native testing platform that runs unit, integration, and end-to-end tests as cluster workflows. Teams execute Playwright, k6, Cypress, and custom jobs next to the services they test, then collect results without standing up a separate CI runner fleet.
+tagline: Kubernetes-native test orchestration for cluster workloads
+github_url: https://github.com/kubeshop/testkube
+website_url: https://testkube.io
+docs_url: https://docs.testkube.io
+install_command: brew install testkube
+category: Dev Tools
+tags: [kubernetes, testing, ci-cd, e2e, k6, playwright, devops]
+pricing: freemium
+is_open_source: true
+license: MIT
+problem_solved: |
+  AI services running in Kubernetes are hard to test from a laptop CI runner:
+  GPU nodes, sidecars, and internal DNS never match production. Testkube
+  schedules tests as cluster workflows beside the workloads they cover, so
+  load tests, API checks, and browser jobs hit real in-cluster endpoints and
+  stream results to one dashboard instead of a pile of ad-hoc Job YAML.
+use_cases:
+  - Run k6 load tests against an in-cluster model-serving endpoint from the same namespace
+  - Execute Playwright or Cypress suites against an internal AI dashboard without exposing it publicly
+  - Orchestrate post-deploy smoke tests for RAG APIs as Kubernetes workflows after each rollout
+  - Collect failing test artifacts from GPU nodes into a single Testkube dashboard for on-call review


### PR DESCRIPTION
## Add InSpec, Testkube, OpenEBS, Borg, Duplicati to catalog

Five catalog entries for infrastructure testing, Kubernetes-native tests, cloud-native storage, and backup tooling used in ML/AI clusters.

| Tool | Category | Why it belongs |
|---|---|---|
| InSpec | Dev Tools | Compliance-as-code for GPU hosts and serving stacks (`inspec/inspec`, Apache-2.0) |
| Testkube | Dev Tools | Kubernetes-native test orchestration (`kubeshop/testkube`) |
| OpenEBS | Data | Cloud-native PVs for stateful AI workloads (`openebs/openebs`, Apache-2.0, 9.8k stars) |
| Borg | Dev Tools | Deduplicating encrypted backups (`borgbackup/borg`, BSD-3-Clause, 13.6k stars) |
| Duplicati | Dev Tools | Client-side encrypted cloud backups (`duplicati/duplicati`, MIT, 14.9k stars) |

All five files passed `npx tsx scripts/validate-tool.ts` locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Catalog Entries**
  * Added OpenEBS to the data tools catalog, including storage features such as persistent volumes, replication, snapshots, and inference-cache support.
  * Added Borg and Duplicati to the developer tools catalog for encrypted, incremental, deduplicated backup workflows.
  * Added Chef InSpec for infrastructure, Kubernetes, host, and container security testing.
  * Added Testkube for Kubernetes cluster testing and artifact collection.
* **Documentation**
  * Included installation details, licensing, links, pricing, categories, tags, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->