### PR TITLE
Add gpustat, Beyla, NVIDIA GPU Operator, blackbox_exporter, Prometheus Operator to catalog

### DIFF
--- a/tools/dev-tools/nvidia-gpu-operator.yaml
+++ b/tools/dev-tools/nvidia-gpu-operator.yaml
@@ -1,0 +1,26 @@
+name: NVIDIA GPU Operator
+description: NVIDIA GPU Operator automates GPU software on Kubernetes. It installs drivers, the container toolkit, device plugin, DCGM exporter, and related components so training and inference pods can request GPUs without hand-maintaining node images.
+tagline: Automate GPU drivers and device plugins on Kubernetes
+
+github_url: https://github.com/NVIDIA/gpu-operator
+website_url: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html
+docs_url: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html
+
+category: Dev Tools
+tags: [nvidia, gpu, kubernetes, operator, dcgm, device-plugin, cuda]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Running GPUs on Kubernetes usually means baking drivers, nvidia-container-toolkit, and
+  the device plugin into every node image, then keeping them in sync across upgrades.
+  GPU Operator watches the cluster and installs those components as containers so GPU
+  nodes come up ready for training and inference without custom AMIs.
+
+use_cases:
+  - Provision NVIDIA drivers and the GPU device plugin on a new Kubernetes GPU node pool
+  - Expose DCGM metrics so Prometheus can scrape GPU health on training clusters
+  - Let inference pods request nvidia.com/gpu without custom node images
+  - Upgrade CUDA driver stacks on GPU nodes through the operator instead of rebuilds
+  - Run mixed CPU and GPU node groups with GPU software only where GPUs exist

--- a/tools/monitoring/beyla.yaml
+++ b/tools/monitoring/beyla.yaml
@@ -1,0 +1,26 @@
+name: Beyla
+description: Grafana Beyla is an eBPF auto-instrumentation agent that captures HTTP, gRPC, and network metrics from applications without code changes or sidecars. It exports OpenTelemetry and Prometheus telemetry so services get RED metrics and traces with zero SDK work.
+tagline: Zero-code eBPF auto-instrumentation for apps and networks
+
+github_url: https://github.com/grafana/beyla
+website_url: https://grafana.com/oss/beyla-ebpf/
+docs_url: https://grafana.com/docs/beyla/latest/
+
+category: Monitoring
+tags: [ebpf, opentelemetry, prometheus, grafana, tracing, metrics, kubernetes]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Instrumenting every microservice with an OpenTelemetry SDK is slow, and sidecars add
+  operational cost. Beyla uses eBPF to observe HTTP, gRPC, and network traffic from the
+  kernel, then exports Prometheus metrics and OpenTelemetry traces so GPU clusters and
+  agent APIs become observable without touching application code.
+
+use_cases:
+  - Auto-instrument HTTP and gRPC model-serving APIs without adding an SDK
+  - Export RED metrics from agent microservices to Prometheus or Grafana Cloud
+  - Capture traces for a polyglot stack where some services cannot take a language agent
+  - Observe Kubernetes workloads at the network layer when you cannot rebuild images
+  - Fill gaps between application APM and kernel-level visibility on GPU inference nodes

--- a/tools/monitoring/blackbox-exporter.yaml
+++ b/tools/monitoring/blackbox-exporter.yaml
@@ -1,0 +1,26 @@
+name: blackbox_exporter
+description: Prometheus Blackbox Exporter probes HTTP, HTTPS, DNS, TCP, ICMP, and gRPC endpoints from the outside so you can alert when model APIs, vector databases, or agent webhooks go dark even if in-process metrics still look healthy.
+tagline: Probe HTTP, DNS, TCP, and ICMP targets from the outside
+
+github_url: https://github.com/prometheus/blackbox_exporter
+website_url: https://prometheus.io/
+docs_url: https://github.com/prometheus/blackbox_exporter
+
+category: Monitoring
+tags: [prometheus, probing, http, uptime, alerting, grpc, dns]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  In-process metrics can look fine while users cannot reach the service. Blackbox Exporter
+  probes HTTP, HTTPS, DNS, TCP, ICMP, and gRPC from outside the process so Prometheus can
+  alert on availability, TLS expiry, and latency of model endpoints and agent webhooks
+  the way a client would see them.
+
+use_cases:
+  - Probe a model inference HTTP API and alert when status or latency degrades
+  - Check TLS certificate expiry on public vector-database and LLM gateway endpoints
+  - ICMP or TCP probe GPU cluster login nodes and internal agent services
+  - DNS probe that the serving hostname still resolves before a traffic spike
+  - gRPC health probes against inference servers that do not expose a /metrics path

