### PR TITLE
Add Cluster API, descheduler, metrics-server, kube-state-metrics, Overmind to catalog

### DIFF
--- a/tools/dev-tools/cluster-api.yaml
+++ b/tools/dev-tools/cluster-api.yaml
@@ -1,0 +1,27 @@
+name: Cluster API
+description: Kubernetes subproject for declarative cluster lifecycle. Manage create, upgrade, and delete of clusters through CRDs so ML platforms can treat GPU clusters as GitOps objects instead of cloud consoles.
+tagline: Declarative Kubernetes cluster lifecycle via CRDs
+
+github_url: https://github.com/kubernetes-sigs/cluster-api
+website_url: https://cluster-api.sigs.k8s.io
+docs_url: https://cluster-api.sigs.k8s.io/introduction.html
+
+install_command: brew install clusterctl
+
+category: Dev Tools
+tags: [kubernetes, cluster, gitops, devops, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Standing up and upgrading Kubernetes clusters by clicking cloud consoles
+  does not scale when ML teams need ephemeral GPU clusters. Cluster API
+  models clusters as Kubernetes objects so you can provision, upgrade, and
+  delete them with the same GitOps flow as application workloads.
+
+use_cases:
+  - Provision ephemeral GPU Kubernetes clusters from a management cluster
+  - Upgrade worker node groups for inference without a cloud console
+  - GitOps the lifecycle of training clusters across AWS, Azure, and vSphere
+  - Delete preview clusters automatically after a PR is merged

--- a/tools/dev-tools/descheduler.yaml
+++ b/tools/dev-tools/descheduler.yaml
@@ -1,0 +1,24 @@
+name: descheduler
+description: Kubernetes descheduler that evicts pods based on policy so clusters rebalance after scale-up, node drain, or topology changes. Useful when training Jobs and inference pods pack unevenly across GPU nodes.
+tagline: Evict pods so Kubernetes clusters rebalance
+
+github_url: https://github.com/kubernetes-sigs/descheduler
+website_url: https://github.com/kubernetes-sigs/descheduler
+docs_url: https://github.com/kubernetes-sigs/descheduler
+
+category: Dev Tools
+tags: [kubernetes, scheduling, devops, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  kube-scheduler only places new pods. After nodes scale or drain, training
+  Jobs and inference replicas stay stuck on hot GPU nodes. The descheduler
+  evicts according to policy so the scheduler can pack workloads again.
+
+use_cases:
+  - Evict pods from overutilized GPU nodes after a training burst
+  - Spread inference replicas after a node pool scales up
+  - Remove pods that violate anti-affinity after topology changes
+  - Rebalance agent worker Deployments following a cluster upgrade

--- a/tools/dev-tools/overmind.yaml
+++ b/tools/dev-tools/overmind.yaml
@@ -1,0 +1,26 @@
+name: Overmind
+description: Process manager for Procfile apps that runs in tmux. Start API, worker, and watcher processes in one command so local ML agent stacks stay inspectable instead of hidden behind a daemon.
+tagline: Procfile process manager built on tmux
+
+github_url: https://github.com/DarthSim/overmind
+website_url: https://github.com/DarthSim/overmind
+
+install_command: brew install overmind
+
+category: Dev Tools
+tags: [procfile, tmux, process-manager, devops, local-dev, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Foreman-style process managers hide logs behind a multiplexer you cannot
+  attach to. Overmind runs each Procfile process in a tmux pane so you can
+  jump into the inference API or the agent worker, restart one process, and
+  keep the rest of the local stack running.
+
+use_cases:
+  - Run API, worker, and Redis-sidecar processes from a Procfile in tmux
+  - Restart a crashed local agent worker without killing the web process
+  - Inspect live logs of an embedding worker in its own tmux pane
+  - Share a local ML stack session with a teammate over tmux

--- a/tools/monitoring/kube-state-metrics.yaml
+++ b/tools/monitoring/kube-state-metrics.yaml
@@ -1,0 +1,25 @@
+name: kube-state-metrics
+description: Prometheus exporter that listens to the Kubernetes API and emits object-state metrics. Expose Deployment, Job, and Node conditions so ML platforms can alert when a training Job fails or a GPU node is NotReady.
+tagline: Kubernetes object metrics for Prometheus
+
+github_url: https://github.com/kubernetes/kube-state-metrics
+website_url: https://github.com/kubernetes/kube-state-metrics
+docs_url: https://github.com/kubernetes/kube-state-metrics
+
+category: Monitoring
+tags: [kubernetes, prometheus, metrics, monitoring, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Prometheus node metrics do not tell you a Job failed or a Deployment is
+  unavailable. kube-state-metrics turns API objects into time series so ML
+  ops can alert on training Job status, replica counts, and node conditions
+  with the same stack as CPU metrics.
+
+use_cases:
+  - Alert when a Kubernetes Job for model training fails
+  - Graph inference Deployment replica availability in Grafana
+  - Track GPU node Ready and pressure conditions over time
+  - Expose PersistentVolumeClaim status for dataset volumes

--- a/tools/monitoring/metrics-server.yaml
+++ b/tools/monitoring/metrics-server.yaml
@@ -1,0 +1,25 @@
+name: metrics-server
+description: Scalable, efficient source of container resource metrics for Kubernetes. Powers kubectl top, HPA, and VPA so inference Deployments can autoscale on CPU and memory without a full Prometheus stack.
+tagline: Resource metrics API for Kubernetes autoscaling
+
+github_url: https://github.com/kubernetes-sigs/metrics-server
+website_url: https://github.com/kubernetes-sigs/metrics-server
+docs_url: https://github.com/kubernetes-sigs/metrics-server
+
+category: Monitoring
+tags: [kubernetes, metrics, autoscaling, monitoring, mlops, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Horizontal Pod Autoscaler and kubectl top need a Metrics API, but running
+  full Prometheus just to scale inference replicas is heavy. metrics-server
+  scrapes kubelets and serves resource metrics so HPA works on CPU and
+  memory out of the box.
+
+use_cases:
+  - Enable kubectl top for GPU node and pod CPU or memory
+  - Autoscale inference Deployments with Horizontal Pod Autoscaler
+  - Feed VPA recommendations for agent worker resource requests
+  - Give kube-capacity utilization numbers on a new cluster


### PR DESCRIPTION
## Summary
Add five Kubernetes / process-manager catalog entries:

- **Cluster API** (kubernetes-sigs/cluster-api, Apache-2.0) — declarative cluster lifecycle via CRDs
- **descheduler** (kubernetes-sigs/descheduler, Apache-2.0) — policy-based pod eviction to rebalance clusters
- **metrics-server** (kubernetes-sigs/metrics-server, Apache-2.0) — resource metrics API for kubectl top and HPA
- **kube-state-metrics** (kubernetes/kube-state-metrics, Apache-2.0) — Kubernetes object metrics for Prometheus
- **Overmind** (DarthSim/overmind, MIT) — Procfile process manager on tmux

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Cluster API, Kubernetes descheduler, Overmind, kube-state-metrics, and metrics-server.
  - Included descriptions, links, installation details, licensing, categories, tags, pricing, and supported use cases.
  - Expanded the catalog’s coverage of Kubernetes cluster management, workload balancing, local process management, and monitoring tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->