### PR TITLE
Add nmap, tcpdump, ImageMagick, rsync, strace to catalog

### DIFF
--- a/tools/data/imagemagick.yaml
+++ b/tools/data/imagemagick.yaml
@@ -1,0 +1,28 @@
+name: ImageMagick
+description: Open-source suite for creating, editing, converting, and displaying images across 200+ formats. ImageMagick is the CLI workhorse for resizing dataset images, converting formats, and generating thumbnails in ML pipelines.
+tagline: Convert and transform images from the command line
+
+github_url: https://github.com/ImageMagick/ImageMagick
+website_url: https://imagemagick.org
+docs_url: https://imagemagick.org/script/command-line-processing.php
+
+install_command: brew install imagemagick
+
+category: Data
+tags: [images, conversion, cli, datasets, computer-vision]
+pricing: free
+is_open_source: true
+license: ImageMagick
+
+problem_solved: |
+  Vision datasets arrive as mixed JPEG, PNG, TIFF, and WebP files at inconsistent
+  sizes. ImageMagick converts, resizes, and strips metadata in batch so you can
+  normalize training images without writing a one-off OpenCV script for every
+  new crawl.
+
+use_cases:
+  - Resize and convert a vision dataset to a single format before training
+  - Generate thumbnails for a dataset browser or labeling UI
+  - Strip EXIF metadata from crawled images used in fine-tuning
+  - Composite overlays for evaluation galleries of model outputs
+  - Convert PDF pages to images for OCR and document-AI pipelines

--- a/tools/dev-tools/nmap.yaml
+++ b/tools/dev-tools/nmap.yaml
@@ -1,0 +1,28 @@
+name: nmap
+description: Network mapper that discovers hosts, open ports, and running services. nmap inventories GPU boxes, checks which inference ports are exposed, and verifies firewall rules before you put a model server on a network.
+tagline: Discover hosts, ports, and services on a network
+
+github_url: https://github.com/nmap/nmap
+website_url: https://nmap.org/
+docs_url: https://nmap.org/book/man.html
+
+install_command: brew install nmap
+
+category: Dev Tools
+tags: [networking, security, scanning, cli, discovery]
+pricing: free
+is_open_source: true
+license: NPSL
+
+problem_solved: |
+  You cannot tell from SSH which ports a training box actually exposes, and a
+  forgotten Jupyter or inference port is a security hole. nmap maps live hosts
+  and services so you can confirm only intended model APIs are reachable before
+  opening a cluster to the rest of the team.
+
+use_cases:
+  - Inventory which GPU nodes and inference ports are live on a lab subnet
+  - Confirm a model server is bound only to the expected interface
+  - Check firewall rules after deploying a vector database
+  - Find forgotten Jupyter or TensorBoard ports on shared machines
+  - Script a pre-flight scan before exposing an agent webhook

--- a/tools/dev-tools/rsync.yaml
+++ b/tools/dev-tools/rsync.yaml
@@ -1,0 +1,28 @@
+name: rsync
+description: Fast incremental file transfer tool for copying and syncing files over SSH or locally. rsync copies only the deltas so you can move datasets, checkpoints, and logs without re-sending gigabytes that already arrived.
+tagline: Incremental file sync over SSH or local disks
+
+github_url: https://github.com/RsyncProject/rsync
+website_url: https://rsync.samba.org/
+docs_url: https://download.samba.org/pub/rsync/rsync.1
+
+install_command: brew install rsync
+
+category: Dev Tools
+tags: [cli, sync, datasets, ssh, backup, artifacts]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  scp re-sends an entire checkpoint directory when one file changes, which
+  wastes hours on multi-gigabyte training runs. rsync transfers only the
+  differences, preserves permissions, and resumes after a drop so you can
+  keep experiment artifacts in sync across GPU nodes and laptops.
+
+use_cases:
+  - Sync a dataset directory from NAS onto a GPU node without recopying files
+  - Resume a dropped checkpoint copy after a cluster network blip
+  - Mirror experiment logs from training boxes to a backup disk
+  - Deploy model artifacts to an inference host over SSH
+  - Exclude cache files while copying a working tree between machines

