### PR TITLE
Add aria2, cloc, bandwhich, Yazi to catalog

### DIFF
--- a/tools/dev-tools/aria2.yaml
+++ b/tools/dev-tools/aria2.yaml
@@ -1,0 +1,28 @@
+name: aria2
+description: Lightweight multi-protocol download utility for HTTP, HTTPS, FTP, SFTP, BitTorrent, and Metalink. aria2 splits files across connections and sources so you can pull large datasets, model weights, and artifacts faster than a single wget stream.
+tagline: Multi-source CLI downloader for large files
+
+github_url: https://github.com/aria2/aria2
+website_url: https://aria2.github.io/
+docs_url: https://aria2.github.io/manual/en/html/index.html
+
+install_command: brew install aria2
+
+category: Dev Tools
+tags: [cli, download, datasets, bittorrent, http, artifacts]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  wget and curl pull one URL at a time, which is slow for multi-gigabyte model
+  weights and public datasets. aria2 parallelizes across connections and sources,
+  resumes interrupted transfers, and speaks HTTP, FTP, SFTP, BitTorrent, and Metalink
+  so you can fetch training data without standing up a custom download script.
+
+use_cases:
+  - Download Hugging Face or S3-hosted model weights with multi-connection speed
+  - Resume an interrupted dataset fetch after a cluster node drops the network
+  - Pull a Metalink or torrent of public training data onto a GPU box
+  - Mirror artifacts across HTTP and FTP mirrors in one command
+  - Script batch downloads of checkpoints in CI without a GUI client

--- a/tools/dev-tools/cloc.yaml
+++ b/tools/dev-tools/cloc.yaml
@@ -1,0 +1,28 @@
+name: cloc
+description: Counts blank lines, comments, and physical lines of source code across hundreds of languages. cloc gives a language mix so you can size an ML repo, compare generated vs handwritten code, and report codebase scale without opening an IDE.
+tagline: Count lines of code by language
+
+github_url: https://github.com/AlDanial/cloc
+website_url: https://github.com/AlDanial/cloc
+docs_url: https://github.com/AlDanial/cloc
+
+install_command: brew install cloc
+
+category: Dev Tools
+tags: [cli, metrics, source-code, languages, productivity]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Sizing a mixed Python, CUDA, and YAML ML repo by hand is slow and wrong.
+  cloc walks the tree, ignores vendored noise when asked, and reports blank,
+  comment, and code lines per language so you can compare generated agent code
+  to handwritten training code before a review or a paper appendix.
+
+use_cases:
+  - Report language mix and code size for an ML training repository
+  - Compare generated agent code against handwritten CUDA kernels
+  - Exclude notebooks and data files when counting production Python
+  - Produce a lines-of-code table for a research paper or audit
+  - Track how a fine-tuning codebase grows across releases

--- a/tools/dev-tools/yazi.yaml
+++ b/tools/dev-tools/yazi.yaml
@@ -1,0 +1,28 @@
+name: Yazi
+description: Blazing fast terminal file manager written in Rust, based on async I/O. Yazi lets you browse, preview, and batch-operate on datasets and checkpoints in the terminal without waiting on a GUI file manager.
+tagline: Async terminal file manager written in Rust
+
+github_url: https://github.com/sxyazi/yazi
+website_url: https://yazi-rs.github.io
+docs_url: https://yazi-rs.github.io
+
+install_command: brew install yazi
+
+category: Dev Tools
+tags: [cli, tui, file-manager, rust, datasets, productivity]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  ls and find are slow when a dataset directory has tens of thousands of shards,
+  and GUI file managers are unavailable on headless GPU boxes. Yazi is an async
+  TUI file manager with previews and batch ops so you can navigate checkpoints
+  and training data without leaving the SSH session.
+
+use_cases:
+  - Browse a large dataset directory on a headless GPU node over SSH
+  - Preview images and text samples before kicking off a training run
+  - Batch-rename or move checkpoint files without a GUI
+  - Jump between experiment output folders with fuzzy find
+  - Inspect logs and artifacts while a training job is still running

--- a/tools/monitoring/bandwhich.yaml
+++ b/tools/monitoring/bandwhich.yaml
@@ -1,0 +1,28 @@
+name: bandwhich
+description: Terminal bandwidth utilization tool that shows which processes and connections are using the network. bandwhich maps live traffic to PIDs so you can find a training job flooding the NIC or a data loader saturating a shared cluster link.
+tagline: See which processes are using the network
+
+github_url: https://github.com/imsnif/bandwhich
+website_url: https://github.com/imsnif/bandwhich
+docs_url: https://github.com/imsnif/bandwhich
+
+install_command: brew install bandwhich
+
+category: Monitoring
+tags: [network, bandwidth, tui, cli, rust, processes]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  iftop shows connections but not which Python process owns them, so a noisy
+  data loader and a model download look the same. bandwhich attributes live
+  bandwidth to processes and remote addresses so you can stop the job saturating
+  a shared GPU node before it starves checkpoint uploads.
+
+use_cases:
+  - Find which training worker is flooding the NIC during a dataset pull
+  - See if a data loader is saturating a shared cluster uplink
+  - Debug slow checkpoint uploads by watching per-process bandwidth
+  - Identify unexpected outbound traffic from an inference container
+  - Compare network use of distributed training ranks on one machine


### PR DESCRIPTION
## Add aria2, cloc, bandwhich, Yazi to catalog

Remainder batch from the candidate tracker (4 tools).

| Tool | Category | Repo | Stars | License |
|------|----------|------|-------|---------|
| aria2 | Dev Tools | aria2/aria2 | 41.9k | GPL-2.0 |
| cloc | Dev Tools | AlDanial/cloc | 23.5k | GPL-2.0 |
| bandwhich | Monitoring | imsnif/bandwhich | 12.0k | MIT |
| Yazi | Dev Tools | sxyazi/yazi | 42.0k | MIT |

All files validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added four open-source developer tools to the catalog:
    - **aria2** for multi-connection downloads, resumable transfers, torrents, and mirror fetching.
    - **cloc** for counting and comparing source code across languages and file types.
    - **Yazi** as a terminal-based file manager.
    - **bandwhich** for monitoring network bandwidth usage by process.
  - Added installation details, documentation links, licensing, pricing, categories, tags, and use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->