### PR TITLE
Add age, PagerDuty, Railway to catalog

### DIFF
--- a/tools/dev-tools/age.yaml
+++ b/tools/dev-tools/age.yaml
@@ -1,0 +1,28 @@
+name: age
+description: A simple, modern file encryption tool and Go library with small explicit keys, no config file, and UNIX-style composability. age encrypts files to recipients so secrets, model weights, and dataset dumps can be shared without a heavyweight PKI.
+tagline: Simple, modern file encryption with small explicit keys
+
+github_url: https://github.com/FiloSottile/age
+website_url: https://age-encryption.org
+docs_url: https://github.com/FiloSottile/age
+
+install_command: brew install age
+
+category: Dev Tools
+tags: [encryption, security, secrets, golang, cli, cryptography]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Teams still encrypt model artifacts and env files with ad-hoc OpenSSL commands or
+  bloated PGP setups that are easy to misconfigure. age uses small explicit keys and a
+  single-purpose CLI so you can encrypt files to recipients, decrypt them in pipelines,
+  and avoid a config-heavy PKI for secrets that AI workloads pass around.
+
+use_cases:
+  - Encrypt API keys and .env files before storing them in object storage
+  - Share model checkpoints with a recipient public key instead of a shared password
+  - Decrypt secrets in a CI job that trains or deploys an agent
+  - Replace ad-hoc OpenSSL enc invocations with a composable UNIX filter
+  - Encrypt dataset dumps at rest before uploading them to a training cluster

--- a/tools/dev-tools/railway.yaml
+++ b/tools/dev-tools/railway.yaml
@@ -1,0 +1,27 @@
+name: Railway
+description: A deployment platform that builds and runs apps from a Git repo with zero config. Railway provisions databases, env vars, and HTTPS so you can ship agent APIs, MCP servers, and model backends without assembling Kubernetes or a custom CI pipeline.
+tagline: Deploy apps and databases from Git with zero config
+
+github_url: https://github.com/railwayapp/cli
+website_url: https://railway.com
+docs_url: https://docs.railway.com
+
+install_command: npm install -g @railway/cli
+
+category: Dev Tools
+tags: [paas, deployment, hosting, git, databases, cli]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Shipping an agent API or MCP server still means stitching a Dockerfile, a registry,
+  a database, secrets, and a reverse proxy. Railway builds from Git, provisions backing
+  services, and gives you HTTPS and logs so small AI products can go live without a
+  platform team or a full Kubernetes cluster.
+
+use_cases:
+  - Deploy an agent or MCP server from a GitHub repo with one CLI command
+  - Provision Postgres or Redis next to an inference API without a separate cloud account
+  - Preview environments for pull requests that change a model-serving app
+  - Store secrets and env vars for LLM keys outside application code
+  - Scale a small production AI app without operating Kubernetes

--- a/tools/monitoring/pagerduty.yaml
+++ b/tools/monitoring/pagerduty.yaml
@@ -1,0 +1,24 @@
+name: PagerDuty
+description: An incident response and on-call platform that routes alerts, runs escalation policies, and coordinates response when model APIs, GPU clusters, or agent pipelines fail. Teams get noise-reduced paging, status updates, and post-incident timelines from one console.
+tagline: On-call incident response for production AI systems
+
+website_url: https://www.pagerduty.com
+docs_url: https://developer.pagerduty.com
+
+category: Monitoring
+tags: [incident-response, on-call, alerting, paging, sla, observability]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Prometheus and log alerts fire, but nobody knows who is on call or how to escalate when
+  an inference endpoint is down at 3am. PagerDuty turns those alerts into incidents with
+  escalation policies, mobile paging, and a response timeline so GPU clusters and agent
+  services get a human in the loop before customers feel the outage.
+
+use_cases:
+  - Page the on-call ML engineer when a model-serving SLO burns
+  - Escalate unanswered GPU cluster alerts from Prometheus Alertmanager
+  - Coordinate incident response across data, platform, and agent teams
+  - Reduce alert noise with event intelligence before waking someone
+  - Capture a post-incident timeline for a failed RAG or training pipeline


### PR DESCRIPTION
## Add 3 tools to the catalog

- **age** (Dev Tools) — FiloSottile/age, modern file encryption with small explicit keys
- **PagerDuty** (Monitoring) — incident response and on-call routing for production alerts
- **Railway** (Dev Tools) — Git-based PaaS for deploying apps, agents, and backing services

Local validation passed for all three YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Age, Railway, and PagerDuty.
  * Added user-facing descriptions, categories, tags, pricing, licensing, links, installation details, and practical use cases for each tool.
  * Documented workflows including file encryption, deployment, infrastructure provisioning, incident response, alerting, and escalation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->