### PR TITLE
Add iperf3, VisiData, lnav, shfmt, yamllint to catalog

### DIFF
--- a/tools/data/visidata.yaml
+++ b/tools/data/visidata.yaml
@@ -1,0 +1,28 @@
+name: VisiData
+description: Terminal spreadsheet for exploring, transforming, and arranging tabular data from CSV, JSON, Parquet, and databases. VisiData lets you open a large training manifest or eval dump in a TUI and filter, join, or plot without loading it into a notebook.
+tagline: Terminal spreadsheet for discovering and arranging data
+
+github_url: https://github.com/saulpw/visidata
+website_url: https://www.visidata.org/
+docs_url: https://www.visidata.org/docs/
+
+install_command: pip install visidata
+
+category: Data
+tags: [csv, tui, tabular, parquet, python, cli]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Opening a multi-gigabyte CSV of labels or eval scores in Excel or a
+  notebook is slow and often crashes. VisiData streams tabular files in
+  a terminal spreadsheet so you can inspect schema, filter bad rows, and
+  export a clean slice before a training or evaluation run.
+
+use_cases:
+  - Inspect a large dataset manifest CSV without loading it into pandas
+  - Filter eval score dumps to the failing examples before a review
+  - Open Parquet shards from a feature store and check column types
+  - Join two label files in the terminal to find missing IDs
+  - Plot a quick histogram of class counts before oversampling

--- a/tools/dev-tools/shfmt.yaml
+++ b/tools/dev-tools/shfmt.yaml
@@ -1,0 +1,28 @@
+name: shfmt
+description: Shell script formatter and parser with Bash and POSIX support, shipped as the shfmt CLI from mvdan/sh. shfmt keeps training launch scripts, Docker entrypoints, and cluster job files consistent so CI can fail on style instead of a missing quote.
+tagline: Autoformat Bash and POSIX shell scripts
+
+github_url: https://github.com/mvdan/sh
+website_url: https://github.com/mvdan/sh
+docs_url: https://github.com/mvdan/sh#shfmt
+
+install_command: brew install shfmt
+
+category: Dev Tools
+tags: [shell, bash, formatter, cli, lint, golang]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Training launchers and Docker entrypoints are shell scripts that break
+  on a missing quote or inconsistent indentation that reviewers miss.
+  shfmt parses and reformats Bash and POSIX scripts so CI can enforce
+  one style and catch syntax issues before a GPU job is submitted.
+
+use_cases:
+  - Format training launch scripts in CI before a cluster submit
+  - Keep Docker entrypoint.sh files consistent across ML images
+  - Diff a reformatted data-pipeline shell script in code review
+  - Parse Bash in a formatter-aware editor for job templates
+  - Enforce POSIX style on shared cluster utility scripts

--- a/tools/dev-tools/yamllint.yaml
+++ b/tools/dev-tools/yamllint.yaml
@@ -1,0 +1,28 @@
+name: yamllint
+description: Linter for YAML files that checks syntax, indentation, duplicates, and style rules. yamllint is the standard gate for Kubernetes manifests, GitHub Actions, and ML config files before they hit a cluster or CI.
+tagline: Linter for YAML files and configs
+
+github_url: https://github.com/adrienverge/yamllint
+website_url: https://yamllint.readthedocs.io/
+docs_url: https://yamllint.readthedocs.io/
+
+install_command: pip install yamllint
+
+category: Dev Tools
+tags: [yaml, linter, python, ci, kubernetes, cli]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  A bad indent or duplicate key in a Kubernetes job or Hydra config
+  only shows up when the training pod fails to start. yamllint checks
+  YAML syntax and style in CI so broken manifests and config files
+  never reach the cluster.
+
+use_cases:
+  - Lint Kubernetes training-job manifests in CI
+  - Catch duplicate keys in Hydra or YAML experiment configs
+  - Validate GitHub Actions workflows before they run GPU jobs
+  - Enforce indent rules on Helm values for inference services
+  - Fail a PR when a dataset YAML has invalid syntax

--- a/tools/monitoring/iperf3.yaml
+++ b/tools/monitoring/iperf3.yaml
@@ -1,0 +1,28 @@
+name: iperf3
+description: TCP, UDP, and SCTP bandwidth measurement tool for measuring throughput between two hosts. iperf3 is the standard way to check whether a GPU cluster interconnect, object-store path, or VPN can actually carry a training data stream.
+tagline: Measure TCP and UDP network bandwidth between hosts
+
+github_url: https://github.com/esnet/iperf
+website_url: https://software.es.net/iperf/
+docs_url: https://software.es.net/iperf/
+
+install_command: brew install iperf3
+
+category: Monitoring
+tags: [network, bandwidth, benchmarking, tcp, udp, cli]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Slow dataset copies get blamed on the training job when the real limit is
+  the path between nodes. iperf3 measures live TCP and UDP throughput so
+  you can tell a saturated NIC, a bad switch hop, or a VPN cap from a
+  poorly tuned data loader.
+
+use_cases:
+  - Measure bandwidth between a GPU node and an object-store gateway before a dataset pull
+  - Compare TCP throughput on a cluster interconnect vs a public cloud VPN
+  - Confirm a new Ethernet or InfiniBand path can feed distributed training
+  - Reproduce a slow Hugging Face download as a raw network test
+  - Tune window sizes when checkpoint sync between ranks is network-bound

--- a/tools/monitoring/lnav.yaml
+++ b/tools/monitoring/lnav.yaml
@@ -1,0 +1,28 @@
+name: lnav
+description: Curses log file navigator that auto-detects formats, indexes timestamps, and lets you SQL-query logs in a TUI. lnav is built for following training, inference, and pipeline logs without grepping through rotated files by hand.
+tagline: Log file navigator with SQL queries in the terminal
+
+github_url: https://github.com/tstack/lnav
+website_url: https://lnav.org/
+docs_url: https://docs.lnav.org/
+
+install_command: brew install lnav
+
+category: Monitoring
+tags: [logs, tui, sql, observability, cli, debugging]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+problem_solved: |
+  Training and serving logs are split across rotated files, JSON lines,
+  and syslog, so finding the OOM or a failed batch means a pile of grep.
+  lnav opens many files at once, detects formats, and lets you query
+  timestamps and fields so you can jump to the failure instead of scrolling.
+
+use_cases:
+  - Follow training logs across rotated files while a job is running
+  - SQL-query JSON inference logs for 5xx spikes in a time window
+  - Open Docker and systemd logs together when a GPU node fails to start
+  - Jump to the first traceback in a long data-pipeline log
+  - Diff two eval run logs to see which step started failing


### PR DESCRIPTION
## Add iperf3, VisiData, lnav, shfmt, yamllint to catalog

Five-tool catalog batch.

| Tool | Category | Notes |
|------|----------|--------|
| iperf3 | Monitoring | TCP/UDP bandwidth measurement (esnet/iperf, 8.7k★) |
| VisiData | Data | Terminal spreadsheet for tabular data (saulpw/visidata, 9.2k★) |
| lnav | Monitoring | Log navigator with SQL queries (tstack/lnav, 10.6k★) |
| shfmt | Dev Tools | Shell formatter from mvdan/sh (9.0k★) |
| yamllint | Dev Tools | YAML linter (adrienverge/yamllint, 3.4k★) |

Local validation: all five YAML files passed `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VisiData, shfmt, yamllint, iperf3, and lnav to the tool catalog.
  * Added installation instructions, project links, licensing and pricing details, categories, tags, and practical use cases for each tool.
  * Expanded coverage for spreadsheet analysis, shell and YAML development, network performance monitoring, and log investigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->