### PR TITLE
Add lazydocker, ctop, kops, kubespray, eksctl to catalog

### DIFF
--- a/tools/dev-tools/ctop.yaml
+++ b/tools/dev-tools/ctop.yaml
@@ -1,0 +1,26 @@
+name: ctop
+description: Top-like TUI for container metrics. Shows CPU, memory, network, and I/O for Docker or runc containers so you can spot a runaway training job without looping docker stats.
+tagline: Top for containers, in a compact TUI
+
+github_url: https://github.com/bcicen/ctop
+website_url: https://bcicen.github.io/ctop/
+
+install_command: brew install ctop
+
+category: Dev Tools
+tags: [docker, tui, containers, metrics, devops, mlops, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  docker stats is a raw stream that is hard to sort and filter when dozens of
+  training and inference containers share a host. ctop gives a top-like view
+  of per-container CPU, memory, and I/O so you can find the noisy neighbor
+  before it starves a GPU job.
+
+use_cases:
+  - Find which container is saturating CPU on a shared training box
+  - Sort running containers by memory while an inference service leaks
+  - Filter Docker hosts to the compose project running an agent stack
+  - Confirm a GPU worker is actually consuming resources after deploy

--- a/tools/dev-tools/eksctl.yaml
+++ b/tools/dev-tools/eksctl.yaml
@@ -1,0 +1,27 @@
+name: eksctl
+description: Official CLI for Amazon EKS. Create, scale, and delete clusters and node groups, including GPU nodes, from one command instead of hand-written CloudFormation.
+tagline: The official CLI for Amazon EKS
+
+github_url: https://github.com/eksctl-io/eksctl
+website_url: https://eksctl.io
+docs_url: https://eksctl.io/introduction/
+
+install_command: brew install eksctl
+
+category: Dev Tools
+tags: [kubernetes, aws, eks, cli, devops, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Creating an EKS cluster in the AWS console or raw CloudFormation is slow
+  and easy to misconfigure for GPU node groups. eksctl wraps cluster, IAM,
+  and node group lifecycle so ML teams can stand up and tear down EKS
+  environments from a CLI or CI job.
+
+use_cases:
+  - Create an EKS cluster with a GPU node group for model training
+  - Scale inference node groups from CI after a traffic spike
+  - Delete ephemeral EKS clusters used for PR previews of agent stacks
+  - Add a managed node group with spot instances for cheaper batch jobs

--- a/tools/dev-tools/kops.yaml
+++ b/tools/dev-tools/kops.yaml
@@ -1,0 +1,27 @@
+name: kops
+description: Production-grade Kubernetes installer for AWS and other clouds. Provisions, upgrades, and manages HA clusters so ML platforms get control planes and GPU node groups without hand-rolled Terraform.
+tagline: Production Kubernetes install, upgrade, and ops
+
+github_url: https://github.com/kubernetes/kops
+website_url: https://kops.sigs.k8s.io/
+docs_url: https://kops.sigs.k8s.io/
+
+install_command: brew install kops
+
+category: Dev Tools
+tags: [kubernetes, aws, cluster, devops, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Standing up a production Kubernetes cluster on AWS from raw EC2 and IAM is
+  error-prone and slow to upgrade. kops encodes HA control planes, networking,
+  and rolling upgrades so ML platforms can add GPU node groups without
+  reinventing cluster lifecycle.
+
+use_cases:
+  - Provision an HA Kubernetes cluster on AWS for training and serving
+  - Rolling-upgrade a GPU node group without draining the whole cluster
+  - Export cluster config as YAML for GitOps of ML platform infrastructure
+  - Add spot GPU instance groups for cheaper batch training

--- a/tools/dev-tools/kubespray.yaml
+++ b/tools/dev-tools/kubespray.yaml
@@ -1,0 +1,25 @@
+name: kubespray
+description: Ansible playbooks for production Kubernetes on bare metal or VMs. Installs HA clusters with configurable CNI and addons so GPU labs can run Kubernetes without a managed control plane.
+tagline: Ansible-powered Kubernetes on any infrastructure
+
+github_url: https://github.com/kubernetes-sigs/kubespray
+website_url: https://kubespray.io
+docs_url: https://kubespray.io
+
+category: Dev Tools
+tags: [kubernetes, ansible, cluster, bare-metal, devops, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Managed Kubernetes is not always an option for on-prem GPU clusters, and
+  kubeadm still leaves networking, HA etcd, and addons as homework. Kubespray
+  packages those into Ansible so you can install a production cluster on
+  existing machines with a repeatable inventory.
+
+use_cases:
+  - Install HA Kubernetes on on-prem GPU servers for training
+  - Choose Calico or Cilium CNI from inventory without rewriting playbooks
+  - Upgrade a bare-metal cluster used for inference without downtime windows
+  - Bootstrap Kubernetes on VMs when a cloud managed control plane is off-limits

--- a/tools/dev-tools/lazydocker.yaml
+++ b/tools/dev-tools/lazydocker.yaml
@@ -1,0 +1,26 @@
+name: lazydocker
+description: Terminal UI for Docker and Compose. Browse containers, logs, images, and volumes in a lazygit-style TUI so ML engineers can debug training and inference containers without memorizing docker CLI flags.
+tagline: A lazier way to manage everything Docker
+
+github_url: https://github.com/jesseduffield/lazydocker
+website_url: https://github.com/jesseduffield/lazydocker
+
+install_command: brew install lazydocker
+
+category: Dev Tools
+tags: [docker, tui, cli, containers, devops, mlops, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  docker ps, logs, stats, and compose live in separate commands, so debugging
+  a stuck training container means hopping across flags. lazydocker puts
+  containers, logs, and images in one TUI so you can jump from a failing GPU
+  job to its logs without assembling docker incantations.
+
+use_cases:
+  - Watch GPU training containers and jump into logs when a job OOMs
+  - Inspect docker-compose stacks for local agent and inference services
+  - Prune unused images after repeated model-serving rebuilds
+  - Restart a crash-looping worker container from the TUI


### PR DESCRIPTION
## Summary
Add five Kubernetes / container Dev Tools entries to the catalog:

- **lazydocker** (jesseduffield/lazydocker, MIT) — TUI for Docker and Compose
- **ctop** (bcicen/ctop, MIT) — top-like TUI for container metrics
- **kops** (kubernetes/kops, Apache-2.0) — production Kubernetes installer and lifecycle
- **kubespray** (kubernetes-sigs/kubespray, Apache-2.0) — Ansible playbooks for HA Kubernetes on any infra
- **eksctl** (eksctl-io/eksctl, Apache-2.0) — official CLI for Amazon EKS

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added ctop to the developer tools catalog for container metrics monitoring.
  - Added eksctl for managing Amazon EKS clusters and node groups.
  - Added kops for Kubernetes cluster provisioning and operations.
  - Added Kubespray for highly available Kubernetes installations and upgrades.
  - Added lazydocker for managing and troubleshooting Docker and Compose environments.
  - Included installation details, documentation links, licensing, pricing, tags, and supported use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->