### PR TITLE
Add Healthchecks, Tyk, git-secrets, Amass, ClamAV to catalog

### DIFF
--- a/tools/dev-tools/amass.yaml
+++ b/tools/dev-tools/amass.yaml
@@ -1,0 +1,27 @@
+name: Amass
+description: OWASP in-depth attack-surface mapping and asset discovery tool. Amass enumerates subdomains, IPs, and related infrastructure from OSINT so security teams can see which APIs, docs hosts, and cloud assets an AI product actually exposes.
+tagline: OWASP attack-surface mapping and asset discovery
+
+github_url: https://github.com/owasp-amass/amass
+website_url: https://owasp.org/www-project-amass/
+docs_url: https://github.com/owasp-amass/amass/blob/master/doc/user_guide.md
+
+install_command: brew install amass
+
+category: Dev Tools
+tags: [osint, recon, attack-surface, subdomains, security, owasp, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Public model demos, staging APIs, and forgotten subdomains expand the
+  attack surface of an AI product faster than inventory spreadsheets.
+  Amass maps DNS, certificates, and OSINT sources into a graph of assets
+  so security teams can find exposed inference endpoints before attackers do.
+
+use_cases:
+  - Enumerate subdomains for an AI product before an external pentest
+  - Discover forgotten staging LLM APIs and docs hosts from certificate transparency
+  - Build an asset graph of cloud IPs tied to a company domain
+  - Track attack-surface drift after launching a new inference or MCP endpoint

--- a/tools/dev-tools/git-secrets.yaml
+++ b/tools/dev-tools/git-secrets.yaml
@@ -1,0 +1,27 @@
+name: git-secrets
+description: AWS Labs git hook that scans commits, messages, and --no-ff merges for secrets matching configurable patterns. git-secrets blocks AWS keys and custom tokens from landing in history so training repos and agent configs do not leak credentials.
+tagline: Prevent committing secrets to a git repository
+
+github_url: https://github.com/awslabs/git-secrets
+website_url: https://github.com/awslabs/git-secrets
+docs_url: https://github.com/awslabs/git-secrets
+
+install_command: brew install git-secrets
+
+category: Dev Tools
+tags: [git, secrets, security, aws, pre-commit, hooks, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  LLM apps and training repos constantly grow AWS keys, OpenAI tokens, and
+  .env files that git add -A will commit. git-secrets installs a client-side
+  hook that matches known AWS patterns plus your own regexes and rejects the
+  commit, stopping leaked keys before they reach GitHub.
+
+use_cases:
+  - Install a pre-commit hook that blocks AWS access keys in ML repositories
+  - Add custom patterns for OpenAI, Anthropic, and Hugging Face tokens
+  - Scan an existing git history for accidentally committed cloud credentials
+  - Enforce secret patterns on merge commits so force-pushed keys still get caught

--- a/tools/dev-tools/tyk.yaml
+++ b/tools/dev-tools/tyk.yaml
@@ -1,0 +1,24 @@
+name: Tyk
+description: Open-source API gateway that fronts REST, GraphQL, and gRPC services with auth, rate limits, and analytics. Tyk sits in front of model-serving and agent APIs so teams can issue keys, cap tokens, and observe traffic without rewriting every inference service.
+tagline: Open-source API gateway for auth, rate limits, and analytics
+
+github_url: https://github.com/TykTechnologies/tyk
+website_url: https://tyk.io
+docs_url: https://tyk.io/docs/
+
+category: Dev Tools
+tags: [api-gateway, graphql, grpc, rate-limiting, auth, open-source]
+pricing: freemium
+is_open_source: true
+
+problem_solved: |
+  Model and agent APIs need API keys, quotas, and request logs, but bolting
+  that onto every FastAPI service duplicates auth bugs. Tyk terminates traffic
+  as a gateway, applies policies and rate limits, and exposes analytics so
+  inference endpoints stay protected and measurable from one control plane.
+
+use_cases:
+  - Put API keys and per-key rate limits in front of a self-hosted LLM or embedding API
+  - Route GraphQL and REST agent backends through one gateway with request analytics
+  - Cap burst traffic to GPU inference so a noisy client cannot starve production
+  - Publish a developer portal for internal ML APIs without rewriting each service

--- a/tools/monitoring/healthchecks.yaml
+++ b/tools/monitoring/healthchecks.yaml
@@ -1,0 +1,25 @@
+name: Healthchecks
+description: Cron job monitoring that pings when a scheduled task is late or silent. Healthchecks is a self-hostable Django app and hosted service that watches backups, ETL, and training jobs via simple HTTP pings so missed runs page a human instead of failing quietly.
+tagline: Dead-man's switch for cron, backups, and jobs
+
+github_url: https://github.com/healthchecks/healthchecks
+website_url: https://healthchecks.io
+docs_url: https://healthchecks.io/docs/
+
+category: Monitoring
+tags: [cron, monitoring, alerting, self-hosted, django, jobs, open-source]
+pricing: freemium
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Nightly embedding jobs, model exports, and backups fail silently when cron
+  never starts or a host is down. Healthchecks expects a periodic ping and
+  alerts Slack, email, or PagerDuty when the ping is late, so ML ops learn
+  about a missed training or ETL run without scraping logs after the fact.
+
+use_cases:
+  - Alert when a nightly embedding or dataset-sync cron job misses its ping window
+  - Watch backup jobs for vector databases and model registries from a single dashboard
+  - Self-host cron monitoring next to an air-gapped training cluster
+  - Page on-call when a weekly fine-tune or evaluation pipeline does not check in

--- a/tools/other/clamav.yaml
+++ b/tools/other/clamav.yaml
@@ -1,0 +1,27 @@
+name: ClamAV
+description: Open-source antivirus engine that scans files, archives, and mail for malware signatures. ClamAV is used as a gateway scanner so datasets, user uploads, and model artifacts are checked before they land on GPU nodes or shared storage.
+tagline: Open-source antivirus engine for files and gateways
+
+github_url: https://github.com/Cisco-Talos/clamav
+website_url: https://www.clamav.net
+docs_url: https://docs.clamav.net
+
+install_command: brew install clamav
+
+category: Other
+tags: [antivirus, malware, scanning, security, gateway, open-source]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Training data, notebook uploads, and model zips can carry malware that
+  commercial AV never sees on a Linux GPU box. ClamAV provides a signature
+  engine and clamd daemon you can run at ingest so untrusted files are
+  scanned before they reach shared NFS, object storage, or a training node.
+
+use_cases:
+  - Scan user-uploaded datasets and notebooks before they reach a training cluster
+  - Run clamd at an S3 or NFS ingest gateway for model artifacts
+  - Check email and ticket attachments in a security mailbox for malware
+  - Add a CI step that fails if a release tarball matches ClamAV signatures


### PR DESCRIPTION
## Add 5 tools to the catalog

- **Healthchecks** (Monitoring) — cron/job dead-man's switch (healthchecks/healthchecks, BSD-3-Clause, 10.3k★)
- **Tyk** (Dev Tools) — open-source API gateway (TykTechnologies/tyk, 10.8k★)
- **git-secrets** (Dev Tools) — AWS Labs git hook that blocks secrets (awslabs/git-secrets, Apache-2.0, 13.4k★)
- **Amass** (Dev Tools) — OWASP attack-surface mapping (owasp-amass/amass, Apache-2.0, 15.1k★)
- **ClamAV** (Other) — open-source antivirus engine (Cisco-Talos/clamav, GPL-2.0, 7.2k★)

All files passed local `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Tools**
  - Added catalog entries for Amass, git-secrets, Tyk, Healthchecks, and ClamAV.
  - Added searchable metadata including descriptions, categories, tags, licensing, pricing, documentation links, and installation guidance.
  - Documented practical use cases for asset discovery, credential protection, API management, job monitoring, and malware scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->