### PR TITLE
Add Conductor, Zellij, Infisical, CodeQL, nvtop to catalog

### DIFF
--- a/tools/agent-frameworks/conductor.yaml
+++ b/tools/agent-frameworks/conductor.yaml
@@ -1,0 +1,23 @@
+name: Conductor
+description: Open-source durable execution engine for microservices and AI agents. Conductor persists every step of a workflow graph so LLM loops, MCP tool calls, human approvals, and retries survive crashes and can be inspected, replayed, or recovered.
+tagline: Durable workflow engine for agents and microservices
+
+github_url: https://github.com/conductor-oss/conductor
+website_url: https://conductor-oss.org
+docs_url: https://docs.conductor-oss.org/
+install_command: npm install -g @conductor-oss/conductor-cli
+
+category: Agents
+tags: [java, workflows, durable-execution, agents, orchestration, mcp, microservices]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Agent loops and multi-step microservice jobs die when a process restarts, and code-first orchestrators couple business logic to replay rules. Conductor stores the orchestration graph and every task result, so workers in any language can poll, fail, retry, or wait for humans while the engine keeps durable state. Native LLM and MCP tasks let you run think-act agents without hiding control flow inside a framework.
+
+use_cases:
+  - Run a think-act agent loop with MCP tool calls that survives worker crashes mid-iteration
+  - Orchestrate RAG pipelines as versioned graphs with retries, timeouts, and human approval gates
+  - Coordinate polyglot workers that poll Conductor for training, evaluation, or data-prep tasks
+  - Replay or restart a failed multi-step agent workflow from the persisted execution history

--- a/tools/dev-tools/codeql.yaml
+++ b/tools/dev-tools/codeql.yaml
@@ -1,0 +1,23 @@
+name: CodeQL
+description: Semantic code analysis engine that treats source as a queryable database so you can find vulnerability variants across a codebase. CodeQL powers GitHub code scanning and is free for open source research, with a CLI and VS Code extension for custom queries.
+tagline: Query code like data to find vulnerability variants
+
+github_url: https://github.com/github/codeql
+website_url: https://codeql.github.com
+docs_url: https://codeql.github.com/docs/
+install_command: brew install codeql
+
+category: Dev Tools
+tags: [security, static-analysis, code-scanning, github, vulnerability, cli]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Prompt-injection handlers, deserialization, and secret handling in AI apps fail in many similar shapes. Grep and linters miss data-flow variants. CodeQL builds a database of the program and runs QL queries that track taint across files, so one pattern finds every similar bug in Python, Java, JavaScript, and more before it ships.
+
+use_cases:
+  - Scan an agent backend for injection and unsafe deserialization with GitHub code scanning
+  - Write a custom QL query that finds leaked API keys flowing into logs in Python ML services
+  - Build a CodeQL database locally and hunt variants of a bug found in a RAG API
+  - Run CodeQL in CI on open-source AI libraries to block known vulnerability classes

--- a/tools/dev-tools/infisical.yaml
+++ b/tools/dev-tools/infisical.yaml
@@ -1,0 +1,23 @@
+name: Infisical
+description: Open-source secrets, certificates, and privileged-access platform that syncs API keys and configs across apps, CI, and infrastructure. Infisical keeps LLM keys, database credentials, and model-registry tokens out of git and environment sprawl.
+tagline: Open-source secrets manager for teams and infrastructure
+
+github_url: https://github.com/Infisical/infisical
+website_url: https://infisical.com
+docs_url: https://infisical.com/docs/documentation/getting-started/introduction
+install_command: brew install infisical
+
+category: Dev Tools
+tags: [secrets-management, security, cli, devops, environment-variables, pki]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  ML stacks juggle provider API keys, feature-store passwords, and cloud tokens that leak through .env files, CI logs, and shared Slack messages. Infisical centralizes those secrets, syncs them into runtimes and pipelines, and self-hosts or runs as cloud so training jobs and agent services get credentials without committing them to the repo.
+
+use_cases:
+  - Inject OpenAI, Anthropic, and vector-DB keys into agent services without storing them in git
+  - Sync environment configs from Infisical into Kubernetes, CI, and local .env files for ML apps
+  - Rotate model-registry and cloud-storage credentials used by training jobs from one dashboard
+  - Self-host a secrets backend for a research lab that cannot put keys in a vendor vault

