### PR TITLE
Add Wrangler, OpenFGA, SpiceDB, Casbin to catalog

### DIFF
--- a/tools/data/spicedb.yaml
+++ b/tools/data/spicedb.yaml
@@ -1,0 +1,22 @@
+name: SpiceDB
+description: SpiceDB is an open-source Google Zanzibar-inspired database for storing and querying fine-grained authorization data. It scales relationship graphs so AI platforms can check permissions on models, datasets, and agent sessions with consistent, low-latency lookups.
+tagline: Zanzibar-inspired database for fine-grained authorization
+github_url: https://github.com/authzed/spicedb
+website_url: https://authzed.com
+docs_url: https://authzed.com/docs/spicedb/getting-started/discovering-spicedb
+install_command: brew install spicedb
+category: Data
+tags: [authorization, zanzibar, database, rebac, security, permissions, data-platform]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Application databases are a poor fit for nested, relationship-based
+  permissions across tenants, datasets, and model artifacts. SpiceDB
+  stores a permission graph and answers check and lookup queries with
+  Zanzibar-style consistency so AI products can authorize every RAG
+  retrieve and agent action without scanning ACLs in Postgres.
+use_cases:
+  - Store relationship tuples for who can read a fine-tuning dataset or invoke a private model
+  - Lookup subjects that may access an agent session before streaming tokens
+  - Keep authorization consistent across microservices that serve embeddings, prompts, and eval jobs

--- a/tools/dev-tools/casbin.yaml
+++ b/tools/dev-tools/casbin.yaml
@@ -1,0 +1,22 @@
+name: Casbin
+description: Apache Casbin is an authorization library that enforces ACL, RBAC, and ABAC from a policy file and a model. Embed it in Python, Go, or Node services so AI APIs gate tools, tenants, and model routes with a single policy language instead of scattered if-statements.
+tagline: Multi-language ACL, RBAC, and ABAC enforcement library
+github_url: https://github.com/casbin/casbin
+website_url: https://casbin.org
+docs_url: https://casbin.org/docs/overview
+install_command: pip install casbin
+category: Dev Tools
+tags: [authorization, rbac, abac, acl, security, python, golang]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Inference APIs accumulate ad-hoc permission checks until nobody can
+  change who may call a tool. Casbin loads a model plus a policy and
+  enforces ACL, RBAC, or ABAC in-process across languages so teams
+  version access rules next to the service instead of rewriting
+  middleware for every new agent route.
+use_cases:
+  - Enforce RBAC on model-serving routes so only billed tenants can call GPT-class endpoints
+  - Gate agent tool use with ABAC attributes such as dataset classification and user role
+  - Share one Casbin policy file across Python training jobs and a Go inference gateway

--- a/tools/dev-tools/openfga.yaml
+++ b/tools/dev-tools/openfga.yaml
@@ -1,0 +1,22 @@
+name: OpenFGA
+description: OpenFGA is a high-performance authorization engine inspired by Google Zanzibar. It stores relationship tuples and answers check, list, and expand queries so AI platforms can enforce fine-grained access on agents, datasets, and model endpoints without hard-coding RBAC.
+tagline: Zanzibar-style authorization for fine-grained access checks
+github_url: https://github.com/openfga/openfga
+website_url: https://openfga.dev
+docs_url: https://openfga.dev/docs
+install_command: brew install openfga
+category: Dev Tools
+tags: [authorization, zanzibar, rbac, rebac, security, openfga, access-control]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Multi-tenant AI products need to answer "can this user run this agent on
+  that dataset?" at request time. Role tables in the app database do not
+  scale to nested teams and shared models. OpenFGA stores relationship
+  tuples and serves check queries so platforms keep authorization logic
+  out of every inference handler.
+use_cases:
+  - Check whether a user can invoke a private agent or model endpoint before the request is billed
+  - Model team and project membership as relationship tuples for shared evaluation datasets
+  - List every document a principal may retrieve in a RAG workspace without scanning the whole corpus ACL

--- a/tools/dev-tools/wrangler.yaml
+++ b/tools/dev-tools/wrangler.yaml
@@ -1,0 +1,21 @@
+name: Wrangler
+description: Wrangler is the CLI for Cloudflare Workers. It develops, previews, and deploys Workers, Pages, and Durable Objects so teams ship edge AI gateways, prompt proxies, and token-routing logic from a local project without clicking through the Cloudflare dashboard.
+tagline: CLI for developing and deploying Cloudflare Workers
+github_url: https://github.com/cloudflare/workers-sdk
+website_url: https://developers.cloudflare.com/workers/
+docs_url: https://developers.cloudflare.com/workers/wrangler/
+install_command: npm install -g wrangler
+category: Dev Tools
+tags: [cloudflare, workers, cli, edge, serverless, javascript, devops]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+problem_solved: |
+  Edge LLM proxies and Workers-based AI gateways need a local inner loop
+  that matches production. Wrangler runs a Workers preview, binds KV and
+  Durable Objects, and deploys from the repo so teams iterate on prompt
+  routing and auth at the edge instead of editing scripts in the dashboard.
+use_cases:
+  - Develop and preview an edge prompt-proxy Worker against local fixtures before deploy
+  - Bind KV, R2, or Durable Objects to an AI gateway Worker from wrangler.toml
+  - Deploy Workers that route model traffic by region from CI with wrangler deploy


### PR DESCRIPTION
## Add Wrangler, OpenFGA, SpiceDB, Casbin to catalog

Remainder batch after PR #506.

| Tool | Category | Why it belongs |
|---|---|---|
| Wrangler | Dev Tools | Cloudflare Workers CLI (`cloudflare/workers-sdk`, Apache-2.0) |
| OpenFGA | Dev Tools | Zanzibar-style authorization engine (`openfga/openfga`, Apache-2.0) |
| SpiceDB | Data | Zanzibar-inspired authorization database (`authzed/spicedb`, Apache-2.0) |
| Casbin | Dev Tools | ACL/RBAC/ABAC library (`casbin/casbin`, Apache-2.0, 20k stars) |

All four files passed `npx tsx scripts/validate-tool.ts` locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for SpiceDB, Casbin, OpenFGA, and Wrangler.
  * Included descriptions, installation details, documentation links, licensing, pricing, categories, tags, and practical use cases for each tool.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->