### PR TITLE
Add NVIDIA Merlin, NVTabular, HugeCTR, Gatus, OpenCost to catalog

### DIFF
--- a/tools/fine-tuning/hugectr.yaml
+++ b/tools/fine-tuning/hugectr.yaml
@@ -1,0 +1,25 @@
+name: HugeCTR
+description: "NVIDIA GPU framework for high-efficiency click-through-rate model training, optimized for large embedding tables and multi-GPU CTR workloads in the Merlin recommender stack."
+tagline: GPU CTR training for large embedding tables
+
+github_url: https://github.com/NVIDIA-Merlin/HugeCTR
+docs_url: https://nvidia-merlin.github.io/HugeCTR/master/hugectr_user_guide.html
+
+category: Fine-tuning
+tags: [cuda, gpu, ctr, recommender, nvidia, embeddings, training]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Click-through models need enormous embedding tables that do not fit a single
+  GPU and train slowly in generic TensorFlow or PyTorch loops. HugeCTR is a
+  dedicated GPU CTR trainer with model-parallel embeddings, NCCL communication,
+  and Merlin integration so teams can train Wide-and-Deep style recommenders at
+  high throughput without hand-rolling embedding sharding.
+
+use_cases:
+  - "Train CTR models with multi-GPU model-parallel embeddings on NVIDIA hardware"
+  - "Run HugeCTR inside a Merlin container after NVTabular feature engineering"
+  - "Benchmark GPU CTR throughput against TensorFlow recommenders on the same click logs"
+  - "Export trained HugeCTR models into Merlin inference for production ranking"

--- a/tools/fine-tuning/nvidia-merlin.yaml
+++ b/tools/fine-tuning/nvidia-merlin.yaml
@@ -1,0 +1,27 @@
+name: NVIDIA Merlin
+description: "Open-source NVIDIA library for end-to-end GPU-accelerated recommender systems, covering feature engineering, deep learning training, and production inference in NGC containers."
+tagline: GPU-accelerated recommender systems, end to end
+
+github_url: https://github.com/NVIDIA-Merlin/Merlin
+website_url: https://developer.nvidia.com/nvidia-merlin
+docs_url: https://nvidia-merlin.github.io/Merlin/stable/README.html
+
+category: Fine-tuning
+tags: [python, gpu, recommender, nvidia, training, inference, recsys]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Recommender pipelines split feature engineering, training, and serving across CPU
+  libraries that choke on terabyte click logs and then fail to match training
+  preprocessing at inference. NVIDIA Merlin is an end-to-end GPU stack (NVTabular,
+  HugeCTR, Merlin Models, Triton) so teams can preprocess, train CTR models, and
+  serve on NVIDIA GPUs from one containerized workflow instead of gluing Spark,
+  TensorFlow, and a separate feature store.
+
+use_cases:
+  - "Train GPU-accelerated click-through models on terabyte-scale session and item logs"
+  - "Run NVTabular feature engineering and HugeCTR training inside a single Merlin NGC container"
+  - "Serve recommender inference on NVIDIA Triton with the same preprocessing used at train time"
+  - "Prototype a recsys pipeline on GPU without assembling separate ETL, training, and serving stacks"

--- a/tools/fine-tuning/nvtabular.yaml
+++ b/tools/fine-tuning/nvtabular.yaml
@@ -1,0 +1,27 @@
+name: NVTabular
+description: "GPU-accelerated feature engineering and preprocessing library for tabular data, built to manipulate terabyte-scale datasets used to train deep learning recommender systems."
+tagline: Terabyte-scale tabular feature engineering on GPU
+
+github_url: https://github.com/NVIDIA-Merlin/NVTabular
+docs_url: https://nvidia-merlin.github.io/NVTabular/stable/Introduction.html
+install_command: pip install nvtabular
+
+category: Fine-tuning
+tags: [python, gpu, feature-engineering, tabular, nvidia, recsys, preprocessing]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Recommender training datasets are often terabytes of click and session logs.
+  Pandas and Spark CPU pipelines take hours to compute categoricals, joins, and
+  normalizations, and the resulting features drift from what the serving path
+  applies. NVTabular runs those transforms on GPU with a high-level API so feature
+  engineering keeps up with GPU training and the same operators can be exported
+  into Merlin inference.
+
+use_cases:
+  - "Preprocess terabyte click logs into categorical and continuous features on GPU before CTR training"
+  - "Replace slow Pandas or Spark recsys ETL with NVTabular operators inside a Merlin workflow"
+  - "Export GPU feature pipelines so training-time transforms match Triton serving"
+  - "Iterate on tabular feature recipes for HugeCTR or Merlin Models without rewriting CUDA kernels"