--- a/tools/dev-tools/zellij.yaml
+++ b/tools/dev-tools/zellij.yaml
@@ -1,0 +1,23 @@
+name: Zellij
+description: Terminal workspace and multiplexer with layouts, floating panes, WASM plugins, and a built-in web client. Zellij gives ML engineers a batteries-included session for training jobs, logs, and editors without sacrificing a simple default UX.
+tagline: Terminal workspace with multiplexer, layouts, and plugins
+
+github_url: https://github.com/zellij-org/zellij
+website_url: https://zellij.dev
+docs_url: https://zellij.dev/documentation/
+install_command: brew install zellij
+
+category: Dev Tools
+tags: [rust, terminal, multiplexer, workspace, cli, plugins, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Training, serving, and data jobs need several terminal panes, persistent sessions, and shared layouts. tmux is powerful but steep. Zellij ships a usable default, named layouts for recurring ML workflows, floating and stacked panes, WASM plugins, and optional web access so a GPU box session stays organized without a heavy custom config.
+
+use_cases:
+  - Save a training layout with logs, GPU monitor, and editor panes that restore on attach
+  - Share a remote GPU-box session through Zellij's web client without exposing raw SSH mux config
+  - Run WASM plugins that surface job status or notes beside a long-running fine-tune
+  - Keep multiple experiment shells in stacked panes instead of a pile of SSH windows

--- a/tools/monitoring/nvtop.yaml
+++ b/tools/monitoring/nvtop.yaml
@@ -1,0 +1,21 @@
+name: nvtop
+description: Interactive GPU and accelerator process monitor in the style of htop. nvtop shows utilization, memory, power, and per-process usage for NVIDIA, AMD, Intel, Apple, Huawei Ascend, and other accelerators used in ML training and inference.
+tagline: htop-style monitor for GPUs and AI accelerators
+
+github_url: https://github.com/Syllo/nvtop
+install_command: brew install nvtop
+
+category: Monitoring
+tags: [gpu, monitoring, nvidia, amd, intel, cli, training, inference]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Training and inference jobs share GPUs, and nvidia-smi snapshots do not show a live per-process view across vendors. nvtop is an htop-like TUI for utilization, memory, power, and processes on NVIDIA, AMD, Intel, Apple, Ascend, and more, so you can see which job is saturating a box without a vendor-specific dashboard.
+
+use_cases:
+  - Watch GPU memory and utilization while a fine-tune shares a machine with inference workers
+  - Identify which process is hogging VRAM on a multi-user training server
+  - Monitor AMD, Intel, or Apple accelerators with the same TUI used for NVIDIA boxes
+  - SSH into a GPU host and get a live process view without a Prometheus stack


### PR DESCRIPTION
## Add Conductor, Zellij, Infisical, CodeQL, nvtop to catalog

Replenishment batch after PR #526 (Hivemind, Circus).

| Tool | Category | Repo | Stars |
|------|----------|------|-------|
| Conductor | Agents | conductor-oss/conductor | 32k |
| Zellij | Dev Tools | zellij-org/zellij | 35k |
| Infisical | Dev Tools | Infisical/infisical | 29k |
| CodeQL | Dev Tools | github/codeql | 10k |
| nvtop | Monitoring | Syllo/nvtop | 11k |

Local validation passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Conductor, CodeQL, Infisical, Zellij, and nvtop.
  - Conductor is documented for durable workflow and microservice orchestration.
  - CodeQL is documented for semantic code analysis and security scanning.
  - Infisical is documented for secrets management and credential rotation.
  - Zellij is documented as a terminal workspace and multiplexer.
  - nvtop is documented for interactive GPU and accelerator monitoring.
  - Each entry includes installation details, links, categorization, licensing, and representative use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->