### PR TITLE
Add Kubescape, husky, tflint, DevSpace, terraform-docs to catalog

### DIFF
--- a/tools/dev-tools/devspace.yaml
+++ b/tools/dev-tools/devspace.yaml
@@ -1,0 +1,28 @@
+name: DevSpace
+description: DevSpace is a CNCF sandbox CLI for developing applications inside Kubernetes. It syncs local files into running pods with hot reload so you skip rebuild-and-redeploy cycles while debugging training or serving stacks.
+tagline: Develop and debug apps directly inside Kubernetes
+
+github_url: https://github.com/devspace-sh/devspace
+website_url: https://devspace.sh
+docs_url: https://devspace.sh/cli/docs/introduction
+
+install_command: brew install devspace
+
+category: Dev Tools
+tags: [kubernetes, developer-experience, hot-reload, cncf, cli, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Rebuilding images and waiting for Kubernetes rollouts makes inner-loop
+  debugging of model servers and agents painfully slow. DevSpace syncs local
+  code into running pods, forwards ports, and streams logs from a single
+  declarative config so the team iterates in-cluster without becoming kubectl
+  experts.
+
+use_cases:
+  - Hot-reload a model-serving container in a remote Kubernetes cluster
+  - Standardize deploy and debug workflows in a shared devspace.yaml
+  - Port-forward and stream logs from inference pods without copying pod IDs
+  - Build images and deploy dependent services with one command

--- a/tools/dev-tools/husky.yaml
+++ b/tools/dev-tools/husky.yaml
@@ -1,0 +1,27 @@
+name: husky
+description: Husky is a lightweight npm package that makes Git hooks easy to set up. It runs lint, test, and format checks on commit or push so broken code never lands on shared branches.
+tagline: Git hooks made easy for Node.js projects
+
+github_url: https://github.com/typicode/husky
+website_url: https://typicode.github.io/husky
+docs_url: https://typicode.github.io/husky
+
+install_command: npm install --save-dev husky
+
+category: Dev Tools
+tags: [git, hooks, npm, javascript, linting, ci, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  ML and agent repos often skip local checks until CI fails. Native Git hooks
+  are awkward to version and share. Husky installs commit and push hooks from
+  package.json so lint, typecheck, and test scripts run on every developer
+  machine before the change reaches the remote.
+
+use_cases:
+  - Run ESLint and Prettier on staged files before each commit
+  - Block pushes when unit tests for an agent or API client fail locally
+  - Share the same Git hook setup across a Node.js monorepo via package.json
+  - Gate commits on typecheck for TypeScript LLM tooling packages

--- a/tools/dev-tools/kubescape.yaml
+++ b/tools/dev-tools/kubescape.yaml
@@ -1,0 +1,28 @@
+name: Kubescape
+description: Kubescape is a CNCF incubating Kubernetes security platform that scans clusters, YAML, and Helm charts for misconfigurations, image CVEs, and compliance against NSA-CISA, MITRE ATT&CK, and CIS from IDE through CI to runtime.
+tagline: Kubernetes security scanning from development to runtime
+
+github_url: https://github.com/kubescape/kubescape
+website_url: https://kubescape.io
+docs_url: https://kubescape.io/docs/
+
+install_command: brew install kubescape
+
+category: Dev Tools
+tags: [kubernetes, security, compliance, cis, scanning, cncf, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  GPU training and inference clusters often ship with privileged pods, missing
+  network policies, and images full of CVEs. Manual CIS and NSA reviews do not
+  scale across YAML, Helm, and live clusters. Kubescape scans manifests and
+  running workloads against those frameworks so posture gaps show up in CI
+  instead of after an incident.
+
+use_cases:
+  - Scan a GPU Kubernetes cluster against NSA-CISA and CIS controls before production
+  - Lint Helm charts and YAML for model-serving stacks in pull requests
+  - Detect CVEs in training and inference container images in CI
+  - Enforce admission policies so unsafe workloads never reach the cluster

--- a/tools/dev-tools/terraform-docs.yaml
+++ b/tools/dev-tools/terraform-docs.yaml
@@ -1,0 +1,27 @@
+name: terraform-docs
+description: terraform-docs generates documentation from Terraform modules in markdown, JSON, YAML, and other formats. It injects inputs, outputs, and providers into README files so module docs stay in sync with the HCL.
+tagline: Auto-generate documentation from Terraform modules
+
+github_url: https://github.com/terraform-docs/terraform-docs
+website_url: https://terraform-docs.io
+docs_url: https://terraform-docs.io
+
+install_command: brew install terraform-docs
+
+category: Dev Tools
+tags: [terraform, documentation, iac, markdown, cli, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Terraform modules for GPU clusters and data platforms drift from their
+  README files as inputs and outputs change. Manual docs rot. terraform-docs
+  reads the HCL and writes tables for variables, outputs, and providers so
+  reviewers see current module contracts in pull requests.
+
+use_cases:
+  - Inject Terraform module inputs and outputs into README.md on every commit
+  - Generate markdown docs for shared GPU and Kubernetes Terraform modules
+  - Run terraform-docs as a GitHub Action that updates PR documentation
+  - Keep pre-commit hooks regenerating module docs when .tf files change

--- a/tools/dev-tools/tflint.yaml
+++ b/tools/dev-tools/tflint.yaml
@@ -1,0 +1,26 @@
+name: tflint
+description: TFLint is a pluggable Terraform linter that finds invalid instance types, deprecated syntax, unused declarations, and cloud-provider mistakes in AWS, Azure, and GCP modules before you apply infrastructure changes.
+tagline: Pluggable linter for Terraform modules
+
+github_url: https://github.com/terraform-linters/tflint
+docs_url: https://github.com/terraform-linters/tflint
+
+install_command: brew install terraform-linters/tap/tflint
+
+category: Dev Tools
+tags: [terraform, linting, iac, aws, gcp, azure, open-source]
+pricing: free
+is_open_source: true
+license: MPL-2.0
+
+problem_solved: |
+  Terraform apply can succeed while still using invalid instance types, unused
+  variables, or deprecated syntax that only fails in a later environment. TFLint
+  checks modules and cloud-provider plugins in CI so those mistakes never reach
+  GPU clusters, vector databases, or model-serving infrastructure.
+
+use_cases:
+  - Lint Terraform modules for GPU node pools before merging a pull request
+  - Catch invalid AWS instance types in training-cluster Terraform
+  - Enforce naming conventions across shared IaC modules with plugins
+  - Run TFLint in GitHub Actions alongside terraform validate


### PR DESCRIPTION
## Summary

Add five Dev Tools catalog entries for Kubernetes security, Git hooks, Terraform linting, in-cluster development, and Terraform module docs.

- **Kubescape** — CNCF incubating Kubernetes security scanner (misconfig, CVE, CIS/NSA)
- **husky** — Git hooks for Node.js projects
- **tflint** — Pluggable Terraform linter with cloud-provider plugins
- **DevSpace** — CNCF sandbox CLI for developing inside Kubernetes
- **terraform-docs** — Generate documentation from Terraform modules

All files validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added DevSpace, Husky, Kubescape, terraform-docs, and TFLint to the Dev Tools catalog.
  - Added searchable metadata including descriptions, installation details, documentation links, licensing, pricing, categories, and tags.
  - Added practical use cases covering Kubernetes development, Git hooks, security compliance, Terraform documentation, and linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->