### PR TITLE
Add Pyserini, Anserini, Inspect AI, EvalPlus, FastGraphRAG to catalog

### DIFF
--- a/tools/llm/evalplus.yaml
+++ b/tools/llm/evalplus.yaml
@@ -1,0 +1,28 @@
+name: EvalPlus
+description: EvalPlus is a rigorous evaluation framework for LLM-generated code. It extends HumanEval and MBPP with extra tests (HumanEval+ and MBPP+) plus EvalPerf efficiency scoring so labs can catch false-pass solutions that official tests miss, used by Llama, Qwen, DeepSeek, and other coding models.
+tagline: Stricter HumanEval and MBPP tests for LLM-generated code
+
+github_url: https://github.com/evalplus/evalplus
+website_url: https://evalplus.github.io
+docs_url: https://github.com/evalplus/evalplus
+
+install_command: pip install evalplus
+
+category: LLM
+tags: [python, llm, evaluation, codegen, humaneval, mbpp, benchmarks]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Stock HumanEval and MBPP tests are thin, so coding models can pass with buggy or
+  inefficient solutions. EvalPlus adds large extra test suites (HumanEval+, MBPP+) and
+  EvalPerf efficiency scoring, with one-command generation and evaluation across vLLM
+  and other backends, so labs stop overestimating code quality from the original oracles.
+
+use_cases:
+  - Score a coding model on HumanEval+ instead of the original 164-test HumanEval set
+  - Compare pass rates on MBPP+ after filtering broken tasks from the base MBPP suite
+  - Measure code efficiency with EvalPerf rather than correctness alone
+  - Run generation, post-processing, and evaluation in one command across vLLM backends
+  - Benchmark new coder models against the public EvalPlus leaderboard

--- a/tools/llm/inspect-ai.yaml
+++ b/tools/llm/inspect-ai.yaml
@@ -1,0 +1,29 @@
+name: Inspect AI
+description: Inspect is an LLM evaluation framework from the UK AI Security Institute. It covers prompt engineering, tool use, multi-turn dialog, and model-graded scoring, with 200-plus built-in evals and a Python API so labs can run rigorous, reproducible model assessments without assembling custom harnesses.
+tagline: UK AISI framework for large language model evaluations
+
+github_url: https://github.com/UKGovernmentBEIS/inspect_ai
+website_url: https://inspect.aisi.org.uk/
+docs_url: https://inspect.aisi.org.uk/
+
+install_command: pip install inspect-ai
+
+category: LLM
+tags: [python, llm, evaluation, safety, scoring, agents, benchmarks]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Serious LLM evals need more than a chat loop. Teams must score tool use, multi-turn
+  dialog, and model-graded tasks across many models, then inspect traces. Inspect AI
+  gives a shared Python framework, CLI, and viewer from the UK AI Security Institute,
+  plus 200-plus ready evals, so safety and quality teams can run comparable assessments
+  without writing a one-off harness for every new elicitation or scoring technique.
+
+use_cases:
+  - Run 200-plus prebuilt Inspect evals against any supported model from a single CLI
+  - Score multi-turn tool-using agents with model-graded rubrics and trace inspection
+  - Compare prompt variants and elicitation strategies with a shared evaluation dataset
+  - Publish custom eval packages that other labs can install and rerun
+  - Track safety and capability regressions as models and system prompts change

--- a/tools/rag/anserini.yaml
+++ b/tools/rag/anserini.yaml
@@ -1,0 +1,27 @@
+name: Anserini
+description: Anserini is a Lucene toolkit for reproducible information retrieval research. It bridges academic IR experiments and production search with Lucene-based indexing, retrieval, and evaluation on standard collections, including BM25 and learned sparse methods used as first-stage retrievers in RAG pipelines.
+tagline: Lucene toolkit for reproducible information retrieval
+
+github_url: https://github.com/castorini/anserini
+website_url: http://anserini.io/
+docs_url: https://github.com/castorini/anserini
+
+category: RAG
+tags: [java, lucene, retrieval, ir, bm25, sparse, rag, search]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Academic IR papers and production Lucene search often live in different worlds, so
+  reproducing BM25 or learned-sparse baselines is painful. Anserini sits on Apache Lucene
+  with a fatjar CLI, prebuilt indexes, and evaluation tooling so researchers and RAG
+  engineers can run the same first-stage retrieval stack that Pyserini wraps in Python,
+  without assembling Lucene indexing, topics, and qrels from scratch.
+
+use_cases:
+  - Index a document collection with Lucene and run BM25 retrieval from a single fatjar
+  - Reproduce TREC and MS MARCO ranking experiments with bundled topics and qrels
+  - Provide a Lucene first-stage retriever that Pyserini and RAG pipelines can call
+  - Evaluate learned sparse retrieval methods against classic lexical baselines
+  - Spin up a REST search service over a prebuilt Anserini index for agent workflows

