### PR TITLE
Add Evidence, Lightdash, Manim, Elementary to catalog

### DIFF
--- a/tools/data/elementary.yaml
+++ b/tools/data/elementary.yaml
@@ -1,0 +1,27 @@
+name: Elementary
+description: "dbt-native data observability for analytics engineers: add tests and monitors on the warehouse in minutes, self-hosted or as a cloud service with lineage and anomaly alerts."
+tagline: dbt-native data observability
+
+github_url: https://github.com/elementary-data/elementary
+website_url: https://www.elementary-data.com/
+docs_url: https://docs.elementary-data.com/
+install_command: pip install elementary-data
+
+category: Data
+tags: [dbt, observability, data-quality, lineage, python, warehouse]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Warehouse pipelines fail silently: a dbt model succeeds while the data is
+  null, late, or drifted, and BI goes wrong. Elementary is dbt-native
+  observability so analytics engineers attach tests, anomaly monitors, and
+  lineage on the models they already run, with a report UI in minutes instead
+  of buying a separate data-quality platform.
+
+use_cases:
+  - "Add anomaly and freshness monitors to dbt models and see failures in an Elementary report"
+  - "Trace lineage from a broken dashboard metric back to the dbt model that produced it"
+  - "Self-host Elementary next to dbt Core or use Elementary Cloud for team alerting"
+  - "Catch silent schema and volume drifts in ML feature tables built with dbt"

--- a/tools/data/evidence.yaml
+++ b/tools/data/evidence.yaml
@@ -1,0 +1,27 @@
+name: Evidence
+description: "Business intelligence as code: build fast, interactive data visualizations from SQL and markdown that version with git instead of a click-ops BI tool."
+tagline: BI as code with SQL and markdown
+
+github_url: https://github.com/evidence-dev/evidence
+website_url: https://evidence.dev
+docs_url: https://docs.evidence.dev
+install_command: npm install @evidence-dev/evidence
+
+category: Data
+tags: [bi, sql, markdown, javascript, analytics, git, visualization]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Dashboards usually live in a GUI BI tool that cannot be reviewed in git and
+  drifts from the warehouse. Evidence treats reports as SQL plus markdown in
+  a code repo, so data teams render interactive charts from queries, review
+  them in pull requests, and publish static or hosted BI without dragging
+  tiles in a proprietary studio.
+
+use_cases:
+  - "Write markdown reports with SQL queries that render interactive charts for stakeholders"
+  - "Version BI pages in git and review metric changes in pull requests"
+  - "Publish a fast static or hosted data site from warehouse queries without a GUI BI vendor"
+  - "Let analytics engineers own dashboards in the same repo as dbt or SQL models"

--- a/tools/data/lightdash.yaml
+++ b/tools/data/lightdash.yaml
@@ -1,0 +1,25 @@
+name: Lightdash
+description: "Open-source agentic BI that sits on dbt: explore metrics as code, share dashboards, and let analysts ask questions at the speed of the warehouse rather than a semantic-layer GUI."
+tagline: Agentic BI on top of dbt
+
+github_url: https://github.com/lightdash/lightdash
+website_url: https://lightdash.com
+docs_url: https://docs.lightdash.com
+
+category: Data
+tags: [bi, dbt, analytics, metrics, dashboard, self-hosted]
+pricing: freemium
+is_open_source: true
+
+problem_solved: |
+  After dbt models land, teams still rebuild metrics in Looker or Tableau and
+  the two layers drift. Lightdash reads the dbt project as the semantic layer
+  so analysts explore, chart, and share from the same YAML metrics, with a
+  self-hosted or cloud app and an agentic querying path instead of maintaining
+  a second BI model.
+
+use_cases:
+  - "Explore dbt metrics and dimensions in a BI UI without rewriting a LookML layer"
+  - "Share self-serve dashboards that stay in sync with dbt model changes"
+  - "Self-host Lightdash next to a warehouse so analytics stays on your infrastructure"
+  - "Ask natural-language questions against dbt-defined metrics for faster analysis"

--- a/tools/other/manim.yaml
+++ b/tools/other/manim.yaml
@@ -1,0 +1,27 @@
+name: Manim
+description: "Animation engine for explanatory math videos, used to program precise diagrams, graphs, and scene-by-scene explanations as Python instead of timeline editors."
+tagline: Programmatic math animation in Python
+
+github_url: https://github.com/3b1b/manim
+website_url: https://www.manim.community/
+docs_url: https://docs.manim.community/
+install_command: pip install manimgl
+
+category: Other
+tags: [python, animation, math, visualization, video, education]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Explaining math and algorithms in video usually means drawing frames by hand
+  or fighting a motion-graphics timeline. Manim lets you write Python that
+  renders exact geometric scenes, so educators and ML explainers generate
+  3Blue1Brown-style animations from code and regenerate them when the math
+  changes.
+
+use_cases:
+  - "Render explanatory math videos where graphs, vectors, and formulas animate from Python"
+  - "Produce lecture clips that stay in sync with a codebase instead of a After Effects project"
+  - "Visualize algorithms and neural-net diagrams as programmatic scenes for talks or docs"
+  - "Teach linear algebra or calculus with reproducible animation scripts students can fork"


### PR DESCRIPTION
## Summary

Add 4 tools to the Agentic AI For Good catalog (remainder batch):

- **Evidence** (Data) — BI as code with SQL and markdown (6.9k stars, MIT, `npm install @evidence-dev/evidence`)
- **Lightdash** (Data) — agentic BI on dbt (6.1k stars)
- **Manim** (Other) — programmatic math animation (93k stars, MIT, `pip install manimgl`)
- **Elementary** (Data) — dbt-native data observability (2.4k stars, Apache-2.0, `pip install elementary-data`)

All files passed local `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Elementary, Evidence, Lightdash, and Manim.
  - Added descriptions, installation instructions, links, categories, tags, pricing details, licensing, and open-source status for each tool.
  - Added use cases highlighting data observability, code-based business intelligence, self-serve analytics, metric exploration, mathematical animation, and educational visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->