--- a/tools/monitoring/gatus.yaml
+++ b/tools/monitoring/gatus.yaml
@@ -1,0 +1,27 @@
+name: Gatus
+description: "Automated, developer-oriented status page that monitors HTTP, TCP, DNS, and more, with alerting and incident support so teams can publish health without a commercial status vendor."
+tagline: Developer-oriented status page with alerting
+
+github_url: https://github.com/TwiN/gatus
+website_url: https://gatus.io
+docs_url: https://gatus.io/docs
+install_command: go install github.com/TwiN/gatus/v5@latest
+
+category: Monitoring
+tags: [go, monitoring, status-page, alerting, health-check, self-hosted]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Most status pages are SaaS products that hide checks behind a vendor, or
+  homegrown cron pings with no incident UX. Gatus is a self-hosted monitor and
+  status page: YAML-defined endpoints, conditions, alerting, and a public page
+  so developers can watch APIs, agent backends, and inference URLs and page
+  the right channel when a check fails.
+
+use_cases:
+  - "Publish a public status page for API and model-serving endpoints with YAML health checks"
+  - "Alert Slack or PagerDuty when an inference URL, TCP port, or DNS record fails conditions"
+  - "Self-host Gatus with Docker or Helm next to Kubernetes workloads that need uptime visibility"
+  - "Track incidents on developer-facing services without paying for a commercial status vendor"

--- a/tools/monitoring/opencost.yaml
+++ b/tools/monitoring/opencost.yaml
@@ -1,0 +1,26 @@
+name: OpenCost
+description: "CNCF open-source cost monitoring for Kubernetes workloads and cloud spend, with allocation by namespace, deployment, and label plus an optional MCP server for agent access to cost data."
+tagline: Kubernetes and cloud cost monitoring
+
+github_url: https://github.com/opencost/opencost
+website_url: https://opencost.io
+docs_url: https://www.opencost.io/docs/installation/install
+
+category: Monitoring
+tags: [kubernetes, cost, monitoring, cncf, finops, helm, mcp]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  GPU training jobs and inference services run on Kubernetes, but cloud bills
+  rarely show which namespace, model, or team spent the money. OpenCost allocates
+  in-cluster and cloud costs by workload so ML platform teams can see GPU and
+  CPU spend per deployment, and agents can query the same data through the
+  optional MCP server instead of scraping billing CSVs.
+
+use_cases:
+  - "Allocate Kubernetes CPU, memory, and GPU cost by namespace and deployment for ML workloads"
+  - "Install OpenCost with Helm and watch cloud spend next to cluster metrics"
+  - "Enable the OpenCost MCP server so coding agents can query cost allocation without a custom API"
+  - "Show FinOps dashboards that map training jobs and inference services to actual cloud cost"


### PR DESCRIPTION
## Summary

Add 5 tools to the Agentic AI For Good catalog:

- **NVIDIA Merlin** (Fine-tuning) — end-to-end GPU recommender stack (908 stars, Apache-2.0, NGC containers)
- **NVTabular** (Fine-tuning) — GPU tabular feature engineering for terabyte recsys data (1.1k stars, `pip install nvtabular`)
- **HugeCTR** (Fine-tuning) — GPU CTR training with model-parallel embeddings (1.0k stars, Apache-2.0)
- **Gatus** (Monitoring) — developer-oriented status page with alerting (12k stars, `go install github.com/TwiN/gatus/v5@latest`)
- **OpenCost** (Monitoring) — CNCF Kubernetes and cloud cost allocation, optional MCP server (6.7k stars, Helm)

All files passed local `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HugeCTR, NVIDIA Merlin, and NVTabular to the Fine-tuning catalog, covering GPU-accelerated recommendation training, feature engineering, and preprocessing.
  * Added Gatus to the Monitoring catalog for self-hosted service monitoring and status pages.
  * Added OpenCost to the Monitoring catalog for Kubernetes and cloud cost allocation, including ML workload visibility.
  * Catalog entries now include descriptions, links, installation details, licensing, tags, and representative use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->