### PR TITLE
Add Prowler, Steampipe, ScoutSuite, Botkube to catalog

### DIFF
--- a/tools/data/steampipe.yaml
+++ b/tools/data/steampipe.yaml
@@ -1,0 +1,27 @@
+name: Steampipe
+description: Steampipe lets you live-query APIs, cloud accounts, SaaS, and code with SQL and no ETL database. DevOps and ML platform teams join AWS, GitHub, Kubernetes, and Slack tables to answer inventory, cost, and security questions that would otherwise need custom scripts.
+tagline: Live SQL queries over APIs, cloud, and code
+
+github_url: https://github.com/turbot/steampipe
+website_url: https://steampipe.io
+docs_url: https://steampipe.io/docs
+
+install_command: brew install steampipe
+
+category: Data
+tags: [sql, cloud, inventory, devops, postgres, plugins, open-source]
+pricing: freemium
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Inventory for GPU instances, IAM users, GitHub repos, and Kubernetes pods
+  lives in many APIs. Writing a one-off Python client for each is slow and
+  stale by the next day. Steampipe exposes those APIs as Postgres foreign
+  tables so you query live cloud and SaaS state with SQL instead of ETL.
+
+use_cases:
+  - Query AWS EC2 GPU instances and their tags with SQL instead of boto3
+  - Join GitHub repos and cloud resources to find unowned ML infrastructure
+  - Inventory Kubernetes pods and node capacity across clusters from one prompt
+  - Build compliance views over IAM, S3, and GitHub without a warehouse

--- a/tools/dev-tools/prowler.yaml
+++ b/tools/dev-tools/prowler.yaml
@@ -1,0 +1,28 @@
+name: Prowler
+description: Prowler is an open-source cloud security platform that audits AWS, Azure, GCP, Kubernetes, and M365 against hundreds of checks. It automates CIS, ISO, and custom assessments so GPU accounts and model-serving projects are not left with public buckets, open security groups, or unused IAM keys.
+tagline: Multi-cloud security assessments and compliance checks
+
+github_url: https://github.com/prowler-cloud/prowler
+website_url: https://prowler.com
+docs_url: https://docs.prowler.com
+
+install_command: brew install prowler
+
+category: Dev Tools
+tags: [cloud-security, aws, azure, gcp, compliance, cis, auditing, open-source]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Cloud accounts that host training data and inference APIs drift from CIS
+  baselines. Console clicking cannot cover hundreds of AWS, Azure, and GCP
+  controls. Prowler runs those checks as CLI or pipeline jobs and reports
+  failed findings so public buckets, open security groups, and stale keys are
+  fixed before an incident.
+
+use_cases:
+  - Audit AWS accounts that hold GPU clusters against CIS and custom checks
+  - Scan Azure and GCP projects used for model training in the same run
+  - Fail CI when a new account is missing CloudTrail, encryption, or MFA
+  - Export findings for incident response after a suspected cloud misconfig

--- a/tools/dev-tools/scoutsuite.yaml
+++ b/tools/dev-tools/scoutsuite.yaml
@@ -1,0 +1,26 @@
+name: ScoutSuite
+description: NCC Group ScoutSuite is a multi-cloud security auditing tool that collects configuration data from AWS, Azure, GCP, Alibaba Cloud, and Oracle Cloud, then produces an HTML report of risks. It helps teams review IAM, storage, and network exposure on accounts that host training data and model APIs.
+tagline: Multi-cloud security auditing with HTML reports
+
+github_url: https://github.com/nccgroup/ScoutSuite
+docs_url: https://github.com/nccgroup/ScoutSuite
+
+install_command: pip install scoutsuite
+
+category: Dev Tools
+tags: [cloud-security, aws, azure, gcp, auditing, python, open-source]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Cloud security reviews for ML accounts often dump CLI output that nobody
+  reads. ScoutSuite enumerates services across AWS, Azure, GCP, and others,
+  then writes a browsable HTML report of IAM, storage, and network findings
+  so reviewers see exposure without assembling screenshots from five consoles.
+
+use_cases:
+  - Generate an HTML audit of AWS accounts used for GPU training
+  - Compare IAM and storage findings across Azure and GCP in one report
+  - Review public buckets and overly broad roles before a pentest
+  - Snapshot cloud configuration for a security review of an ML platform

--- a/tools/monitoring/botkube.yaml
+++ b/tools/monitoring/botkube.yaml
@@ -1,0 +1,26 @@
+name: Botkube
+description: Botkube is a Kubernetes monitoring app that sends cluster events, kubectl-style debugging, and best-practice recommendations into Slack, Discord, or Mattermost. Platform teams watch failing training jobs and crashing inference pods in chat without hopping into a dashboard.
+tagline: Kubernetes monitoring and debugging in Slack
+
+github_url: https://github.com/kubeshop/botkube
+website_url: https://botkube.io
+docs_url: https://docs.botkube.io
+
+category: Monitoring
+tags: [kubernetes, slack, monitoring, chatops, alerting, debugging, open-source]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  CrashLoopBackOff on an inference Deployment is easy to miss until users
+  complain. Dashboards are another tab; chat is where the team already is.
+  Botkube watches Kubernetes events, posts them to Slack or Discord, and
+  lets you run allowed kubectl-style actions from chat so GPU jobs get
+  attention when they fail.
+
+use_cases:
+  - Alert Slack when a training Job or inference Deployment crash-loops
+  - Run allowed kubectl get and describe from chat during an incident
+  - Recommend Kubernetes best practices on noisy or misconfigured workloads
+  - Route namespace events for ML platform teams without extra dashboards


### PR DESCRIPTION
## Catalog batch

Adds four cloud-security, inventory, and Kubernetes chatops tools:

| Tool | Category | Why it belongs |
|---|---|---|
| **Prowler** | Dev Tools | Multi-cloud security assessments (14.8k★, Apache-2.0) |
| **Steampipe** | Data | Live SQL over APIs, cloud, and code (7.9k★, AGPL-3.0) |
| **ScoutSuite** | Dev Tools | NCC Group multi-cloud security auditor (7.8k★, GPL-2.0) |
| **Botkube** | Monitoring | Kubernetes events and debugging in Slack (2.3k★, MIT) |

Local validation: `npx tsx scripts/validate-tool.ts` passed for all four files.
