### PR TITLE
Add SenseVoice, VoiceStudio, IndexTTS, Apache Paimon, Nessie to catalog

### DIFF
--- a/tools/data/apache-paimon.yaml
+++ b/tools/data/apache-paimon.yaml
@@ -1,0 +1,26 @@
+name: Apache Paimon
+description: "Lake format for a realtime lakehouse with Flink and Spark, supporting streaming and batch on the same tables so CDC and analytics share one storage layer."
+tagline: Realtime lakehouse format for Flink and Spark
+
+github_url: https://github.com/apache/paimon
+website_url: https://paimon.apache.org/
+docs_url: https://paimon.apache.org/docs/master/
+
+category: Data
+tags: [apache, lakehouse, streaming, flink, spark, data-lake, java]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Streaming CDC and batch analytics usually land in different stores, so feature
+  pipelines and training jobs read stale copies. Apache Paimon is a lake format
+  with changelog tables, primary keys, and Flink/Spark engines so the same
+  lakehouse table serves realtime updates and batch reads for ML feature stores
+  without a separate OLAP clone.
+
+use_cases:
+  - "Build a Flink CDC pipeline into Paimon tables and query the same data with Spark batch jobs"
+  - "Store changelog and primary-key lakehouse tables for ML feature freshness"
+  - "Unify streaming ingestion and lakehouse analytics without maintaining Kafka plus a warehouse copy"
+  - "Run streaming upserts into object storage for large-scale training and inference feature reads"

--- a/tools/data/nessie.yaml
+++ b/tools/data/nessie.yaml
@@ -1,0 +1,26 @@
+name: Nessie
+description: "Transactional catalog for data lakes with Git-like branches, commits, and tags so Iceberg and similar tables can be isolated, reviewed, and rolled back like code."
+tagline: Git-like transactions for the data lake
+
+github_url: https://github.com/projectnessie/nessie
+website_url: https://projectnessie.org
+docs_url: https://projectnessie.org/docs/
+
+category: Data
+tags: [data-lake, git, iceberg, catalog, versioning, java]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Data lake tables are hard to experiment on: a bad write lands on main, and
+  there is no branch or pull-request workflow for parquet. Nessie is a
+  transactional catalog with Git-like semantics so Iceberg (and similar) tables
+  can be branched, merged, and tagged, giving ML feature and analytics pipelines
+  isolated experiments and rollback instead of mutating production data in place.
+
+use_cases:
+  - "Branch an Iceberg catalog to try a feature-engineering job without writing to production tables"
+  - "Commit and tag lakehouse snapshots so training runs pin exact table versions"
+  - "Review and merge data changes with Git-like semantics before they hit the main catalog"
+  - "Run Nessie in Docker next to Spark or Flink as the transactional catalog for a data lake"

--- a/tools/other/indextts.yaml
+++ b/tools/other/indextts.yaml
@@ -1,0 +1,25 @@
+name: IndexTTS
+description: "Industrial-level zero-shot text-to-speech system with controllable timbre and emotion, aimed at efficient high-quality speech generation from a short speaker prompt."
+tagline: Controllable zero-shot industrial TTS
+
+github_url: https://github.com/index-tts/index-tts
+website_url: https://github.com/index-tts/index-tts
+docs_url: https://github.com/index-tts/index-tts
+
+category: Other
+tags: [tts, zero-shot, speech, python, voice, emotion]
+pricing: free
+is_open_source: true
+
+problem_solved: |
+  Zero-shot TTS that sounds production-ready usually needs a commercial API or
+  a slow research stack that is hard to run. IndexTTS is an industrial
+  controllable TTS system: clone a voice from a short prompt, steer emotion,
+  and generate speech efficiently with a uv-managed local install and web UI
+  so product teams can prototype dubbed or character voices without a vendor.
+
+use_cases:
+  - "Clone a speaker from a short reference clip and synthesize new lines in that timbre"
+  - "Control emotion in zero-shot TTS for characters, IVR, or audiobook narration"
+  - "Run the IndexTTS web UI locally with uv for interactive voice prototyping"
+  - "Batch-generate multilingual speech for video or game pipelines from text prompts"

