### PR TITLE
Add difftastic, duf, broot, unison, coreutils to catalog

### DIFF
--- a/tools/dev-tools/broot.yaml
+++ b/tools/dev-tools/broot.yaml
@@ -1,0 +1,28 @@
+name: broot
+description: Interactive directory tree navigator that shows a condensed view of large folders. broot helps you find bloated experiment dirs, dataset shards, and nested caches without waiting on a full recursive ls.
+tagline: Interactive tree navigator for large directories
+
+github_url: https://github.com/Canop/broot
+website_url: https://dystroy.org/broot
+docs_url: https://dystroy.org/broot/documentation/
+
+install_command: brew install broot
+
+category: Dev Tools
+tags: [cli, tui, file-manager, rust, datasets]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  find and du take too long on a dataset tree with tens of thousands of
+  files, and you still cannot jump into the noisy subdirectory. broot shows
+  a live condensed tree so you can locate oversized experiment folders and
+  nested caches without waiting on a full recursive listing.
+
+use_cases:
+  - Find which experiment subdirectory is consuming unexpected disk
+  - Jump into a nested dataset folder without chaining cd
+  - Preview file sizes while deciding what to delete from a GPU node
+  - Search a large repo tree by name from the terminal
+  - Navigate caches and virtualenv dirs that ls hides in noise

--- a/tools/dev-tools/coreutils.yaml
+++ b/tools/dev-tools/coreutils.yaml
@@ -1,0 +1,28 @@
+name: coreutils
+description: GNU file, shell, and text utilities including ls, cp, mv, sort, and sha256sum. coreutils is the baseline CLI toolkit on Linux GPU nodes and the Homebrew formula that gives macOS the GNU variants used in training scripts.
+tagline: GNU file, shell, and text command-line utilities
+
+github_url: https://github.com/coreutils/coreutils
+website_url: https://www.gnu.org/software/coreutils/
+docs_url: https://www.gnu.org/software/coreutils/manual/coreutils.html
+
+install_command: brew install coreutils
+
+category: Dev Tools
+tags: [cli, gnu, linux, shell, scripting]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Training scripts assume GNU ls, cp, timeout, and sha256sum flags that
+  BSD/macOS utilities do not share. coreutils provides the GNU versions so
+  dataset checksums, timeouts, and recursive copies behave the same on a
+  laptop and a Linux GPU node.
+
+use_cases:
+  - Checksum dataset shards with sha256sum before a training run
+  - Use GNU timeout around a hanging data-download step
+  - Recursively copy experiment dirs with GNU cp flags
+  - Sort and unique large ID lists from a data pipeline
+  - Align macOS developer machines with Linux cluster coreutils behavior

--- a/tools/dev-tools/difftastic.yaml
+++ b/tools/dev-tools/difftastic.yaml
@@ -1,0 +1,28 @@
+name: difftastic
+description: Structural diff that understands syntax, so it compares functions and AST nodes instead of raw lines. difftastic makes code review of generated agent patches and refactors easier than a line-oriented git diff.
+tagline: Syntax-aware structural diff for code review
+
+github_url: https://github.com/Wilfred/difftastic
+website_url: https://difftastic.wilfred.me.uk/
+docs_url: https://difftastic.wilfred.me.uk/
+
+install_command: brew install difftastic
+
+category: Dev Tools
+tags: [diff, git, cli, rust, code-review]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Line diffs explode when an agent reformats a file or moves a function, so
+  reviewers cannot see the real change. difftastic compares syntax trees so
+  you can review generated Python, TypeScript, and config patches by language
+  structure instead of wrapping noise.
+
+use_cases:
+  - Review agent-generated refactors without format-only noise
+  - Diff two versions of a training config with real structural changes
+  - Compare generated vs handwritten Python before merging a PR
+  - Use as git external diff for language-aware reviews
+  - Inspect JSON and YAML experiment configs that reordered keys

--- a/tools/dev-tools/duf.yaml
+++ b/tools/dev-tools/duf.yaml
@@ -1,0 +1,28 @@
+name: duf
+description: Disk usage and free-space utility that presents a readable table of mounts, sizes, and percent used. duf replaces df on GPU boxes so you can see which disk is about to fill with checkpoints and datasets.
+tagline: Readable disk usage table for mounts and free space
+
+github_url: https://github.com/muesli/duf
+website_url: https://github.com/muesli/duf
+docs_url: https://github.com/muesli/duf
+
+install_command: brew install duf
+
+category: Dev Tools
+tags: [disk, cli, monitoring, linux, storage]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  df output is hard to scan when a node has NFS, local NVMe, and a Docker
+  overlay, and a full disk kills training mid-epoch. duf prints a color
+  table of mounts and free space so you can see which volume is filling with
+  checkpoints before the job dies.
+
+use_cases:
+  - Check free space on GPU node NVMe before a long training run
+  - Find which mount holds overflowing checkpoint directories
+  - Compare local disk vs NFS capacity on a shared cluster login node
+  - Spot a Docker overlay filling up from intermediate images
+  - Script a pre-flight disk check in a training launch wrapper

--- a/tools/dev-tools/unison.yaml
+++ b/tools/dev-tools/unison.yaml
@@ -1,0 +1,28 @@
+name: unison
+description: Bidirectional file synchronizer that keeps two replicas in sync over SSH or a socket. unison is useful when a laptop and a GPU node both edit configs, notebooks, and small artifacts and you need a two-way merge instead of one-way rsync.
+tagline: Bidirectional file sync between two machines
+
+github_url: https://github.com/bcpierce00/unison
+website_url: https://github.com/bcpierce00/unison
+docs_url: https://github.com/bcpierce00/unison/wiki
+
+install_command: brew install unison
+
+category: Dev Tools
+tags: [sync, cli, ssh, backup, datasets]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  rsync is one-way, so edits on a laptop and a GPU node overwrite each
+  other if you copy the wrong direction. unison compares both sides,
+  detects conflicts, and syncs notebooks, configs, and small artifacts
+  bidirectionally over SSH.
+
+use_cases:
+  - Keep training configs in sync between a laptop and a GPU workstation
+  - Two-way sync of notebooks without clobbering remote edits
+  - Replicate a small artifact directory after working on both machines
+  - Detect conflicting experiment YAML files before a run
+  - Sync a project tree over SSH when git is the wrong tool for large files


### PR DESCRIPTION
## Add difftastic, duf, broot, unison, coreutils to catalog

Fourth batch this run, after PRs #532-#534.

| Tool | Category | Repo | Stars | License |
|------|----------|------|-------|---------|
| difftastic | Dev Tools | Wilfred/difftastic | 25.9k | MIT |
| duf | Dev Tools | muesli/duf | 15.3k | MIT |
| broot | Dev Tools | Canop/broot | 12.9k | MIT |
| unison | Dev Tools | bcpierce00/unison | 5.5k | GPL-3.0 |
| coreutils | Dev Tools | coreutils/coreutils | 5.3k | GPL-3.0 |

All files validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for five developer tools: broot, GNU coreutils, difftastic, duf, and Unison.
  * Included descriptions, installation instructions, links, licensing details, categories, tags, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->