### PR TITLE
Add lsd, gopass, git-absorb, fswatch, dua to catalog

### DIFF
--- a/tools/dev-tools/dua.yaml
+++ b/tools/dev-tools/dua.yaml
@@ -1,0 +1,28 @@
+name: dua
+description: Fast disk usage analyzer and interactive cleaner written in Rust. dua shows which checkpoint dirs, caches, and datasets are eating a GPU node's disk so you can delete them without waiting on du.
+tagline: Fast disk usage analyzer and cleaner
+
+github_url: https://github.com/Byron/dua-cli
+website_url: https://github.com/Byron/dua-cli
+docs_url: https://github.com/Byron/dua-cli
+
+install_command: brew install dua-cli
+
+category: Dev Tools
+tags: [disk, cli, rust, storage, cleanup]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  GPU nodes fill up with old checkpoints, Hugging Face caches, and
+  unpacked datasets, and du -sh is too slow to hunt the culprit.
+  dua walks the tree quickly and can delete selected dirs so you
+  reclaim disk before the next training job fails.
+
+use_cases:
+  - Find which checkpoint run is filling a GPU node's disk
+  - Delete stale Hugging Face cache dirs interactively
+  - Compare dataset shard sizes before a copy to object storage
+  - Clean leftover experiment dirs after a failed sweep
+  - Inspect disk use of a Docker build cache on a shared machine

--- a/tools/dev-tools/fswatch.yaml
+++ b/tools/dev-tools/fswatch.yaml
@@ -1,0 +1,28 @@
+name: fswatch
+description: Cross-platform file change monitor with backends for inotify, FSEvents, kqueue, and more. fswatch runs a command when dataset files, configs, or model checkpoints change, which is useful for local training and data pipelines.
+tagline: Cross-platform file change monitor
+
+github_url: https://github.com/emcrisostomo/fswatch
+website_url: https://emcrisostomo.github.io/fswatch/
+docs_url: https://emcrisostomo.github.io/fswatch/doc/
+
+install_command: brew install fswatch
+
+category: Dev Tools
+tags: [filesystem, watch, cli, inotify, macos, linux]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Retraining or re-exporting when a config or data file changes usually
+  means a manual rerun. fswatch monitors directories across macOS and
+  Linux and runs a command on change so local pipelines stay in sync
+  without a heavy watcher framework.
+
+use_cases:
+  - Rerun a data-prep script when new files land in a drop folder
+  - Reload a local inference server when a prompt template changes
+  - Watch Hydra config dirs and kick a smoke training job
+  - Sync a dataset folder to object storage on change
+  - Trigger a test suite when shell launch scripts are edited

--- a/tools/dev-tools/git-absorb.yaml
+++ b/tools/dev-tools/git-absorb.yaml
@@ -1,0 +1,28 @@
+name: git-absorb
+description: Automatically creates git fixup commits by matching staged hunks to later commits in a branch. git-absorb is the faster way to fold review fixes into a feature branch of training scripts or catalog YAML without hand-building rebase todos.
+tagline: Automatic git commit --fixup
+
+github_url: https://github.com/tummychow/git-absorb
+website_url: https://github.com/tummychow/git-absorb
+docs_url: https://crates.io/crates/git-absorb
+
+install_command: brew install git-absorb
+
+category: Dev Tools
+tags: [git, cli, rust, rebase, workflow]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Review comments on a long training-script branch mean many tiny fix
+  commits that you then rebase by hand. git-absorb maps staged hunks to
+  the right earlier commits so you can autosquash without writing a rebase
+  todo.
+
+use_cases:
+  - Fold PR review fixes into the original training-script commits
+  - Absorb YAML catalog nits into the add-tool commit before squash
+  - Clean a feature branch of ML infra changes before merge
+  - Auto-fixup staged hunks after a CI lint failure
+  - Keep a data-pipeline branch history readable without manual rebase

--- a/tools/dev-tools/gopass.yaml
+++ b/tools/dev-tools/gopass.yaml
@@ -1,0 +1,28 @@
+name: gopass
+description: Team-oriented Unix password manager built on GPG and Git, with a CLI for secrets. gopass stores API keys, cloud credentials, and Hugging Face tokens in a shared encrypted store instead of dumping them into .env files.
+tagline: Team password manager for Unix, GPG, and Git
+
+github_url: https://github.com/gopasspw/gopass
+website_url: https://www.gopass.pw/
+docs_url: https://github.com/gopasspw/gopass/blob/master/docs/index.md
+
+install_command: brew install gopass
+
+category: Dev Tools
+tags: [secrets, passwords, gpg, git, cli, security]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  ML teams share OpenAI keys, cloud creds, and Hugging Face tokens in Slack
+  or unencrypted .env files. gopass keeps those secrets in a GPG-encrypted
+  Git store so training jobs and local shells can fetch credentials without
+  committing them.
+
+use_cases:
+  - Store OpenAI and Hugging Face tokens for a research team
+  - Check out cloud credentials on a GPU node without a plaintext .env
+  - Rotate an API key in a shared Git-backed secret store
+  - Inject secrets into a local training script from gopass show
+  - Onboard a new engineer to project credentials without Slack pastes

--- a/tools/dev-tools/lsd.yaml
+++ b/tools/dev-tools/lsd.yaml
@@ -1,0 +1,28 @@
+name: lsd
+description: Next-generation ls with colors, icons, and tree view, written in Rust. lsd is a drop-in listing tool for exploring dataset directories, experiment folders, and checkpoint trees without the plain ls output.
+tagline: Next-gen ls with colors, icons, and tree view
+
+github_url: https://github.com/lsd-rs/lsd
+website_url: https://github.com/lsd-rs/lsd
+docs_url: https://github.com/lsd-rs/lsd
+
+install_command: brew install lsd
+
+category: Dev Tools
+tags: [cli, rust, ls, filesystem, terminal]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Plain ls makes it hard to scan mixed dataset dirs, checkpoint trees, and
+  experiment folders on a GPU node. lsd adds colors, icons, and a tree view
+  so you can see file types and sizes at a glance when navigating training
+  artifacts.
+
+use_cases:
+  - Tree-list a checkpoint directory on a GPU node
+  - Scan a dataset folder with icons for file types
+  - List experiment outputs sorted by size after a training run
+  - Replace ls in a developer shell for ML project navigation
+  - Inspect nested Hydra output dirs without a GUI file manager


### PR DESCRIPTION
## Add lsd, gopass, git-absorb, fswatch, dua to catalog

Five-tool catalog batch.

| Tool | Category | Notes |
|------|----------|--------|
| lsd | Dev Tools | Next-gen ls (lsd-rs/lsd, 16.2k★, Apache-2.0) |
| gopass | Dev Tools | Team password manager (gopasspw/gopass, 7.1k★, MIT) |
| git-absorb | Dev Tools | Automatic git fixup (tummychow/git-absorb, 5.7k★) |
| fswatch | Dev Tools | Cross-platform file watcher (5.5k★, GPL-3.0) |
| dua | Dev Tools | Fast disk usage analyzer (Byron/dua-cli, 6.2k★, MIT) |

Local validation: all five YAML files passed `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for five developer tools: `dua`, `fswatch`, `git-absorb`, `gopass`, and `lsd`.
  * Included installation details, documentation links, licensing, pricing, categories, tags, and practical use cases for each tool.
  * Added use cases covering disk cleanup, file monitoring, Git workflow improvements, password management, and enhanced directory listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->