### PR TITLE
Add cdk8s, Crane, Okteto, kube-capacity to catalog

### DIFF
--- a/tools/dev-tools/cdk8s.yaml
+++ b/tools/dev-tools/cdk8s.yaml
@@ -1,0 +1,29 @@
+name: cdk8s
+description: Define Kubernetes apps and abstractions in TypeScript, Python, Java, or Go. cdk8s synthesizes typed constructs into standard YAML manifests you can apply to any cluster, so ML serving charts stay in code instead of hand-edited YAML.
+tagline: Kubernetes apps as real code, not YAML copies
+
+github_url: https://github.com/cdk8s-team/cdk8s
+website_url: https://cdk8s.io
+docs_url: https://cdk8s.io/docs/latest/
+
+install_command: |
+  npm install cdk8s
+  pip install cdk8s
+
+category: Dev Tools
+tags: [kubernetes, cdk, typescript, python, infrastructure, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Hand-written Kubernetes YAML for inference services, GPU jobs, and agent
+  workers drifts and is hard to reuse. cdk8s lets you model those resources as
+  typed classes that synthesize to standard manifests, so ML platform charts
+  stay DRY, testable, and language-native.
+
+use_cases:
+  - Author inference Deployments and Services as TypeScript classes instead of YAML
+  - Share Python constructs for GPU Job templates across training environments
+  - Generate Helm-compatible manifests for agent workers from a single cdk8s app
+  - Unit-test Kubernetes resource graphs before applying them to a cluster

--- a/tools/dev-tools/crane.yaml
+++ b/tools/dev-tools/crane.yaml
@@ -1,0 +1,27 @@
+name: Crane
+description: CLI for container registries from Google's go-containerregistry. Copy, tag, mutate, and inspect images without a Docker daemon, which speeds CI for model serving images and GPU inference containers.
+tagline: Registry operations without a Docker daemon
+
+github_url: https://github.com/google/go-containerregistry
+website_url: https://github.com/google/go-containerregistry/tree/main/cmd/crane
+docs_url: https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md
+
+install_command: brew install crane
+
+category: Dev Tools
+tags: [containers, registry, cli, docker, ci, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Copying or retagging model images in CI usually needs a Docker daemon and
+  full pulls. Crane talks to registries directly, so you can copy, mutate
+  config, and inspect layers of serving images in GitHub Actions without
+  privileged builders.
+
+use_cases:
+  - Copy a trained model image between registries in CI without docker pull
+  - Retag a GPU inference image to latest after a successful deploy
+  - Inspect image config and layers before promoting a serving build
+  - Mutate an image entrypoint in-place for debug variants of agent workers

--- a/tools/dev-tools/kube-capacity.yaml
+++ b/tools/dev-tools/kube-capacity.yaml
@@ -1,0 +1,25 @@
+name: kube-capacity
+description: CLI that combines kubectl top and describe into a cluster resource view. Shows CPU and memory requests, limits, and utilization per node and pod so ML teams can spot GPU-node packing issues before jobs queue.
+tagline: Cluster resource requests, limits, and util in one CLI
+
+github_url: https://github.com/robscott/kube-capacity
+
+install_command: brew install robscott/tap/kube-capacity
+
+category: Dev Tools
+tags: [kubernetes, cli, capacity, mlops, observability, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  kubectl top and describe scatter CPU and memory data across commands, so it
+  is easy to miss nodes that are request-packed while GPU training jobs wait.
+  kube-capacity prints requests, limits, and utilization together so platform
+  teams can see packing and headroom in one table.
+
+use_cases:
+  - Compare node CPU and memory requests versus actual utilization
+  - Find over-requested inference pods that starve training jobs
+  - Export cluster capacity as JSON for capacity-planning dashboards
+  - Filter GPU node pools before scheduling a large training batch

--- a/tools/dev-tools/okteto.yaml
+++ b/tools/dev-tools/okteto.yaml
@@ -1,0 +1,27 @@
+name: Okteto
+description: Develop applications directly inside a Kubernetes cluster. Sync local code to remote pods so ML APIs, agents, and GPU services can be iterated against real cluster resources instead of a laptop-only stack.
+tagline: Inner-loop Kubernetes development for real clusters
+
+github_url: https://github.com/okteto/okteto
+website_url: https://okteto.com
+docs_url: https://www.okteto.com/docs/
+
+install_command: brew install okteto
+
+category: Dev Tools
+tags: [kubernetes, development, devops, remote-dev, mlops, open-source]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Local Docker Compose cannot reproduce GPU nodes, sidecars, or cluster
+  networking that inference and agent services depend on. Okteto syncs your
+  local tree into a remote Kubernetes pod so you iterate against the same
+  cluster your production jobs use.
+
+use_cases:
+  - Hot-reload a FastAPI inference service running on a remote GPU node
+  - Debug an agent worker against in-cluster Redis, queues, and secrets
+  - Replace laptop minikube with a shared dev namespace for ML platform work
+  - Preview pull requests as live Kubernetes environments before merge


### PR DESCRIPTION
## Summary
Add four Kubernetes / container Dev Tools entries to the catalog:

- **cdk8s** (cdk8s-team/cdk8s, Apache-2.0) — define Kubernetes apps as typed TypeScript/Python/Java/Go constructs that synthesize to standard YAML
- **Crane** (google/go-containerregistry, Apache-2.0) — registry CLI for copy/tag/mutate/inspect without a Docker daemon
- **Okteto** (okteto/okteto, Apache-2.0) — develop and hot-reload apps directly inside a Kubernetes cluster
- **kube-capacity** (robscott/kube-capacity, Apache-2.0) — cluster CPU/memory requests, limits, and utilization in one CLI

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all four files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cdk8s, Crane, kube-capacity, and Okteto to the developer tools catalog.
  - cdk8s supports defining Kubernetes applications with familiar programming languages and generating YAML manifests.
  - Crane provides daemonless container registry operations for CI workflows.
  - kube-capacity offers Kubernetes resource capacity visibility.
  - Okteto enables local development workflows against remote Kubernetes pods.
- **Documentation**
  - Added installation details, licensing, pricing, categories, tags, problem statements, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->