--- a/tools/monitoring/gpustat.yaml
+++ b/tools/monitoring/gpustat.yaml
@@ -1,0 +1,28 @@
+name: gpustat
+description: A command-line utility for querying NVIDIA GPU status. gpustat shows utilization, memory, temperature, and which processes own each GPU in a compact table, making multi-GPU training boxes easier to inspect than raw nvidia-smi.
+tagline: Compact nvidia-smi-style GPU status in one command
+
+github_url: https://github.com/wookayin/gpustat
+website_url: https://pypi.org/project/gpustat/
+docs_url: https://github.com/wookayin/gpustat
+
+install_command: pip install gpustat
+
+category: Monitoring
+tags: [gpu, nvidia, nvidia-smi, python, metrics, training, cli]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  nvidia-smi dumps a dense table that is hard to scan when several training jobs share a box.
+  gpustat prints a one-line-per-GPU view with utilization, memory, temperature, and the
+  processes holding the device, so ML engineers can see who is occupying which GPU before
+  launching another job or debugging an OOM.
+
+use_cases:
+  - Check which process owns each GPU on a shared training machine before starting a run
+  - Watch GPU memory and utilization while a fine-tune or inference job is in flight
+  - Script a watch loop that alerts when a GPU is idle or over temperature
+  - Inspect multi-GPU nodes in a cluster login session without parsing nvidia-smi XML
+  - Confirm a container actually received the GPUs it requested after a Kubernetes launch

--- a/tools/monitoring/prometheus-operator.yaml
+++ b/tools/monitoring/prometheus-operator.yaml
@@ -1,0 +1,26 @@
+name: Prometheus Operator
+description: Prometheus Operator manages Prometheus, Alertmanager, and related monitoring components on Kubernetes via CRDs. Teams declare ServiceMonitors and PrometheusRules so GPU clusters and agent workloads get scrape configs and alerts without editing Prometheus YAML by hand.
+tagline: Kubernetes CRDs for Prometheus, Alertmanager, and scrape config
+
+github_url: https://github.com/prometheus-operator/prometheus-operator
+website_url: https://prometheus-operator.dev
+docs_url: https://prometheus-operator.dev/docs/getting-started/introduction/
+
+category: Monitoring
+tags: [prometheus, kubernetes, operator, alerting, servicemonitor, crd]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Running Prometheus on Kubernetes by hand means stitching scrape configs, Alertmanager,
+  and service discovery every time a new workload appears. Prometheus Operator introduces
+  CRDs such as Prometheus, ServiceMonitor, and PrometheusRule so GPU clusters and agent
+  services can opt into scraping and alerting as Kubernetes objects.
+
+use_cases:
+  - Deploy a Prometheus instance on Kubernetes with CRDs instead of raw ConfigMaps
+  - Add a ServiceMonitor so a new model-serving Deployment is scraped automatically
+  - Manage Alertmanager and PrometheusRules as GitOps objects alongside app manifests
+  - Watch GPU and DCGM exporters without rewriting prometheus.yml on every change
+  - Run multiple Prometheus shards for large agent and training clusters


### PR DESCRIPTION
## Add 5 tools to the catalog

- **gpustat** (Monitoring) — compact CLI for NVIDIA GPU utilization, memory, temperature, and owning processes
- **Beyla** (Monitoring) — Grafana eBPF auto-instrumentation that exports OpenTelemetry and Prometheus telemetry without SDKs
- **NVIDIA GPU Operator** (Dev Tools) — Kubernetes operator that installs GPU drivers, toolkit, device plugin, and DCGM exporter
- **blackbox_exporter** (Monitoring) — Prometheus prober for HTTP, DNS, TCP, ICMP, and gRPC from outside the process
- **Prometheus Operator** (Monitoring) — CRDs for Prometheus, Alertmanager, ServiceMonitor, and PrometheusRule on Kubernetes

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for NVIDIA GPU Operator, Grafana Beyla, Prometheus Blackbox Exporter, gpustat, and Prometheus Operator.
  - Added descriptions, links, categories, tags, pricing, licensing details, and practical use cases for each tool.
  - Expanded discoverability for GPU provisioning and monitoring, eBPF-based observability, endpoint probing, NVIDIA GPU inspection, and Kubernetes-native Prometheus management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->