### PR TITLE
Add Silero VAD, pprof, nvitop to catalog

### DIFF
--- a/tools/dev-tools/pprof.yaml
+++ b/tools/dev-tools/pprof.yaml
@@ -1,0 +1,22 @@
+name: pprof
+description: Profiling visualization and analysis tool from Google that turns CPU, heap, and contention profiles into interactive graphs and flame charts. pprof is the standard way to inspect Go services, including model-serving and agent backends.
+tagline: Visualize CPU and memory profiles as graphs and flame charts
+
+github_url: https://github.com/google/pprof
+docs_url: https://github.com/google/pprof/blob/main/doc/README.md
+install_command: go install github.com/google/pprof@latest
+
+category: Dev Tools
+tags: [go, profiling, performance, flamegraph, cpu, memory, observability]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Inference proxies, agent APIs, and data workers written in Go hide CPU and memory hotspots until production latency spikes. pprof collects runtime profiles and renders call graphs and flame charts so you can see which handlers, serializers, or embedding calls dominate, then compare before and after a change.
+
+use_cases:
+  - Profile a Go model-serving API to find CPU hotspots in JSON, gRPC, or embedding calls
+  - Capture heap profiles from a long-running agent worker and inspect retained objects
+  - Compare contention profiles before and after a concurrency change in a pipeline
+  - Serve pprof HTTP endpoints in development and pull flame charts from a remote GPU box

--- a/tools/monitoring/nvitop.yaml
+++ b/tools/monitoring/nvitop.yaml
@@ -1,0 +1,23 @@
+name: nvitop
+description: Interactive NVIDIA GPU process viewer and Python library that monitors utilization, memory, temperature, and per-process usage. nvitop goes beyond nvidia-smi with a tree view, filtering, and an API for training scripts and cluster dashboards.
+tagline: Interactive NVIDIA GPU process viewer and Python monitoring API
+
+github_url: https://github.com/XuehaiPan/nvitop
+website_url: https://nvitop.readthedocs.io
+docs_url: https://nvitop.readthedocs.io
+install_command: pip install nvitop
+
+category: Monitoring
+tags: [python, nvidia, gpu, monitoring, cuda, training, cli]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  nvidia-smi is a snapshot, not a process manager, and wrapping NVML in every training script is tedious. nvitop gives an interactive tree of GPU processes plus a Python API so you can watch VRAM, kill runaway jobs, and log metrics from PyTorch jobs without building a custom NVML wrapper.
+
+use_cases:
+  - Interactively inspect which PID owns VRAM on a shared training server and kill leaked processes
+  - Log GPU utilization and memory from inside a PyTorch training loop via the nvitop API
+  - Filter GPU processes by user or command when multiple experiments share a node
+  - Replace ad-hoc nvidia-smi watch loops with a tree view of CUDA contexts and host trees

--- a/tools/other/silero-vad.yaml
+++ b/tools/other/silero-vad.yaml
@@ -1,0 +1,22 @@
+name: Silero VAD
+description: Pre-trained voice activity detector that flags speech timestamps in audio with a 2 MB PyTorch or ONNX model. Silero VAD runs in under 1 ms per chunk on CPU and is used to trim silence in STT, voice-agent, and dataset-prep pipelines.
+tagline: Fast on-device voice activity detection for speech pipelines
+
+github_url: https://github.com/snakers4/silero-vad
+docs_url: https://github.com/snakers4/silero-vad/wiki
+install_command: pip install silero-vad
+
+category: Other
+tags: [python, pytorch, onnx, speech, vad, audio, stt]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Speech-to-text, voice agents, and audio datasets waste compute on silence and noise. Cloud VAD APIs add latency and cost. Silero VAD is a 2 MB MIT-licensed model that returns speech timestamps in milliseconds on CPU via PyTorch or ONNX, so you can gate ASR, chunk recordings, and clean training audio without a GPU or a hosted detector.
+
+use_cases:
+  - Gate a streaming STT or voice-agent pipeline so the LLM only sees speech segments
+  - Strip silence from call-center and podcast audio before transcription or dataset export
+  - Run on-device VAD in telephony bots at 8 kHz or 16 kHz without a GPU
+  - Batch-detect speech regions when preparing multilingual audio corpora for ASR training


### PR DESCRIPTION
## Add Silero VAD, pprof, nvitop to catalog

Remainder batch after PR #527.

| Tool | Category | Repo | Stars |
|------|----------|------|-------|
| Silero VAD | Other | snakers4/silero-vad | 10k |
| pprof | Dev Tools | google/pprof | 9.3k |
| nvitop | Monitoring | XuehaiPan/nvitop | 7.1k |

Local validation passed for all three files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for **pprof**, a Go profiling tool for analyzing performance, memory usage, and contention.
  - Added **nvitop**, an interactive NVIDIA GPU monitoring tool for inspecting processes, VRAM, and training metrics.
  - Added **Silero VAD**, a voice activity detection tool for speech pipelines, telephony, and audio processing.

- **Documentation**
  - Added installation details, links, licensing information, categories, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->