### PR TITLE
Add LLM2Vec, Soup, OpenMAIC, Bleve, VLMEvalKit to catalog

### DIFF
--- a/tools/agent-frameworks/openmaic.yaml
+++ b/tools/agent-frameworks/openmaic.yaml
@@ -1,0 +1,24 @@
+name: OpenMAIC
+description: "Open Multi-Agent Interactive Classroom from Tsinghua MAIC: one-click immersive courses where multiple AI agents teach, quiz, and discuss with students through slides, voice, and Socratic dialogue."
+tagline: Multi-agent interactive classroom in one click
+
+github_url: https://github.com/THU-MAIC/OpenMAIC
+
+category: Agents
+tags: [agents, multi-agent, education, classroom, tsinghua, interactive]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Building an interactive AI classroom usually means wiring a frontend, an LLM backend,
+  slide generation, speech, and several agent roles by hand. OpenMAIC packages that stack
+  into a one-click multi-agent classroom: teacher, tutor, and peer agents run a live
+  lesson with slides and Socratic dialogue so educators and researchers can ship an
+  immersive learning experience without assembling the orchestration themselves.
+
+use_cases:
+  - "Spin up a multi-agent classroom where a teacher agent lectures and tutor agents answer student questions live"
+  - "Generate interactive courses with slides, voice, and Socratic dialogue from a topic in one click"
+  - "Research multi-agent teaching strategies by swapping agent roles, persistence, and video-export profiles"
+  - "Self-host an OpenMAIC classroom with Docker Compose for campus or lab deployments"

--- a/tools/fine-tuning/soup.yaml
+++ b/tools/fine-tuning/soup.yaml
@@ -1,0 +1,27 @@
+name: Soup
+description: "A YAML-first CLI for the post-training stack: it doctors data, picks a method, writes configs, and fine-tunes LLMs including layer streaming so an 8B model can train on a 4 GB laptop GPU."
+tagline: Fine-tune LLMs from one YAML, even on a 4 GB GPU
+
+github_url: https://github.com/MakazhanAlpamys/Soup
+website_url: https://trysoup.dev
+docs_url: https://trysoup.dev/docs/getting-started
+install_command: pip install "soup-cli[train]"
+
+category: Fine-tuning
+tags: [python, fine-tuning, lora, dpo, yaml, llm, cli, quantization]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Fine-tuning still means juggling Axolotl, Unsloth, or LLaMA-Factory configs, guessing
+  learning rates, and failing when the base model does not fit in VRAM. Soup writes the
+  config from your data, selects SFT/DPO/ORPO/SimPO/KTO, gates every save with a ship
+  verdict, and can stream frozen layers from RAM or NVMe so Llama-3.1-8B LoRA trains on
+  a 4 GB card instead of requiring a datacenter GPU.
+
+use_cases:
+  - "Fine-tune Llama or Qwen with LoRA from a single soup.yaml on a laptop GPU using layer streaming"
+  - "Migrate an Axolotl or LLaMA-Factory config into Soup and run SFT or DPO without rewriting hyperparameters"
+  - "Run soup data doctor and soup ship to catch silent training failures and refuse a model that breaks general knowledge"
+  - "Serve adapters with an OpenAI-compatible Soup server after training, including GGUF and vLLM export paths"