--- a/tools/other/sensevoice.yaml
+++ b/tools/other/sensevoice.yaml
@@ -1,0 +1,26 @@
+name: SenseVoice
+description: "Open-source speech model for Mandarin, Cantonese, English, Japanese, and Korean ASR plus language ID, emotion recognition, and audio event detection, served through FunASR and Docker."
+tagline: Multilingual ASR with emotion and event detection
+
+github_url: https://github.com/QwenAudio/SenseVoice
+website_url: https://huggingface.co/spaces/FunAudioLLM/SenseVoice
+docs_url: https://github.com/QwenAudio/SenseVoice
+
+category: Other
+tags: [speech, asr, emotion, audio, multilingual, funasr, python]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Multilingual speech apps often need ASR, language ID, emotion, and audio-event
+  tags from separate models. SenseVoiceSmall does those tasks in one open
+  checkpoint for zh, yue, en, ja, and ko, with FunASR serving, VAD timestamps,
+  and Docker so teams can transcribe and classify audio without stitching
+  Whisper plus extra classifiers.
+
+use_cases:
+  - "Transcribe Mandarin, Cantonese, English, Japanese, or Korean audio with a single SenseVoiceSmall checkpoint"
+  - "Detect spoken language, emotion, and audio events alongside ASR in a call-center or meeting pipeline"
+  - "Serve SenseVoice through FunASR or Docker with GPU or CPU for an OpenAI-compatible speech endpoint"
+  - "Compose SenseVoice with FSMN-VAD and punctuation models for per-sentence timestamps and speaker labels"

--- a/tools/other/voicestudio.yaml
+++ b/tools/other/voicestudio.yaml
@@ -1,0 +1,26 @@
+name: VoiceStudio
+description: "Open-source, fully local ElevenLabs alternative for voice cloning, voice design, video dubbing, dictation, transcription, and audiobook creation across hundreds of languages."
+tagline: Local voice cloning, dubbing, and audiobooks
+
+github_url: https://github.com/debpalash/VoiceStudio
+website_url: https://voicestudio.sh
+docs_url: https://github.com/debpalash/VoiceStudio
+
+category: Other
+tags: [tts, voice-cloning, dubbing, local, speech, audiobook, self-hosted]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Production voice cloning and dubbing usually means sending audio to a hosted
+  API with per-character fees and data leaving the machine. VoiceStudio runs
+  cloning, design, dubbing, dictation, transcription, and audiobook generation
+  locally in 646 languages so creators keep voices and scripts on their own GPU
+  instead of an ElevenLabs-class SaaS.
+
+use_cases:
+  - "Clone a speaker locally and generate TTS without sending audio to a hosted voice API"
+  - "Dub video into another language with on-device voice design and speech generation"
+  - "Produce audiobooks and dictation workflows from a self-hosted VoiceStudio Docker container"
+  - "Run an OpenAI-compatible local /v1/audio/speech endpoint for apps that currently call ElevenLabs"


### PR DESCRIPTION
## Summary

Add 5 tools to the Agentic AI For Good catalog:

- **SenseVoice** (Other) — multilingual ASR plus emotion and audio events (9.2k stars, MIT)
- **VoiceStudio** (Other) — local ElevenLabs alternative for cloning, dubbing, and audiobooks (18k stars, AGPL-3.0)
- **IndexTTS** (Other) — industrial zero-shot controllable TTS (23k stars)
- **Apache Paimon** (Data) — realtime lakehouse format for Flink and Spark (3.4k stars, Apache-2.0)
- **Nessie** (Data) — Git-like transactional catalog for data lakes (1.5k stars, Apache-2.0)

All files passed local `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apache Paimon, Nessie, IndexTTS, SenseVoice, and VoiceStudio to the product catalog.
  * Included descriptions, links, categories, tags, pricing, licensing, and representative use cases for each listing.
  * Added discoverable entries for lakehouse data management, speech synthesis, multilingual speech recognition, and local voice tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->