### PR TITLE
Add Jsonnet, Jasmine, Garden, Tailscale, workerd to catalog

### DIFF
--- a/tools/dev-tools/garden.yaml
+++ b/tools/dev-tools/garden.yaml
@@ -1,0 +1,21 @@
+name: Garden
+description: Garden is a DevOps automation tool for Kubernetes development and testing. It spins production-like environments on demand, caches builds and tests, and uses the same garden.yml workflows from local iteration through CI so ML services get realistic cluster feedback early.
+tagline: On-demand Kubernetes environments for develop, test, and CI
+github_url: https://github.com/garden-io/garden
+website_url: https://garden.io
+docs_url: https://docs.garden.io
+category: Dev Tools
+tags: [kubernetes, devops, ci-cd, testing, helm, developer-experience]
+pricing: freemium
+is_open_source: true
+license: MPL-2.0
+problem_solved: |
+  AI services that depend on Helm charts, sidecars, and in-cluster databases
+  are slow to test because every engineer waits on a shared staging cluster.
+  Garden builds, deploys, and tests from garden.yml with smart caching so
+  teams get production-like Kubernetes environments on demand instead of
+  hand-running kubectl against a crowded namespace.
+use_cases:
+  - Spin up a production-like namespace to develop a model-serving Helm chart with its vector database sidecar
+  - Cache container builds and integration tests for RAG APIs so CI only reruns what changed
+  - Use the same garden.yml from laptop inner loop through GitHub Actions for inference stack deploys

--- a/tools/dev-tools/jasmine.yaml
+++ b/tools/dev-tools/jasmine.yaml
@@ -1,0 +1,21 @@
+name: Jasmine
+description: Jasmine is a behavior-driven JavaScript testing framework for browsers and Node.js that needs no external runner or DOM. Teams use it to unit-test AI web UIs, SDK clients, and prompt-tooling libraries with readable specs and zero config.
+tagline: Batteries-included BDD tests for JavaScript
+github_url: https://github.com/jasmine/jasmine
+website_url: https://jasmine.github.io
+docs_url: https://jasmine.github.io/pages/getting_started.html
+install_command: npm install --save-dev jasmine
+category: Dev Tools
+tags: [testing, javascript, bdd, nodejs, browser, unit-tests]
+pricing: free
+is_open_source: true
+license: MIT
+problem_solved: |
+  Frontend and Node SDKs around LLM apps still need unit tests that run in
+  a browser or CI without a heavy runner. Jasmine ships matchers, spies, and
+  a CLI so teams assert chat-widget behavior and client-library contracts
+  without wiring Jest, Mocha, and a custom reporter from scratch.
+use_cases:
+  - Unit-test a browser chat widget that streams model tokens without standing up a full browser-automation suite
+  - Spec Node.js SDK methods that wrap OpenAI or Anthropic clients with spies on HTTP calls
+  - Run the same Jasmine suite in CI and in a browser for shared AI dashboard components

