### PR TITLE
Add detect-secrets, Collectd, Conftest to catalog

### DIFF
--- a/tools/dev-tools/conftest.yaml
+++ b/tools/dev-tools/conftest.yaml
@@ -1,0 +1,27 @@
+name: Conftest
+description: Policy tests for structured config using Open Policy Agent Rego. Conftest checks Kubernetes YAML, Terraform JSON, Dockerfiles, and other structured files in CI so IaC for GPU clusters and model-serving stacks fails on policy, not in production.
+tagline: Rego tests for Kubernetes, Terraform, and other config
+
+github_url: https://github.com/open-policy-agent/conftest
+website_url: https://www.conftest.dev
+docs_url: https://www.conftest.dev/install/
+
+install_command: brew install conftest
+
+category: Dev Tools
+tags: [policy-as-code, opa, rego, kubernetes, terraform, ci, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Checkov and similar scanners ship built-in policies, but custom rules for
+  "no public GPU nodes" or "inference pods must set limits" need a unit-test
+  workflow. Conftest runs Rego against YAML, JSON, and HCL so platform teams
+  version policy tests next to the manifests they protect.
+
+use_cases:
+  - Unit-test Kubernetes manifests so inference pods cannot omit resource limits
+  - Fail CI when Terraform JSON would create a public training subnet
+  - Share Rego policies across Helm charts and Kustomize overlays
+  - Verify Dockerfiles and compose files against org-wide security baselines

--- a/tools/dev-tools/detect-secrets.yaml
+++ b/tools/dev-tools/detect-secrets.yaml
@@ -1,0 +1,28 @@
+name: detect-secrets
+description: Yelp's enterprise-friendly secret scanner that finds high-entropy strings and known credential patterns in a repo, then stores a baseline so known secrets are not re-flagged. detect-secrets plugs into pre-commit and CI to stop new API keys from landing in ML code.
+tagline: Prevent new secrets in git with a scanned baseline
+
+github_url: https://github.com/Yelp/detect-secrets
+website_url: https://github.com/Yelp/detect-secrets
+docs_url: https://github.com/Yelp/detect-secrets
+
+install_command: pip install detect-secrets
+
+category: Dev Tools
+tags: [secrets, security, pre-commit, git, python, scanning, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Training repos accumulate OpenAI keys, AWS credentials, and .env samples
+  that regex hooks miss once a secret is already in history. detect-secrets
+  scans for entropy and known formats, writes a baseline JSON, and only
+  fails CI on newly introduced secrets so teams can adopt scanning without
+  rewriting old files first.
+
+use_cases:
+  - Add a pre-commit hook that blocks new API keys in Python ML repositories
+  - Baseline an existing monorepo so only newly added secrets fail CI
+  - Scan pull requests for high-entropy tokens before they reach GitHub
+  - Audit Jupyter notebooks and config YAML for leaked cloud credentials

--- a/tools/monitoring/collectd.yaml
+++ b/tools/monitoring/collectd.yaml
@@ -1,0 +1,27 @@
+name: Collectd
+description: System statistics collection daemon that gathers CPU, memory, disk, network, and plugin metrics and ships them to Graphite, Prometheus, or other backends. Collectd is a long-standing host agent for machines that are not Kubernetes pods.
+tagline: Host metrics collection daemon with a large plugin set
+
+github_url: https://github.com/collectd/collectd
+website_url: https://collectd.org
+docs_url: https://collectd.org/documentation.shtml
+
+install_command: brew install collectd
+
+category: Monitoring
+tags: [metrics, monitoring, daemon, linux, plugins, observability, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Bare-metal GPU boxes and VMs still need CPU, disk, and interface metrics
+  when they are not in a Prometheus-operator cluster. Collectd runs as a
+  small daemon with dozens of plugins and forwards samples to Graphite,
+  InfluxDB, or write_prometheus so classic hosts stay observable.
+
+use_cases:
+  - Collect CPU, memory, and disk metrics from bare-metal GPU training hosts
+  - Forward host stats from VMs into Graphite or Prometheus without a full exporter stack
+  - Use plugins for NVIDIA, network, and process stats on shared workstations
+  - Keep long-running inference appliances instrumented when Kepler is not installed


### PR DESCRIPTION
## Add 3 tools to the catalog

- **detect-secrets** (Dev Tools) — Yelp secret scanner with baseline (Yelp/detect-secrets, Apache-2.0, 4.6k★)
- **Collectd** (Monitoring) — host metrics collection daemon (collectd/collectd, MIT, 3.4k★)
- **Conftest** (Dev Tools) — Rego tests for structured config (open-policy-agent/conftest, Apache-2.0, 3.3k★)

OSSEC was skipped as a Wazuh fork variant already in the catalog.

All files passed local `npx tsx scripts/validate-tool.ts`.
