### PR TITLE
Add Velociraptor, MISP, Scaphandre, Ackee to catalog

### DIFF
--- a/tools/monitoring/scaphandre.yaml
+++ b/tools/monitoring/scaphandre.yaml
@@ -1,0 +1,25 @@
+name: Scaphandre
+description: Energy consumption metrology agent that exposes per-process and host power metrics for Linux and Windows. Scaphandre reads RAPL and related sensors and exports Prometheus-compatible metrics so teams can attribute watts to training jobs, agents, and services.
+tagline: Energy metrology agent for process-level watts
+
+github_url: https://github.com/hubblo-org/scaphandre
+website_url: https://hubblo-org.github.io/scaphandre-documentation/
+docs_url: https://hubblo-org.github.io/scaphandre-documentation/
+
+category: Monitoring
+tags: [energy, prometheus, sustainability, rapl, metrics, linux, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Host-level power meters cannot tell which Python training process or agent
+  is burning joules on a shared box. Scaphandre samples RAPL and maps watts
+  to processes, then serves Prometheus metrics so ML ops can see energy per
+  job without a Kubernetes-only exporter.
+
+use_cases:
+  - Export per-process watt metrics from a Linux GPU box into Prometheus
+  - Compare energy of two training runs after a batch-size or precision change
+  - Attribute power on a shared workstation to agents, Jupyter, and idle daemons
+  - Feed sustainability dashboards when Kepler is not running because the host is bare metal

--- a/tools/other/ackee.yaml
+++ b/tools/other/ackee.yaml
@@ -1,0 +1,26 @@
+name: Ackee
+description: Self-hosted, Node.js analytics tool that counts visits without cookies or personal data. Ackee stores anonymized traffic in MongoDB and exposes a GraphQL API and dashboard for product and docs sites that cannot use Google Analytics.
+tagline: Self-hosted privacy-first analytics for the web
+
+github_url: https://github.com/electerious/Ackee
+website_url: https://ackee.electerious.com
+docs_url: https://docs.ackee.electerious.com
+
+category: Other
+tags: [analytics, privacy, self-hosted, nodejs, graphql, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Teams that want first-party analytics without Google cookies often land on
+  hosted SaaS they cannot keep in-region. Ackee is a small Node server plus
+  tracker script that stores anonymized page views in your MongoDB, with a
+  GraphQL API for custom dashboards, so docs and product sites get counts
+  under your own infra.
+
+use_cases:
+  - Self-host docs analytics for an AI product without cookies or a third-party pixel
+  - Query anonymized page views via GraphQL to build an internal traffic dashboard
+  - Run Ackee on Docker or Vercel next to a marketing site that must stay GDPR-clean
+  - Replace a blocked Google Analytics snippet on an MCP or catalog landing page

--- a/tools/other/misp.yaml
+++ b/tools/other/misp.yaml
@@ -1,0 +1,26 @@
+name: MISP
+description: Open-source threat intelligence platform for collecting, storing, and sharing security indicators and malware details. MISP helps SOC and ML platform teams exchange IOCs, correlate incidents, and keep blocklists current without a closed intel vendor.
+tagline: Open threat intelligence sharing platform
+
+github_url: https://github.com/MISP/MISP
+website_url: https://www.misp-project.org
+docs_url: https://www.misp-project.org/documentation/
+
+category: Other
+tags: [threat-intelligence, security, ioc, sharing, malware, open-source]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  AI platforms get probed, scraped, and abused with the same IPs, keys, and
+  malware families, but intel stays in tickets and vendor PDFs. MISP stores
+  structured events and attributes, shares them with trusted communities, and
+  feeds blocklists so GPU clusters and public APIs can block known bad
+  indicators instead of rediscovering them per incident.
+
+use_cases:
+  - Share IOCs for GPU-node malware and crypto-miners with a trusted security community
+  - Correlate phishing and API-abuse events against a structured MISP attribute graph
+  - Feed blocklists for inference endpoints from MISP events instead of ad-hoc spreadsheets
+  - Store malware samples and sightings from training-cluster incidents for later hunts

--- a/tools/other/velociraptor.yaml
+++ b/tools/other/velociraptor.yaml
@@ -1,0 +1,26 @@
+name: Velociraptor
+description: Endpoint visibility and digital forensics platform that collects, hunts, and investigates host telemetry at scale. Velociraptor uses VQL to query processes, files, and artifacts across a fleet so security and ML ops teams can hunt leaked keys, GPU miners, and compromised training nodes.
+tagline: Hunt and collect endpoint telemetry with VQL
+
+github_url: https://github.com/Velocidex/velociraptor
+website_url: https://docs.velociraptor.app
+docs_url: https://docs.velociraptor.app
+
+category: Other
+tags: [dfir, endpoint, security, forensics, vql, hunting, open-source]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Compromised GPU nodes, stolen cloud keys, and silent miners are hard to find
+  with SSH and ad-hoc scripts across a heterogeneous fleet. Velociraptor deploys
+  a lightweight client, then runs VQL hunts and artifact collections from a
+  central server so IR and platform teams can ask the same question of every
+  training host and get structured answers.
+
+use_cases:
+  - Hunt leaked API keys and unexpected GPU processes across an ML workstation fleet
+  - Collect forensic artifacts from a compromised training or inference node without rebuilding it
+  - Schedule VQL hunts for crypto-miners or reverse shells on Kubernetes worker hosts
+  - Build an endpoint inventory of CUDA drivers, containers, and SSH keys for incident response


### PR DESCRIPTION
## Add 4 tools to the catalog

- **Velociraptor** (Other) — endpoint visibility and DFIR hunts via VQL (Velocidex/velociraptor, AGPL-3.0, 4.2k★)
- **MISP** (Other) — open threat intelligence sharing platform (MISP/MISP, AGPL-3.0, 6.5k★)
- **Scaphandre** (Monitoring) — energy metrology agent for process-level watts (hubblo-org/scaphandre, Apache-2.0, 2.0k★)
- **Ackee** (Other) — self-hosted privacy-first Node.js analytics (electerious/Ackee, MIT, 4.7k★)

All files passed local `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Scaphandre to the tool catalog for monitoring host and process-level energy consumption.
  - Added Ackee, a self-hosted, privacy-focused analytics solution.
  - Added MISP, an open-source threat intelligence platform.
  - Added Velociraptor, an endpoint visibility and digital forensics platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->