### PR TITLE
Add Test Kitchen, Serverspec, Rancher Desktop to catalog

### DIFF
--- a/tools/dev-tools/rancher-desktop.yaml
+++ b/tools/dev-tools/rancher-desktop.yaml
@@ -1,0 +1,22 @@
+name: Rancher Desktop
+description: Rancher Desktop runs container engines and a local Kubernetes cluster on a developer workstation. It ships k3s plus nerdctl or dockerd so ML engineers can build images, test Helm charts, and iterate on serving stacks without a remote cluster or Docker Desktop license.
+tagline: Local Kubernetes and containers on the desktop
+github_url: https://github.com/rancher-sandbox/rancher-desktop
+website_url: https://rancherdesktop.io
+docs_url: https://docs.rancherdesktop.io
+install_command: brew install --cask rancher
+category: Dev Tools
+tags: [kubernetes, containers, desktop, k3s, docker, devops, local-dev]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Testing AI services that need Kubernetes usually means a shared remote
+  cluster or a paid Docker Desktop seat. Rancher Desktop runs k3s and a
+  container engine locally with nerdctl or dockerd, so engineers build
+  images, apply Helm charts, and debug GPU-adjacent workloads on their
+  laptop without fighting cluster quotas or a proprietary runtime license.
+use_cases:
+  - Run a local k3s cluster to develop Helm charts for model-serving and vector-database stacks
+  - Build and test inference container images with nerdctl or dockerd before pushing to a registry
+  - Reproduce Kubernetes Job and StatefulSet behavior for training sidecars on a laptop without a remote cluster

--- a/tools/dev-tools/serverspec.yaml
+++ b/tools/dev-tools/serverspec.yaml
@@ -1,0 +1,22 @@
+name: Serverspec
+description: Serverspec is an RSpec-based framework for testing server configuration. Write specs that SSH into hosts provisioned by Chef, Puppet, Ansible, or by hand and assert packages, services, ports, and files match the intended ML node baseline.
+tagline: RSpec tests for servers configured by any provisioner
+github_url: https://github.com/mizzy/serverspec
+website_url: https://serverspec.org
+docs_url: https://serverspec.org
+install_command: gem install serverspec
+category: Dev Tools
+tags: [testing, rspec, infrastructure, ruby, ssh, devops, compliance]
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: |
+  After Chef, Puppet, or Ansible finishes, nobody knows if the GPU host
+  actually has the right packages, ports, and services. Serverspec SSHes
+  into the machine and runs RSpec examples against live state so teams
+  prove CUDA, docker, and sshd match the baseline instead of trusting
+  that the provisioner reported success.
+use_cases:
+  - Assert NVIDIA driver, CUDA toolkit, and docker packages are installed on every GPU worker after Ansible converges
+  - Check that model-serving ports are listening and unwanted daemons are stopped on inference VMs
+  - Verify SSH hardening and file permissions on jump hosts that hold training credentials

--- a/tools/dev-tools/test-kitchen.yaml
+++ b/tools/dev-tools/test-kitchen.yaml
@@ -1,0 +1,22 @@
+name: Test Kitchen
+description: Test Kitchen is an integration-testing harness for infrastructure code. It spins isolated instances, applies Chef, Ansible, or shell provisioners, then runs verification so GPU images, serving AMIs, and ML node cookbooks are proven before they hit a cluster.
+tagline: Integration tests for infrastructure code on isolated platforms
+github_url: https://github.com/test-kitchen/test-kitchen
+website_url: https://kitchen.ci
+docs_url: https://kitchen.ci/docs/getting-started/introduction/
+install_command: gem install test-kitchen
+category: Dev Tools
+tags: [testing, infrastructure, chef, ansible, ruby, devops, vagrant]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Infrastructure code for ML hosts is easy to write and hard to prove: a
+  cookbook that installs CUDA may work on one AMI and fail on another.
+  Test Kitchen creates throwaway instances per platform, converges the
+  provisioner, then runs tests so platform teams catch broken GPU images
+  and serving nodes in CI instead of on the first training job.
+use_cases:
+  - Converge a Chef cookbook that installs NVIDIA drivers and CUDA on multiple Linux AMIs before publishing the image
+  - Test Ansible playbooks for model-serving nodes against Vagrant or cloud instances in CI
+  - Verify shell-provisioned GPU worker images boot with the expected container runtime and kernel modules


### PR DESCRIPTION
## Add Test Kitchen, Serverspec, Rancher Desktop to catalog

Remainder batch after PR #504.

| Tool | Category | Why it belongs |
|---|---|---|
| Test Kitchen | Dev Tools | Integration tests for infrastructure code (`test-kitchen/test-kitchen`, Apache-2.0) |
| Serverspec | Dev Tools | RSpec tests against live server state (`mizzy/serverspec`, MIT) |
| Rancher Desktop | Dev Tools | Local Kubernetes and containers on the desktop (`rancher-sandbox/rancher-desktop`, Apache-2.0). Distinct from existing Rancher multi-cluster manager. |

All three files passed `npx tsx scripts/validate-tool.ts` locally.