--- a/tools/monitoring/strace.yaml
+++ b/tools/monitoring/strace.yaml
@@ -1,0 +1,28 @@
+name: strace
+description: Linux diagnostic tool that traces system calls and signals for a process. strace shows why a training job hangs on open, read, or connect so you can debug missing files, blocked sockets, and permission errors.
+tagline: Trace Linux system calls for hanging processes
+
+github_url: https://github.com/strace/strace
+website_url: https://strace.io/
+docs_url: https://man7.org/linux/man-pages/man1/strace.1.html
+
+install_command: brew install strace
+
+category: Monitoring
+tags: [linux, debugging, syscalls, cli, diagnostics]
+pricing: free
+is_open_source: true
+license: LGPL-2.1-or-later
+
+problem_solved: |
+  When a Python training job hangs with no traceback, logs do not show the
+  kernel call it is stuck on. strace prints open, read, write, and connect
+  so you can see a missing data file, a blocked NFS mount, or a refused
+  model-server socket without attaching a full debugger.
+
+use_cases:
+  - Find which file a data loader is stuck opening on a GPU node
+  - See why an inference process cannot connect to a vector database
+  - Diagnose permission errors on checkpoint directories
+  - Trace unexpected network calls from a training container
+  - Confirm a process is blocked on NFS rather than GPU compute

--- a/tools/monitoring/tcpdump.yaml
+++ b/tools/monitoring/tcpdump.yaml
@@ -1,0 +1,28 @@
+name: tcpdump
+description: Command-line packet analyzer that captures and prints network traffic. tcpdump is the fast way to see DNS, HTTP, and TLS on a headless GPU node when Wireshark is not available.
+tagline: Capture packets from the command line
+
+github_url: https://github.com/the-tcpdump-group/tcpdump
+website_url: https://www.tcpdump.org/
+docs_url: https://www.tcpdump.org/manpages/tcpdump.1.html
+
+install_command: brew install tcpdump
+
+category: Monitoring
+tags: [networking, packets, cli, debugging, linux]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  When an agent call hangs, application logs rarely show DNS failures or TLS
+  alerts. tcpdump captures packets on a headless node so you can see which host
+  was contacted, whether the handshake completed, and how much data moved,
+  without installing a GUI sniffer.
+
+use_cases:
+  - Capture DNS and TLS while an inference client fails to reach the API
+  - Confirm a data loader is talking to the expected object-storage endpoint
+  - Filter HTTP traffic from a vector database on a shared GPU box
+  - Debug webhook delivery from an agent runtime with a short pcap
+  - Verify multicast or NCCL-related traffic during distributed training


### PR DESCRIPTION
## Add nmap, tcpdump, ImageMagick, rsync, strace to catalog

Replenishment batch after PR #532.

| Tool | Category | Repo | Stars | License |
|------|----------|------|-------|---------|
| nmap | Dev Tools | nmap/nmap | 13.5k | NPSL |
| tcpdump | Monitoring | the-tcpdump-group/tcpdump | 3.2k | BSD-3-Clause |
| ImageMagick | Data | ImageMagick/ImageMagick | 17.4k | ImageMagick |
| rsync | Dev Tools | RsyncProject/rsync | 5.2k | GPL-3.0 |
| strace | Monitoring | strace/strace | 2.7k | LGPL-2.1-or-later |

All files validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ImageMagick to the tool catalog for image conversion, resizing, thumbnail creation, metadata removal, and PDF-to-image workflows.
  * Added Nmap for network discovery, port and service auditing, firewall checks, and security diagnostics.
  * Added rsync for dataset synchronization, log mirroring, artifact deployment, and resilient transfers.
  * Added strace for diagnosing stalled Linux processes.
  * Added tcpdump for capturing and troubleshooting network traffic, including DNS, TLS, HTTP, storage, and webhook activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->