### PR TITLE
Add Infracost, Checkov, VictoriaLogs, Kepler, GoatCounter to catalog

### DIFF
--- a/tools/dev-tools/checkov.yaml
+++ b/tools/dev-tools/checkov.yaml
@@ -1,0 +1,28 @@
+name: Checkov
+description: Policy-as-code scanner that finds misconfigurations, CVEs, and secrets in Terraform, CloudFormation, Kubernetes, Helm, Docker, and serverless templates before they reach production. Checkov runs in CI so GPU clusters, vector databases, and model-serving stacks are not deployed with open security groups or leaked keys.
+tagline: Prevent IaC misconfigurations and secrets before deploy
+
+github_url: https://github.com/bridgecrewio/checkov
+website_url: https://www.checkov.io
+docs_url: https://www.checkov.io/1.Welcome/What%20is%20Checkov.html
+
+install_command: pip install checkov
+
+category: Dev Tools
+tags: [security, iac, terraform, kubernetes, policy-as-code, scanning, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  ML infrastructure YAML and Terraform often ship with public buckets, 0.0.0.0
+  security groups, privileged pods, and hardcoded API keys. Those land in GPU
+  clusters because review cannot catch every graph. Checkov scans IaC, images,
+  and packages against hundreds of built-in policies in CI so misconfigurations
+  fail the build instead of production.
+
+use_cases:
+  - Scan Terraform for GPU cluster networking, IAM, and storage misconfigurations in pull requests
+  - Fail CI when Kubernetes manifests grant privileged containers or open ClusterRoles
+  - Detect secrets and CVE-laden base images in Dockerfiles used for training jobs
+  - Enforce CIS and custom policies across Helm charts for model-serving stacks

--- a/tools/dev-tools/infracost.yaml
+++ b/tools/dev-tools/infracost.yaml
@@ -1,0 +1,28 @@
+name: Infracost
+description: Open-source CLI that estimates cloud costs from Terraform, Terragrunt, Pulumi, and OpenTofu plan diffs in pull requests. Infracost shows engineers and AI coding agents the dollar impact of IaC changes before merge, so GPU clusters and model-serving stacks stay on budget.
+tagline: Cloud cost estimates for Terraform in pull requests
+
+github_url: https://github.com/infracost/infracost
+website_url: https://infracost.io
+docs_url: https://www.infracost.io/docs/
+
+install_command: brew install infracost
+
+category: Dev Tools
+tags: [finops, terraform, iac, cloud-cost, ci-cd, open-source]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  GPU nodes, vector databases, and model-serving stacks are easy to over-provision
+  in Terraform, and cost only shows up on the cloud bill after apply. Infracost
+  parses plan JSON, prices resources against cloud catalogs, and posts a PR comment
+  with the monthly delta so engineers and coding agents catch a $10k GPU mistake
+  before it ships.
+
+use_cases:
+  - Comment monthly cost deltas on Terraform PRs that add GPU node pools or inference autoscaling
+  - Compare AWS, GCP, and Azure prices for the same training cluster before choosing a region
+  - Block CI when an IaC change would raise monthly spend above a FinOps threshold
+  - Give AI coding agents cost context so generated Terraform does not silently add expensive SKUs

--- a/tools/monitoring/kepler.yaml
+++ b/tools/monitoring/kepler.yaml
@@ -1,0 +1,27 @@
+name: Kepler
+description: Kubernetes-based Efficient Power Level Exporter that reports energy consumption at container, pod, and node level as Prometheus metrics. Kepler uses eBPF and RAPL to estimate watts so ML teams can track GPU and CPU energy of training and inference workloads.
+tagline: Prometheus exporter for Kubernetes energy use
+
+github_url: https://github.com/sustainable-computing-io/kepler
+website_url: https://sustainable-computing.io
+docs_url: https://sustainable-computing.io
+
+install_command: helm install kepler oci://quay.io/sustainable_computing_io/charts/kepler --namespace kepler --create-namespace
+
+category: Monitoring
+tags: [energy, kubernetes, prometheus, ebpf, sustainability, gpu, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Cloud bills show dollars, not watts, so teams cannot tell which training job
+  or inference pod is burning energy. Kepler estimates power at node, pod, and
+  container granularity from eBPF and RAPL, then exports Prometheus metrics so
+  ML ops can attribute GPU and CPU joules to workloads and cut waste.
+
+use_cases:
+  - Export per-pod watt metrics for GPU training jobs into Prometheus and Grafana
+  - Attribute cluster energy to inference vs batch so FinOps and sustainability reports match
+  - Alert when a runaway agent or training pod spikes node power beyond a budget
+  - Compare energy of model-serving deployments after a quantization or batch-size change

--- a/tools/monitoring/victorialogs.yaml
+++ b/tools/monitoring/victorialogs.yaml
@@ -1,0 +1,26 @@
+name: VictoriaLogs
+description: Fast logs database from the VictoriaMetrics team that ingests and queries terabytes of logs with LogsQL. VictoriaLogs is a lightweight Loki alternative for training-job logs, inference traces, and agent stdout without the operational cost of Elasticsearch.
+tagline: Fast, easy logs database for terabyte-scale ingest
+
+github_url: https://github.com/VictoriaMetrics/VictoriaLogs
+website_url: https://docs.victoriametrics.com/victorialogs/
+docs_url: https://docs.victoriametrics.com/victorialogs/
+
+category: Monitoring
+tags: [logs, observability, loki-alternative, logsql, monitoring, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Training jobs, agents, and inference servers emit huge unstructured logs that
+  Elasticsearch is expensive to run and Loki can struggle to query at terabyte
+  scale. VictoriaLogs stores logs with high compression, accepts Elasticsearch,
+  Loki, Datadog, and syslog protocols, and answers LogsQL filters so ML ops can
+  debug GPU OOMs and agent traces without a heavy ELK stack.
+
+use_cases:
+  - Store and search multi-terabyte training and inference logs with LogsQL instead of Elasticsearch
+  - Ingest Loki and Elasticsearch-compatible log streams from Kubernetes ML workloads
+  - Debug GPU OOM and agent failures by filtering structured fields across days of logs
+  - Run a single-node or clustered logs backend beside VictoriaMetrics for full observability

--- a/tools/other/goatcounter.yaml
+++ b/tools/other/goatcounter.yaml
@@ -1,0 +1,26 @@
+name: GoatCounter
+description: Privacy-friendly web analytics that counts visitors without cookies or personal data. GoatCounter is a lightweight, self-hostable alternative to Google Analytics for product sites and docs, with a hosted option and an EUPL-licensed Go server.
+tagline: Easy web analytics without tracking personal data
+
+github_url: https://github.com/arp242/goatcounter
+website_url: https://www.goatcounter.com
+docs_url: https://www.goatcounter.com/help
+
+category: Other
+tags: [analytics, privacy, self-hosted, golang, web, open-source]
+pricing: freemium
+is_open_source: true
+license: EUPL-1.2
+
+problem_solved: |
+  Product and docs sites still need page-view counts, but Google Analytics
+  drops cookies, ships personal data to third parties, and is blocked by many
+  browsers. GoatCounter records counts without personal data, runs as a small
+  Go binary you can self-host, or as a hosted service, so teams get traffic
+  numbers without a tracking pixel stack.
+
+use_cases:
+  - Track docs and changelog traffic for an AI product without cookies or a cookie banner
+  - Self-host analytics next to a marketing site when GDPR rules out Google Analytics
+  - Count unique visitors to an MCP or catalog landing page with a tiny JS snippet
+  - Replace a blocked analytics script with a privacy-first counter that still shows referrers


### PR DESCRIPTION
## Add 5 tools to the catalog

- **Infracost** (Dev Tools) — cloud cost estimates for Terraform/Pulumi/OpenTofu in PRs (infracost/infracost, Apache-2.0, 12.5k★)
- **Checkov** (Dev Tools) — IaC/policy-as-code scanner for Terraform, K8s, Helm, Docker (bridgecrewio/checkov, Apache-2.0, 9.0k★)
- **VictoriaLogs** (Monitoring) — logs database from the VictoriaMetrics team (VictoriaMetrics/VictoriaLogs, Apache-2.0, 2.2k★)
- **Kepler** (Monitoring) — Kubernetes energy exporter as Prometheus metrics (sustainable-computing-io/kepler, Apache-2.0, 1.6k★)
- **GoatCounter** (Other) — privacy-friendly web analytics without personal data (arp242/goatcounter, EUPL-1.2, 5.9k★)

All files passed local `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Checkov for scanning infrastructure-as-code, container images, and packages for misconfigurations and secrets.
  - Added Infracost for estimating cloud costs from Terraform plans and reporting cost changes.
  - Added Kepler for monitoring Kubernetes power and energy usage.
  - Added VictoriaLogs for scalable log storage, ingestion, and troubleshooting.
  - Added GoatCounter for privacy-friendly, cookie-free website analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->