### PR TITLE
Add Hivemind, Circus to catalog

### DIFF
--- a/tools/dev-tools/circus.yaml
+++ b/tools/dev-tools/circus.yaml
@@ -1,0 +1,23 @@
+name: Circus
+description: Python process and socket manager built on ZeroMQ that watches, restarts, and scales worker processes from a single config. Circus keeps long-running Python services, data pipeline workers, and model-serving processes alive with sockets, watchers, and a control channel.
+tagline: Process and socket manager for Python workers
+
+github_url: https://github.com/circus-tent/circus
+website_url: https://circus.readthedocs.io
+docs_url: https://circus.readthedocs.io
+install_command: pip install circus
+
+category: Dev Tools
+tags: [python, process-manager, zeromq, sockets, devops, workers, supervision]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Python ML services and data workers crash, leak memory, or need extra processes as load grows. Running them under systemd or a shell loop gives little control over sockets, scaling, or live reconfiguration. Circus supervises watchers and sockets from one INI config, restarts failing processes, and exposes a ZeroMQ control channel so you can add, stop, or inspect workers without taking the stack down.
+
+use_cases:
+  - Supervise model-serving Python workers with automatic restart after crashes or memory limits
+  - Bind sockets once in Circus and hand them to forked workers so reloads do not drop connections
+  - Scale data-pipeline consumers up or down at runtime through the circusctl control channel
+  - Run mixed Python and non-Python watchers from a single circus.ini in a training or inference host

--- a/tools/dev-tools/hivemind.yaml
+++ b/tools/dev-tools/hivemind.yaml
@@ -1,0 +1,22 @@
+name: Hivemind
+description: Decentralized PyTorch library for training neural networks across volunteer machines over the internet. Hivemind runs distributed averaging, Mixture-of-Experts layers, and DHT-based peer discovery so you can scale training without a dedicated GPU cluster.
+tagline: Train PyTorch models across volunteer machines, not a private cluster
+
+github_url: https://github.com/learning-at-home/hivemind
+docs_url: https://learning-at-home.readthedocs.io/
+install_command: pip install hivemind
+
+category: Dev Tools
+tags: [python, pytorch, distributed-training, decentralized, dht, mixture-of-experts, volunteer-computing]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Large-model training usually needs a private GPU cluster with fast interconnects. Independent labs and open collaborations rarely have that. Hivemind turns unreliable volunteer machines into a training swarm: peers discover each other over a DHT, average gradients asynchronously, and host Mixture-of-Experts layers that other peers can call. You get collaborative training and inference over the public internet without a central coordinator.
+
+use_cases:
+  - Train a language model collaboratively across home GPUs that join and leave the swarm
+  - Host decentralized Mixture-of-Experts layers that other peers query during training or inference
+  - Adapt an existing PyTorch Lightning training loop to slow, unreliable networks via the Hivemind strategy
+  - Power volunteer inference networks such as Petals without standing up a managed GPU fleet


### PR DESCRIPTION
## Add Hivemind, Circus to catalog

Remainder batch from the tracker (2 tools).

| Tool | Category | Repo | Stars |
|------|----------|------|-------|
| Hivemind | Dev Tools | learning-at-home/hivemind | 2.5k |
| Circus | Dev Tools | circus-tent/circus | 1.6k |

- Local validation passed (`npx tsx scripts/validate-tool.ts`)
- Distinct from existing Petals (Hivemind is the underlying decentralized training library)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Circus to the Dev Tools catalog with installation details, documentation links, licensing, and use cases.
  * Added Hivemind to the Dev Tools catalog with installation details, documentation links, licensing, and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->