--- a/tools/dev-tools/jsonnet.yaml
+++ b/tools/dev-tools/jsonnet.yaml
@@ -1,0 +1,21 @@
+name: Jsonnet
+description: Jsonnet is a data templating language that extends JSON with variables, functions, and imports. Teams generate Kubernetes manifests, model-serving configs, and experiment parameter files from one source of truth instead of copy-pasting JSON across environments.
+tagline: JSON templating for configs, manifests, and experiment files
+github_url: https://github.com/google/jsonnet
+website_url: https://jsonnet.org
+docs_url: https://jsonnet.org/learning/tutorial.html
+install_command: pip install jsonnet
+category: Dev Tools
+tags: [json, templating, kubernetes, configuration, google, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  ML platforms drown in duplicated JSON and YAML: one file per environment
+  for serving, another for training, another for CI. Jsonnet adds variables,
+  functions, and imports on top of JSON so a single library emits environment
+  specific manifests and hyperparameter files without a custom generator.
+use_cases:
+  - Generate Kubernetes manifests for model-serving stacks from one Jsonnet library per environment
+  - Parameterize experiment configs with functions so training jobs share defaults and override only what changes
+  - Compose Helm-adjacent JSON for vector database and feature-store deployments without copy-paste YAML

--- a/tools/dev-tools/tailscale.yaml
+++ b/tools/dev-tools/tailscale.yaml
@@ -1,0 +1,22 @@
+name: Tailscale
+description: Tailscale is a WireGuard-based mesh VPN that connects laptops, GPU boxes, and cloud VMs with identity-aware access. ML teams reach private Jupyter hosts, inference endpoints, and on-prem clusters without opening inbound ports or running a classic VPN concentrator.
+tagline: Identity-aware WireGuard mesh for private ML infrastructure
+github_url: https://github.com/tailscale/tailscale
+website_url: https://tailscale.com
+docs_url: https://tailscale.com/kb
+install_command: brew install tailscale
+category: Dev Tools
+tags: [vpn, wireguard, networking, zero-trust, mesh, devops, security]
+pricing: freemium
+is_open_source: true
+license: BSD-3-Clause
+problem_solved: |
+  GPU boxes, Jupyter servers, and internal model APIs live on private
+  networks that are painful to reach from a laptop. Tailscale builds a
+  WireGuard mesh keyed by identity so researchers SSH to training nodes
+  and hit private inference URLs without inbound firewall holes or a
+  company VPN appliance that never quite routes to the lab subnet.
+use_cases:
+  - SSH to on-prem GPU workers from a laptop without exposing port 22 to the internet
+  - Reach a private model-serving endpoint during development as if it were on localhost
+  - Connect CI runners and home-lab vector databases over an identity-aware mesh instead of a site-to-site VPN

--- a/tools/dev-tools/workerd.yaml
+++ b/tools/dev-tools/workerd.yaml
@@ -1,0 +1,22 @@
+name: workerd
+description: workerd is Cloudflare's open-source JavaScript and Wasm runtime that powers Workers. Run the same isolate model locally or self-hosted so edge AI gateways, prompt proxies, and lightweight inference adapters can be tested without deploying to Cloudflare first.
+tagline: Open-source Cloudflare Workers JavaScript and Wasm runtime
+github_url: https://github.com/cloudflare/workerd
+website_url: https://blog.cloudflare.com/workerd-open-source-workers-runtime/
+docs_url: https://developers.cloudflare.com/workers/
+install_command: npm install workerd
+category: Dev Tools
+tags: [javascript, wasm, edge, cloudflare, workers, runtime, serverless]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Edge AI gateways and prompt proxies written for Cloudflare Workers are
+  hard to debug if the only runtime is the hosted platform. workerd is the
+  same JavaScript and Wasm isolate engine, installable locally, so teams
+  run Workers-compatible code against fixtures before shipping an edge
+  LLM proxy or auth wrapper.
+use_cases:
+  - Run Cloudflare Workers locally to test an edge prompt-proxy before deploying
+  - Self-host Workers-compatible JavaScript for an AI gateway that must stay off Cloudflare
+  - Execute Wasm and JS isolates in CI to regression-test token-routing logic at the edge


### PR DESCRIPTION
## Add Jsonnet, Jasmine, Garden, Tailscale, workerd to catalog

Replenishment batch after catalog pool exhaustion.

| Tool | Category | Why it belongs |
|---|---|---|
| Jsonnet | Dev Tools | JSON templating for K8s/ML configs (`google/jsonnet`, Apache-2.0, 7.5k stars) |
| Jasmine | Dev Tools | BDD JavaScript testing (`jasmine/jasmine`, MIT, 15.8k stars) |
| Garden | Dev Tools | Kubernetes dev/test environments (`garden-io/garden`, MPL-2.0, 3.6k stars) |
| Tailscale | Dev Tools | Identity-aware WireGuard mesh (`tailscale/tailscale`, BSD-3-Clause, 36k stars) |
| workerd | Dev Tools | Open-source Cloudflare Workers runtime (`cloudflare/workerd`, Apache-2.0, 8.6k stars) |

All five files passed `npx tsx scripts/validate-tool.ts` locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Garden, Jasmine, Jsonnet, Tailscale, and workerd.
  - Included descriptions, documentation and website links, installation guidance, licensing, pricing, categories, and tags.
  - Added practical use cases covering Kubernetes development, JavaScript testing, configuration generation, private infrastructure connectivity, and edge gateway testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->