### PR TITLE
Add subfinder, kube-linter, Goldilocks, Talisman to catalog

### DIFF
--- a/tools/dev-tools/goldilocks.yaml
+++ b/tools/dev-tools/goldilocks.yaml
@@ -1,0 +1,25 @@
+name: Goldilocks
+description: Fairwinds Goldilocks uses the Kubernetes Vertical Pod Autoscaler to recommend CPU and memory requests from live usage. It shows per-namespace right-sizing so GPU and CPU workloads stop over-requesting capacity or getting OOM-killed.
+tagline: Right-size Kubernetes resource requests from live usage
+
+github_url: https://github.com/FairwindsOps/goldilocks
+website_url: https://www.fairwinds.com/goldilocks
+docs_url: https://goldilocks.docs.fairwinds.com
+
+category: Dev Tools
+tags: [kubernetes, vpa, rightsizing, resources, finops, helm, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Teams guess CPU and memory requests for inference and training pods. Too high
+  and the cluster wastes nodes; too low and jobs OOM or throttle. Goldilocks
+  watches Vertical Pod Autoscaler recommendations and presents them per
+  namespace so resource requests match real usage instead of copy-pasted YAML.
+
+use_cases:
+  - Right-size CPU and memory requests for model-serving deployments
+  - Find namespaces that over-request capacity on GPU or CPU nodes
+  - Use VPA recommendations to cut cloud spend without causing OOM kills
+  - Review per-workload resource quality before a cluster capacity upgrade

--- a/tools/dev-tools/kube-linter.yaml
+++ b/tools/dev-tools/kube-linter.yaml
@@ -1,0 +1,28 @@
+name: kube-linter
+description: KubeLinter is a static analysis tool for Kubernetes YAML and Helm charts. It checks that workloads follow security and operability best practices, so privileged pods, missing resource limits, and unsafe defaults fail CI before they reach GPU clusters.
+tagline: Lint Kubernetes YAML and Helm charts in CI
+
+github_url: https://github.com/stackrox/kube-linter
+website_url: https://docs.kubelinter.io
+docs_url: https://docs.kubelinter.io
+
+install_command: brew install kube-linter
+
+category: Dev Tools
+tags: [kubernetes, linting, helm, security, static-analysis, ci, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Kubernetes manifests for training and serving can apply while still running as
+  root, skipping resource limits, or mounting the Docker socket. Those issues
+  surface only after a cluster incident. KubeLinter scans YAML and Helm charts
+  against built-in checks so policy failures stop the pipeline instead of
+  production.
+
+use_cases:
+  - Lint Helm charts for model-serving stacks in pull requests
+  - Fail CI when pods request privileged mode or hostPath mounts
+  - Enforce resource requests and limits on GPU training job templates
+  - Add custom checks for organization Kubernetes policy alongside built-in rules

--- a/tools/dev-tools/subfinder.yaml
+++ b/tools/dev-tools/subfinder.yaml
@@ -1,0 +1,27 @@
+name: subfinder
+description: subfinder is a fast passive subdomain enumeration tool from ProjectDiscovery. It queries dozens of sources without sending traffic to the target, so security and ML data teams map attack surface and related hostnames before active scans or dataset collection.
+tagline: Fast passive subdomain enumeration
+
+github_url: https://github.com/projectdiscovery/subfinder
+website_url: https://projectdiscovery.io
+docs_url: https://docs.projectdiscovery.io/tools/subfinder/overview
+
+install_command: brew install subfinder
+
+category: Dev Tools
+tags: [recon, subdomains, osint, security, golang, cli, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Finding every hostname in front of an AI product is slow if you brute-force DNS
+  or hit the target. Missed subdomains hide staging model APIs and forgotten GPU
+  dashboards. subfinder enumerates names passively from public sources so teams
+  inventory attack surface without announcing a scan to production.
+
+use_cases:
+  - Map subdomains for an AI SaaS before a security review or bug bounty
+  - Discover staging inference endpoints that should not be public
+  - Feed hostname lists into Nuclei or httpx for further probing
+  - Build an asset inventory from certificates and passive DNS without active scans

--- a/tools/dev-tools/talisman.yaml
+++ b/tools/dev-tools/talisman.yaml
@@ -1,0 +1,28 @@
+name: Talisman
+description: Thoughtworks Talisman is a pre-commit and pre-push hook that scans outgoing changesets for secrets such as tokens, passwords, and private keys. It blocks commits that would leak API keys for LLM providers, cloud accounts, or model registries.
+tagline: Pre-commit hook that blocks secrets from entering git
+
+github_url: https://github.com/thoughtworks/talisman
+website_url: https://thoughtworks.github.io/talisman
+docs_url: https://thoughtworks.github.io/talisman
+
+install_command: brew install talisman
+
+category: Dev Tools
+tags: [git, secrets, pre-commit, security, hooks, scanning, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  LLM API keys, cloud credentials, and private keys still land in git history
+  when developers paste them into notebooks or env files. Rotating after a
+  push is slower than blocking the commit. Talisman inspects the outgoing
+  changeset in a pre-commit or pre-push hook and refuses patterns that look
+  like secrets before they leave the laptop.
+
+use_cases:
+  - Block commits that contain OpenAI, cloud, or database credentials
+  - Run as a pre-push hook so CI never sees leaked private keys
+  - Scan an existing repo history for files that look like secrets
+  - Add a lightweight secret gate alongside detect-secrets or git-secrets


### PR DESCRIPTION
## Catalog batch

Adds four Kubernetes, recon, and git-secrets tools:

| Tool | Category | Why it belongs |
|---|---|---|
| **subfinder** | Dev Tools | ProjectDiscovery passive subdomain enumeration (14k★, MIT) |
| **kube-linter** | Dev Tools | StackRox static analysis for Kubernetes YAML and Helm (3.5k★, Apache-2.0) |
| **Goldilocks** | Dev Tools | Fairwinds VPA-based Kubernetes resource right-sizing (3.3k★, Apache-2.0) |
| **Talisman** | Dev Tools | Thoughtworks pre-commit hook that blocks secrets (2.1k★, MIT) |

Local validation: `npx tsx scripts/validate-tool.ts` passed for all four files.
