### PR TITLE
Add csvkit, qsv, axel to catalog

### DIFF
--- a/tools/data/csvkit.yaml
+++ b/tools/data/csvkit.yaml
@@ -1,0 +1,28 @@
+name: csvkit
+description: Suite of command-line tools for converting to and working with CSV, including csvcut, csvstat, csvgrep, and SQL against CSV files. csvkit is the Python toolkit for slicing training manifests, label files, and eval dumps without opening a notebook.
+tagline: Command-line tools for converting and querying CSV
+
+github_url: https://github.com/wireservice/csvkit
+website_url: https://csvkit.readthedocs.io/
+docs_url: https://csvkit.readthedocs.io/
+
+install_command: pip install csvkit
+
+category: Data
+tags: [csv, python, cli, etl, tabular, data]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Training manifests and label files live as CSV, but cutting columns,
+  checking stats, or grepping rows usually means a one-off pandas script.
+  csvkit gives Unix-style tools for CSV so you can inspect, convert, and
+  SQL-query those files in a pipeline before a training run.
+
+use_cases:
+  - Cut columns from a large dataset manifest before upload
+  - Compute stats on a label CSV to check class balance
+  - Convert Excel annotation exports to UTF-8 CSV
+  - SQL-query a metrics CSV without loading it into a notebook
+  - Grep eval dumps for failing example IDs in CI

--- a/tools/data/qsv.yaml
+++ b/tools/data/qsv.yaml
@@ -1,0 +1,28 @@
+name: qsv
+description: Fast CSV and tabular data-wrangling toolkit written in Rust, with commands for frequency, join, sample, and schema. qsv handles multi-gigabyte training manifests and eval dumps that choke slower Python CSV tools.
+tagline: Ultra-fast CSV data-wrangling toolkit
+
+github_url: https://github.com/dathere/qsv
+website_url: https://qsv.dathere.com/
+docs_url: https://github.com/dathere/qsv
+
+install_command: brew install qsv
+
+category: Data
+tags: [csv, rust, cli, etl, tabular, data]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Multi-gigabyte CSV manifests and eval dumps take minutes in pandas or
+  csvkit when you only need a frequency count or a sample. qsv is a
+  Rust CLI that streams those files so you can profile, join, and slice
+  training data on a laptop or CI runner.
+
+use_cases:
+  - Frequency-count classes in a multi-GB label CSV
+  - Sample rows from a huge training manifest for a smoke test
+  - Join two eval dumps on example ID without loading them into memory
+  - Infer a schema from a messy CSV before a Spark or pandas load
+  - Slice a dataset CSV by date column for a backfill job

--- a/tools/dev-tools/axel.yaml
+++ b/tools/dev-tools/axel.yaml
@@ -1,0 +1,28 @@
+name: axel
+description: Lightweight CLI download accelerator that fetches a file over multiple HTTP connections. axel is useful when pulling large model weights or dataset shards over a slow link and a single wget stream cannot fill the pipe.
+tagline: Lightweight CLI download accelerator
+
+github_url: https://github.com/axel-download-accelerator/axel
+website_url: https://github.com/axel-download-accelerator/axel
+docs_url: https://github.com/axel-download-accelerator/axel
+
+install_command: brew install axel
+
+category: Dev Tools
+tags: [download, http, cli, networking, datasets]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  A single-connection wget or curl of a multi-GB checkpoint often leaves
+  bandwidth unused on long-haul links. axel opens several HTTP connections
+  so model weights and dataset shards download faster without a heavy
+  download manager.
+
+use_cases:
+  - Accelerate a large model-weight download over HTTP
+  - Pull dataset shards in parallel connections on a cluster login node
+  - Resume an interrupted checkpoint download without a browser
+  - Compare single-stream vs multi-connection throughput to an object store
+  - Fetch release tarballs faster in CI image builds


### PR DESCRIPTION
## Add csvkit, qsv, axel to catalog

Remainder batch from the catalog tracker (3 tools).

| Tool | Category | Notes |
|------|----------|--------|
| csvkit | Data | Python CSV CLI suite (wireservice/csvkit, 6.4k★, MIT) |
| qsv | Data | Fast Rust CSV wrangling toolkit (dathere/qsv, 3.7k★) |
| axel | Dev Tools | Lightweight CLI download accelerator (3.4k★, GPL-2.0) |

Local validation: all three YAML files passed `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added csvkit to the data tools catalog, including installation details, links, and use cases for CSV processing.
  - Added qsv to the data tools catalog, highlighting high-performance tabular data operations.
  - Added axel to the developer tools catalog, with installation details and use cases for accelerated downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->