### PR TITLE
Add nethogs, mtr, BusyBox to catalog

### DIFF
--- a/tools/dev-tools/busybox.yaml
+++ b/tools/dev-tools/busybox.yaml
@@ -1,0 +1,26 @@
+name: BusyBox
+description: Tiny Unix utility suite that packs common commands like sh, wget, tar, and grep into one binary. BusyBox is the default userland in Alpine containers and many ML images where a full GNU toolchain is too large.
+tagline: Tiny Unix utilities in a single binary
+
+github_url: https://github.com/mirror/busybox
+website_url: https://www.busybox.net/
+docs_url: https://www.busybox.net/downloads/BusyBox.html
+
+category: Dev Tools
+tags: [cli, linux, containers, alpine, embedded, shell]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  GPU and inference containers often cannot ship a full GNU userland, so
+  debug shells, wget of checkpoints, and tar of datasets fail inside the
+  image. BusyBox provides the common Unix tools in one small binary so
+  Alpine-based training and serving images still have a usable shell.
+
+use_cases:
+  - Debug an Alpine-based training container with a shell, ps, and wget
+  - Fetch a checkpoint inside a minimal inference image without installing curl
+  - Unpack dataset tarballs in CI images that only ship BusyBox tar
+  - Build slim ML Docker images that still include a POSIX-like userland
+  - Inspect processes and logs in distroless-adjacent GPU runtime containers

--- a/tools/monitoring/mtr.yaml
+++ b/tools/monitoring/mtr.yaml
@@ -1,0 +1,28 @@
+name: mtr
+description: Network diagnostic that combines traceroute and ping into one live view of hop latency and loss. mtr is the go-to tool when a GPU cluster, object store, or Hugging Face download path is slow and you need to see where packets drop.
+tagline: Combined traceroute and ping for path diagnosis
+
+github_url: https://github.com/traviscross/mtr
+website_url: https://www.bitwizard.nl/mtr/
+docs_url: https://github.com/traviscross/mtr
+
+install_command: brew install mtr
+
+category: Monitoring
+tags: [network, traceroute, ping, diagnostics, cli, latency]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  A slow dataset pull or model download can be the NIC, the ISP, or a hop
+  to the object store, and ping or traceroute alone does not show live loss
+  along the path. mtr repeatedly probes every hop so you can see where
+  latency and packet loss start before you blame the training job.
+
+use_cases:
+  - Diagnose packet loss between a GPU node and an S3-compatible object store
+  - Check hop latency when Hugging Face model downloads stall mid-file
+  - Confirm a VPN or office path is dropping packets before a remote training SSH session
+  - Compare paths from a laptop vs a cluster login node to the same API endpoint
+  - Watch live loss while an inference replica cannot reach a vector database

--- a/tools/monitoring/nethogs.yaml
+++ b/tools/monitoring/nethogs.yaml
@@ -1,0 +1,28 @@
+name: nethogs
+description: Linux net top that groups bandwidth by process so you can see which PID is using the network. nethogs is the classic per-process bandwidth view on GPU nodes when a data loader or checkpoint upload saturates the NIC.
+tagline: Per-process network bandwidth on Linux
+
+github_url: https://github.com/raboof/nethogs
+website_url: https://raboof.github.io/nethogs/
+docs_url: https://github.com/raboof/nethogs
+
+install_command: brew install nethogs
+
+category: Monitoring
+tags: [network, bandwidth, linux, processes, cli, monitoring]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  iftop shows connections but not the owning process, so a noisy data loader
+  and a model download look the same. nethogs groups live bandwidth by PID
+  so you can stop the job saturating a shared GPU node before it starves
+  checkpoint uploads or distributed training all-reduce.
+
+use_cases:
+  - Find which training worker is flooding the NIC during a dataset pull
+  - See if a data loader is saturating a shared cluster uplink
+  - Debug slow checkpoint uploads by watching per-process bandwidth
+  - Identify unexpected outbound traffic from an inference container
+  - Compare network use of distributed training ranks on one machine


### PR DESCRIPTION
## Add nethogs, mtr, BusyBox to catalog

Remainder batch from the catalog tracker (3 tools).

| Tool | Category | Notes |
|------|----------|--------|
| nethogs | Monitoring | Linux net top, per-process bandwidth (raboof/nethogs, 3.6k★, GPL-2.0) |
| mtr | Monitoring | Combined traceroute + ping (traviscross/mtr, 3.3k★, GPL-2.0) |
| BusyBox | Dev Tools | Tiny Unix userland used in Alpine/ML containers (mirror/busybox, 2.1k★, GPL-2.0) |

Local validation: all three YAML files passed `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BusyBox to the developer tools catalog, including descriptions, links, licensing details, installation context, and example use cases.
  * Added MTR to the monitoring catalog for network diagnostics, with metadata, installation guidance, licensing details, and example use cases.
  * Added Nethogs to the monitoring catalog for per-process network bandwidth monitoring, with metadata, installation guidance, licensing details, and example use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->