--- a/tools/rag/fast-graphrag.yaml
+++ b/tools/rag/fast-graphrag.yaml
@@ -1,0 +1,29 @@
+name: FastGraphRAG
+description: Fast GraphRAG is a promptable graph RAG framework for interpretable, agent-driven retrieval. It builds and incrementally updates a knowledge graph, explores it with PageRank, and runs at a fraction of Microsoft GraphRAG cost while remaining fully asynchronous and typed.
+tagline: Cheap, incremental graph RAG with PageRank exploration
+
+github_url: https://github.com/circlemind-ai/fast-graphrag
+website_url: https://circlemind.co
+docs_url: https://github.com/circlemind-ai/fast-graphrag
+
+install_command: pip install fast-graphrag
+
+category: RAG
+tags: [python, rag, knowledge-graph, graphrag, pagerank, agents, retrieval]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Classic GraphRAG is expensive and slow to index, and vector RAG hides why a chunk was
+  retrieved. Fast GraphRAG builds a queryable knowledge graph with domain prompts and
+  entity types, updates it incrementally, and explores it with PageRank so answers stay
+  interpretable. Reported indexing on a novel costs about 6x less than Microsoft GraphRAG,
+  which matters when the corpus keeps growing.
+
+use_cases:
+  - Index a long narrative or corpus into a knowledge graph with custom entity types
+  - Answer multi-hop questions by exploring entity relations instead of vector chunks
+  - Incrementally insert new documents without rebuilding the entire graph
+  - Debug retrieval by inspecting the graph of characters, places, and events
+  - Drop graph RAG into an existing agent pipeline with a typed async Python API

--- a/tools/rag/pyserini.yaml
+++ b/tools/rag/pyserini.yaml
@@ -1,0 +1,29 @@
+name: Pyserini
+description: Pyserini is a Python toolkit for reproducible information retrieval with sparse Lucene/Anserini indexes and dense Faiss embeddings. It ships prebuilt indexes, queries, qrels, and evaluation scripts so RAG teams can run first-stage retrieval on standard collections without rebuilding IR plumbing.
+tagline: Python IR toolkit for sparse and dense first-stage retrieval
+
+github_url: https://github.com/castorini/pyserini
+website_url: http://pyserini.io/
+docs_url: https://github.com/castorini/pyserini
+
+install_command: pip install pyserini
+
+category: RAG
+tags: [python, rag, retrieval, lucene, faiss, sparse, dense, ir]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building a first-stage retriever for RAG usually means wiring Lucene or Faiss by hand,
+  then hunting for indexes, queries, and relevance judgments. Pyserini wraps Anserini
+  sparse search and Faiss dense search in one Python package, with prebuilt indexes and
+  evaluation scripts for MS MARCO and other IR collections, so you can reproduce ranking
+  runs and plug retrieval into a multi-stage pipeline without reinventing IR infrastructure.
+
+use_cases:
+  - Run BM25 first-stage retrieval over MS MARCO or BEIR collections using prebuilt indexes
+  - Combine sparse Lucene hits with dense Faiss embeddings for hybrid RAG retrieval
+  - Reproduce published IR ranking runs with bundled queries, qrels, and evaluation scripts
+  - Serve retrieval over a REST API or MCP server for agentic search workflows
+  - Prototype multimodal image search with the optional Pyserini extras package


### PR DESCRIPTION
## Summary

Adds five catalog entries for retrieval and LLM evaluation:

- **Pyserini** (RAG) — Python IR toolkit wrapping Anserini/Lucene sparse search and Faiss dense retrieval, with prebuilt indexes.
- **Anserini** (RAG) — Lucene toolkit for reproducible information retrieval (Java fatjar; no pip package).
- **Inspect AI** (LLM) — UK AI Security Institute evaluation framework with 200+ built-in evals (`pip install inspect-ai`).
- **EvalPlus** (LLM) — Stricter HumanEval+/MBPP+ and EvalPerf scoring for LLM-generated code.
- **FastGraphRAG** (RAG) — Incremental, PageRank-based graph RAG from Circlemind (`pip install fast-graphrag`).

All files passed local `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for EvalPlus and Inspect AI, including descriptions, links, installation details, licensing, pricing, and evaluation use cases.
  * Added catalog entries for Anserini, Fast GraphRAG, and Pyserini, with retrieval capabilities, setup information, metadata, and supported RAG use cases.
* **Documentation**
  * Expanded the tool catalog with structured information to help users discover and compare LLM evaluation and retrieval tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->