### PR TITLE
Add Katana, Naabu, kube-bench, kube-hunter, Popeye to catalog

### DIFF
--- a/tools/dev-tools/katana.yaml
+++ b/tools/dev-tools/katana.yaml
@@ -1,0 +1,28 @@
+name: Katana
+description: Katana is ProjectDiscovery's next-generation crawling and spidering framework. It crawls web apps with a headless or standard engine to collect URLs, forms, and JavaScript endpoints so security and data teams map attack surface and scrape training-site structure without a brittle custom crawler.
+tagline: Next-generation web crawling and spidering framework
+
+github_url: https://github.com/projectdiscovery/katana
+website_url: https://projectdiscovery.io
+docs_url: https://docs.projectdiscovery.io/tools/katana/overview
+
+install_command: brew install katana
+
+category: Dev Tools
+tags: [crawler, recon, security, golang, spider, cli, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Mapping every URL and JS endpoint in front of an AI product usually means a
+  slow browser script that misses APIs. Missed paths hide admin panels and
+  model endpoints. Katana crawls with optional headless Chrome, extracts
+  endpoints from HTML and JavaScript, and feeds other recon tools so the
+  surface is complete before a scan or scrape.
+
+use_cases:
+  - Crawl a web app to collect URLs and forms before a security review
+  - Extract JavaScript endpoints that expose inference or admin APIs
+  - Feed discovered paths into Nuclei or httpx for further probing
+  - Map site structure for dataset collection without a custom scraper

--- a/tools/dev-tools/kube-bench.yaml
+++ b/tools/dev-tools/kube-bench.yaml
@@ -1,0 +1,27 @@
+name: kube-bench
+description: Aqua kube-bench checks whether a Kubernetes cluster follows the CIS Kubernetes Benchmark. It runs as a job inside the cluster and reports failed controls so GPU training and inference clusters are not left with default insecure kubelet, API server, or etcd settings.
+tagline: CIS Kubernetes Benchmark checks for your cluster
+
+github_url: https://github.com/aquasecurity/kube-bench
+docs_url: https://github.com/aquasecurity/kube-bench
+
+install_command: brew install kube-bench
+
+category: Dev Tools
+tags: [kubernetes, cis, security, benchmarking, aqua, compliance, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Managed and self-hosted Kubernetes for ML often ships with kubelet anonymous
+  auth, weak file permissions, or etcd exposed. CIS controls are long and easy
+  to skip. kube-bench runs the CIS Kubernetes Benchmark as a job and prints
+  pass/fail so those gaps are visible before a cluster holds training data or
+  model weights.
+
+use_cases:
+  - Audit a GPU Kubernetes cluster against the CIS Kubernetes Benchmark
+  - Run kube-bench as a Job after cluster provisioning in CI or GitOps
+  - Compare control-plane and worker node findings before production cutover
+  - Track CIS pass rate over time as cluster configuration changes

--- a/tools/dev-tools/kube-hunter.yaml
+++ b/tools/dev-tools/kube-hunter.yaml
@@ -1,0 +1,27 @@
+name: kube-hunter
+description: Aqua kube-hunter hunts for security weaknesses in Kubernetes clusters from remote, internal, or in-cluster network positions. It reports open dashboards, unauthenticated APIs, and exposed kubelets so ML clusters are not left reachable from the office network or the public internet.
+tagline: Hunt for security weaknesses in Kubernetes clusters
+
+github_url: https://github.com/aquasecurity/kube-hunter
+docs_url: https://github.com/aquasecurity/kube-hunter
+
+install_command: pip install kube-hunter
+
+category: Dev Tools
+tags: [kubernetes, security, pentest, aqua, hunting, network, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  CIS YAML checks do not show what an attacker on the same network can reach.
+  Open dashboards, anonymous kubelets, and unauthenticated API servers still
+  appear on GPU clusters. kube-hunter probes from remote or inside the cluster
+  and lists active weaknesses so those exposures are fixed before they hold
+  training data.
+
+use_cases:
+  - Probe a Kubernetes API from the office network for anonymous access
+  - Run an in-cluster hunt for exposed kubelets and dashboards
+  - Validate that a GPU cluster is not reachable from an untrusted VLAN
+  - Generate a hunter report before an external pentest of ML infrastructure

--- a/tools/dev-tools/naabu.yaml
+++ b/tools/dev-tools/naabu.yaml
@@ -1,0 +1,28 @@
+name: Naabu
+description: Naabu is a fast port scanner written in Go by ProjectDiscovery. It focuses on reliable SYN and CONNECT scanning so recon and ML data teams find open services on hosts discovered by subfinder before they probe HTTP or run vulnerability templates.
+tagline: Fast Go port scanner for attack-surface discovery
+
+github_url: https://github.com/projectdiscovery/naabu
+website_url: https://projectdiscovery.io
+docs_url: https://docs.projectdiscovery.io/tools/naabu/overview
+
+install_command: brew install naabu
+
+category: Dev Tools
+tags: [port-scanner, recon, security, golang, cli, network, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  After subdomain enumeration you still do not know which ports are open on
+  GPU jump hosts or inference VMs. Full nmap on large ranges is slow for
+  everyday recon. Naabu does fast SYN or CONNECT scans and pairs with
+  ProjectDiscovery tools so open services are listed before HTTP probing or
+  vulnerability templates run.
+
+use_cases:
+  - Scan ports on hosts found by subfinder before probing HTTP
+  - Inventory open services on GPU cloud nodes during a security review
+  - Combine with httpx to check which ports speak HTTP or TLS
+  - Run a lightweight port scan in CI against a staging network range

--- a/tools/dev-tools/popeye.yaml
+++ b/tools/dev-tools/popeye.yaml
@@ -1,0 +1,28 @@
+name: Popeye
+description: Popeye is a Kubernetes cluster sanitizer that scans live resources for misconfigurations, unused objects, and best-practice gaps. It reports pods without limits, stale ReplicaSets, and risky RBAC so ML clusters stay clean instead of accumulating silent waste and exposure.
+tagline: Sanitize live Kubernetes clusters for waste and risk
+
+github_url: https://github.com/derailed/popeye
+website_url: https://popeyecli.io
+docs_url: https://popeyecli.io
+
+install_command: brew install popeye
+
+category: Dev Tools
+tags: [kubernetes, sanitizer, best-practices, cli, rbac, resources, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Live Kubernetes clusters for training and serving accumulate unused PVCs,
+  pods without resource limits, and overly broad Roles that YAML linters never
+  see because they only look at files. Popeye reads the live API, scores
+  resources, and prints sanitizer reports so waste and risky defaults are
+  cleaned up in the running cluster.
+
+use_cases:
+  - Scan a live cluster for pods missing limits, probes, or healthy replicas
+  - Find unused ConfigMaps, Secrets, and PVCs left by failed training jobs
+  - Report risky RBAC bindings before tightening cluster access
+  - Run Popeye in CI against a staging cluster after each GitOps sync


### PR DESCRIPTION
## Catalog batch

Adds five Kubernetes security and recon tools:

| Tool | Category | Why it belongs |
|---|---|---|
| **Katana** | Dev Tools | ProjectDiscovery crawler/spider (17k★, MIT) |
| **Naabu** | Dev Tools | ProjectDiscovery Go port scanner (6.2k★, MIT) |
| **kube-bench** | Dev Tools | Aqua CIS Kubernetes Benchmark checker (8.2k★, Apache-2.0) |
| **kube-hunter** | Dev Tools | Aqua Kubernetes weakness hunter (5.1k★, Apache-2.0) |
| **Popeye** | Dev Tools | Live Kubernetes cluster sanitizer (6.4k★, Apache-2.0) |

Local validation: `npx tsx scripts/validate-tool.ts` passed for all five files.