--- a/tools/llm/vlmevalkit.yaml
+++ b/tools/llm/vlmevalkit.yaml
@@ -1,0 +1,26 @@
+name: VLMEvalKit
+description: "Open-source toolkit for evaluating large vision-language models with one-command runs across 220-plus LMMs and 80-plus benchmarks, powering the OpenVLM leaderboard with generation-based scoring."
+tagline: One-command evaluation for vision-language models
+
+github_url: https://github.com/open-compass/VLMEvalKit
+website_url: https://huggingface.co/spaces/opencompass/open_vlm_leaderboard
+docs_url: https://github.com/open-compass/VLMEvalKit
+
+category: LLM
+tags: [python, evaluation, vlm, multimodal, benchmark, leaderboard, llm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Comparing vision-language models means cloning a different eval repo per benchmark,
+  preparing datasets, and reconciling incompatible metrics. VLMEvalKit unifies 80-plus
+  multimodal benchmarks and 220-plus models behind one command, with generation-based
+  scoring, exact match and LLM answer extraction, plus distributed inference via vLLM
+  or LMDeploy so labs can reproduce OpenVLM leaderboard numbers without a custom harness.
+
+use_cases:
+  - "Run one-command eval of a new VLM on MMBench, MMMU, MathVista, OCRBench, and MMVet"
+  - "Compare open-source and API multimodal models on the OpenVLM leaderboard protocol"
+  - "Add a custom VLM to VLMEvalKit and submit results for the public OpenVLM leaderboard"
+  - "Speed up large or thinking-mode models with multi-node inference through vLLM or LMDeploy"

--- a/tools/rag/llm2vec.yaml
+++ b/tools/rag/llm2vec.yaml
@@ -1,0 +1,28 @@
+name: LLM2Vec
+description: "Converts decoder-only large language models into bidirectional text encoders via bidirectional attention, masked next-token prediction, and unsupervised contrastive learning, producing dense embeddings for retrieval and similarity search."
+tagline: Turn decoder-only LLMs into powerful text encoders
+
+github_url: https://github.com/McGill-NLP/llm2vec
+website_url: https://mcgill-nlp.github.io/llm2vec/
+docs_url: https://mcgill-nlp.github.io/llm2vec/tutorial
+install_command: pip install llm2vec
+
+category: RAG
+tags: [python, embeddings, rag, encoder, contrastive, retrieval, llm]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Decoder-only LLMs are trained for next-token generation, so they are weak bidirectional
+  encoders for retrieval, clustering, and semantic search. Teams either train a separate
+  embedding model or accept unidirectional representations. LLM2Vec is a three-step recipe
+  that unlocks bidirectional attention, continues training with masked next-token prediction,
+  then applies unsupervised contrastive learning so an existing LLM becomes a competitive
+  dense text encoder without a full embedding-model rebuild.
+
+use_cases:
+  - "Convert an open decoder-only LLM into a dense encoder and index documents for RAG retrieval"
+  - "Train unsupervised contrastive embeddings from an LLM checkpoint for semantic search and clustering"
+  - "Benchmark LLM-derived encoders against dedicated embedding models on retrieval and NLU tasks"
+  - "Swap a frozen LLM2Vec encoder into an existing vector search pipeline without changing the rest of the stack"

--- a/tools/vector-databases/bleve.yaml
+++ b/tools/vector-databases/bleve.yaml
@@ -1,0 +1,26 @@
+name: Bleve
+description: "A Go indexing library for full-text, numeric, geo-spatial, and vector search with a single API, used to embed hybrid retrieval inside Go services without standing up a separate search cluster."
+tagline: Text, geo, and vector indexing for Go
+
+github_url: https://github.com/blevesearch/bleve
+docs_url: https://blevesearch.com/
+install_command: go install github.com/blevesearch/bleve/v2/cmd/bleve@latest
+
+category: Vector DB
+tags: [go, search, vector, full-text, indexing, hybrid, geo]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Go services that need search often add Elasticsearch or a remote vector database just
+  to index text and embeddings, adding ops cost and latency. Bleve is an embeddable Go
+  library that indexes text, numbers, geo, and vectors in-process so you can run hybrid
+  keyword-plus-vector retrieval next to the application without operating a separate
+  search cluster.
+
+use_cases:
+  - "Embed full-text and vector search inside a Go API so RAG or product search stays in-process"
+  - "Build hybrid keyword plus kNN retrieval over documents stored with Bleve indexes"
+  - "Index geo and numeric fields alongside embeddings for location-aware search in Go services"
+  - "Prototype search locally with the bleve CLI, then ship the same index format in production"


### PR DESCRIPTION
## Summary

Add 5 tools to the Agentic AI For Good catalog:

- **LLM2Vec** (RAG) — McGill NLP recipe to convert decoder-only LLMs into bidirectional text encoders (1.7k stars, MIT, `pip install llm2vec`)
- **Soup** (Fine-tuning) — YAML-first post-training CLI with layer streaming for 8B LoRA on a 4 GB GPU (5.3k stars, Apache-2.0, `pip install "soup-cli[train]"`). Distinct from Beautiful Soup.
- **OpenMAIC** (Agents) — Tsinghua MAIC open multi-agent interactive classroom (31k stars, MIT)
- **Bleve** (Vector DB) — Go library for full-text, geo, and vector indexing (11k stars, Apache-2.0)
- **VLMEvalKit** (LLM) — OpenCompass toolkit for evaluating vision-language models; powers the OpenVLM leaderboard (4.4k stars, Apache-2.0)

All files passed local `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for OpenMAIC, Soup, VLMEvalKit, LLM2Vec, and Bleve.
  * Added descriptions, links, licensing, pricing, installation details, categories, tags, and use cases for each tool.
  * Added coverage for interactive multi-agent classrooms, post-training workflows, vision-language evaluation, embedding generation, and vector search capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->