### PR TITLE
Add Watchman, Sealed Secrets, External Secrets, node_exporter to catalog

### DIFF
--- a/tools/dev-tools/external-secrets.yaml
+++ b/tools/dev-tools/external-secrets.yaml
@@ -1,0 +1,25 @@
+name: External Secrets
+description: Kubernetes operator that syncs secrets from AWS, GCP, Azure, Vault, and other backends into native Secret objects so ML workloads get credentials without copying them into the cluster by hand.
+tagline: Sync cloud secrets into Kubernetes automatically
+
+github_url: https://github.com/external-secrets/external-secrets
+website_url: https://external-secrets.io
+docs_url: https://external-secrets.io/latest/
+
+category: Dev Tools
+tags: [kubernetes, secrets, vault, aws, gitops, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Copying API keys from AWS Secrets Manager or Vault into Kubernetes Secrets
+  by hand drifts and leaks. External Secrets Operator pulls from those
+  backends on a schedule so inference pods and training Jobs always see the
+  current credential without a human paste.
+
+use_cases:
+  - Sync AWS Secrets Manager keys into inference Deployments
+  - Pull HashiCorp Vault tokens for agent workers at runtime
+  - Map GCP Secret Manager values into training Job env vars
+  - Refresh database credentials for a feature store without redeploying YAML

--- a/tools/dev-tools/sealed-secrets.yaml
+++ b/tools/dev-tools/sealed-secrets.yaml
@@ -1,0 +1,27 @@
+name: Sealed Secrets
+description: Kubernetes controller and kubeseal CLI for one-way encrypted Secrets. Commit sealed manifests to Git so ML platform credentials can live in GitOps without plaintext API keys.
+tagline: Encrypt Kubernetes Secrets for safe GitOps
+
+github_url: https://github.com/bitnami/sealed-secrets
+website_url: https://github.com/bitnami/sealed-secrets
+docs_url: https://github.com/bitnami/sealed-secrets
+
+install_command: brew install kubeseal
+
+category: Dev Tools
+tags: [kubernetes, secrets, gitops, security, devops, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Kubernetes Secrets are base64, not encrypted, so storing inference API keys
+  in Git is a leak waiting to happen. Sealed Secrets encrypts them with a
+  cluster-side key so only the controller can decrypt, which makes GitOps of
+  ML credentials safe.
+
+use_cases:
+  - Seal OpenAI or Anthropic API keys before committing GitOps manifests
+  - Store Hugging Face tokens as SealedSecrets in a public platform repo
+  - Rotate database passwords for feature stores without plaintext diffs
+  - Encrypt cloud credentials used by training Jobs in a shared cluster

--- a/tools/dev-tools/watchman.yaml
+++ b/tools/dev-tools/watchman.yaml
@@ -1,0 +1,27 @@
+name: Watchman
+description: File-watching service from Meta. Recursively watches huge source trees and fires commands on change, so ML repos, dataset folders, and codegen pipelines can rebuild without polling.
+tagline: Watch files and take action when they change
+
+github_url: https://github.com/facebook/watchman
+website_url: https://facebook.github.io/watchman/
+docs_url: https://facebook.github.io/watchman/docs/install.html
+
+install_command: brew install watchman
+
+category: Dev Tools
+tags: [filesystem, watch, build, devops, python, mlops, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Polling large ML repositories or dataset directories for changes wastes CPU
+  and misses events. Watchman maintains a persistent watch with a query API so
+  tools like Jest, Buck, and custom data pipelines get reliable change
+  notifications instead of walking the tree on a timer.
+
+use_cases:
+  - Trigger dataset preprocessing when new files land in a training directory
+  - Speed up JS or Python test watchers on monorepos that include model code
+  - Invalidate a local embedding cache when source documents change
+  - Drive incremental rebuilds for generated protobufs in an ML service

--- a/tools/monitoring/node-exporter.yaml
+++ b/tools/monitoring/node-exporter.yaml
@@ -1,0 +1,26 @@
+name: node_exporter
+description: Prometheus exporter for hardware and OS metrics. Exposes CPU, memory, disk, and network stats from every node so GPU training hosts and inference boxes can be scraped like the rest of the fleet.
+tagline: Prometheus exporter for machine metrics
+
+github_url: https://github.com/prometheus/node_exporter
+website_url: https://prometheus.io/docs/guides/node-exporter/
+docs_url: https://prometheus.io/docs/guides/node-exporter/
+
+install_command: brew install node_exporter
+
+category: Monitoring
+tags: [prometheus, metrics, linux, monitoring, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Application metrics miss host-level CPU steal, disk saturation, and NIC
+  errors that kill training jobs. node_exporter exposes those OS metrics in
+  Prometheus format so ML ops can alert on the machine, not only the pod.
+
+use_cases:
+  - Scrape CPU and disk metrics from GPU training hosts
+  - Alert when an inference box is swapping or filling its data disk
+  - Compare node load across a Kubernetes worker pool in Grafana
+  - Feed hardware metrics into capacity planning for model serving


### PR DESCRIPTION
## Summary
Add four remaining catalog entries from the post-#522 replenishment:

- **Watchman** (facebook/watchman, MIT) — Meta file-watching service for large trees
- **Sealed Secrets** (bitnami/sealed-secrets, Apache-2.0) — one-way encrypted Kubernetes Secrets plus kubeseal
- **External Secrets** (external-secrets/external-secrets, Apache-2.0) — sync cloud/Vault secrets into Kubernetes
- **node_exporter** (prometheus/node_exporter, Apache-2.0) — Prometheus exporter for host metrics

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all four files.
