### PR TITLE
Add doggo, pigz, minisign, sqlite-vec, Pixeltable to catalog

### DIFF
--- a/tools/data/pigz.yaml
+++ b/tools/data/pigz.yaml
@@ -1,0 +1,26 @@
+name: pigz
+description: Parallel gzip implementation by Mark Adler that uses multiple cores to compress and decompress gzip streams while staying fully compatible with gzip. Speeds up packing of training datasets, logs, and model artifacts on multi-core machines without changing the .gz format.
+tagline: Multi-core gzip for large datasets and artifacts
+
+github_url: https://github.com/madler/pigz
+website_url: https://zlib.net/pigz/
+docs_url: https://zlib.net/pigz/
+install_command: brew install pigz
+
+category: Data
+tags: [compression, gzip, parallel, datasets, cli, zlib, data-pipeline]
+pricing: free
+is_open_source: true
+license: Zlib
+
+problem_solved: |
+  Single-threaded gzip leaves most CPU cores idle while compressing multi-gigabyte
+  training dumps, logs, and checkpoints. pigz is a drop-in gzip replacement that
+  splits compression across cores, cutting wall-clock time for dataset packaging
+  and artifact shipping while remaining compatible with standard .gz tools.
+
+use_cases:
+  - Compress multi-gigabyte training datasets across all CPU cores before upload
+  - Speed up gzip of experiment logs and checkpoint tarballs in CI pipelines
+  - Decompress large .gz dumps in parallel when staging data for training jobs
+  - Replace gzip in data packaging scripts without changing the on-disk format

--- a/tools/data/pixeltable.yaml
+++ b/tools/data/pixeltable.yaml
@@ -1,0 +1,26 @@
+name: Pixeltable
+description: Unified multimodal backend for AI data apps. One Python API stores images, video, audio, and documents, runs models as computed columns, indexes embeddings, and versions data so you do not glue blob storage, a vector DB, and an orchestrator together.
+tagline: Multimodal database, orchestration, and serving in one Python API
+
+github_url: https://github.com/pixeltable/pixeltable
+website_url: https://www.pixeltable.com
+docs_url: https://docs.pixeltable.com
+install_command: pip install pixeltable
+
+category: Data
+tags: [multimodal, python, embeddings, data-pipeline, rag, computer-vision, orchestration]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Multimodal AI apps usually stitch S3, Postgres, a vector store, and Airflow
+  just to chunk media, run models, and serve embeddings. Pixeltable puts storage,
+  computed columns, incremental inference, and versioning in one Python table
+  so new rows trigger chunking and embeddings without glue scripts.
+
+use_cases:
+  - Store images, video, and documents in one table and run models as computed columns
+  - Build a RAG pipeline where chunking and embeddings update incrementally on insert
+  - Export Pixeltable tables to Parquet or PyTorch datasets for training
+  - Version multimodal datasets and recompute stale columns after a model change

--- a/tools/dev-tools/doggo.yaml
+++ b/tools/dev-tools/doggo.yaml
@@ -1,0 +1,26 @@
+name: doggo
+description: Command-line DNS client written in Go that replaces dig with colorized tabular output and modern transports including DNS-over-HTTPS, DNS-over-TLS, DNS-over-QUIC, and DNSCrypt. JSON output makes it easy to script DNS lookups in CI, infra debugging, and ML service discovery.
+tagline: Human-friendly DNS client with DoH, DoT, DoQ, and JSON output
+
+github_url: https://github.com/mr-karan/doggo
+website_url: https://doggo.mrkaran.dev/
+docs_url: https://doggo.mrkaran.dev/docs/
+install_command: brew install doggo
+
+category: Dev Tools
+tags: [dns, cli, golang, doh, networking, developer-tools, debugging]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Classic dig output is hard to scan and does not speak modern encrypted DNS
+  transports out of the box. doggo gives colorized, tabular, or JSON DNS answers
+  over DoH, DoT, DoQ, and DNSCrypt so you can debug service discovery, model
+  endpoints, and cluster DNS without wrestling BIND-style records.
+
+use_cases:
+  - Debug DNS for LLM APIs, vector DB hosts, and model registries with readable tables
+  - Query DNS-over-HTTPS or DNS-over-TLS from CI when UDP 53 is blocked
+  - Emit JSON answers and pipe them into scripts that check service discovery
+  - Run reverse lookups and compare resolvers when an inference endpoint fails to resolve

--- a/tools/dev-tools/minisign.yaml
+++ b/tools/dev-tools/minisign.yaml
@@ -1,0 +1,26 @@
+name: minisign
+description: Dead-simple file signing tool using Ed25519. Creates compact signatures you can verify without a GPG keyring, with OpenBSD signify compatibility. Ideal for signing model weights, dataset releases, and CLI binaries that ML teams ship to users.
+tagline: Simple Ed25519 signatures for files and releases
+
+github_url: https://github.com/jedisct1/minisign
+website_url: https://jedisct1.github.io/minisign/
+docs_url: https://jedisct1.github.io/minisign/
+install_command: brew install minisign
+
+category: Dev Tools
+tags: [cryptography, signing, ed25519, security, cli, releases, supply-chain]
+pricing: free
+is_open_source: true
+license: ISC
+
+problem_solved: |
+  GPG-based release signing is heavy for teams that just need to prove a model
+  checkpoint or binary was not tampered with. minisign signs files with Ed25519
+  in a few commands, produces tiny .minisig files, and lets users verify with a
+  short public key instead of importing a full OpenPGP keyring.
+
+use_cases:
+  - Sign model weight archives and dataset tarballs before publishing a release
+  - Verify downloaded CLI tools and ML binaries against a published public key
+  - Add compact signatures to GitHub release assets without operating GPG
+  - Check OpenBSD signify-compatible signatures in supply-chain CI gates

--- a/tools/vector-databases/sqlite-vec.yaml
+++ b/tools/vector-databases/sqlite-vec.yaml
@@ -1,0 +1,28 @@
+name: sqlite-vec
+description: Tiny vector search extension for SQLite that stores float, int8, and binary embeddings in vec0 virtual tables and runs KNN queries anywhere SQLite runs, including WASM, laptops, and edge devices. Successor to sqlite-vss with no extra native dependencies.
+tagline: Vector search as a SQLite extension that runs anywhere
+
+github_url: https://github.com/asg017/sqlite-vec
+website_url: https://alexgarcia.xyz/sqlite-vec/
+docs_url: https://alexgarcia.xyz/sqlite-vec/
+install_command: |
+  pip install sqlite-vec
+  npm install sqlite-vec
+
+category: Vector DB
+tags: [sqlite, vector-search, embeddings, knn, local-first, python, wasm, rag]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Most vector databases need a separate server, Docker stack, or heavy native
+  library. sqlite-vec loads as a SQLite extension so you can store embeddings
+  next to application rows, run KNN in SQL, and ship local RAG or on-device
+  search without standing up Pinecone, pgvector, or a sidecar process.
+
+use_cases:
+  - Build local RAG over documents stored in SQLite with KNN on embeddings
+  - Ship on-device semantic search in a desktop or mobile app with one database file
+  - Prototype vector search in notebooks without running a vector DB server
+  - Query embeddings from Python, Node, Go, or WASM using the same vec0 tables


### PR DESCRIPTION
## Catalog batch

Add 5 tools to the Agentic AI For Good catalog:

| Tool | Category | Repo |
|------|----------|------|
| doggo | Dev Tools | mr-karan/doggo (4.5k, GPL-3.0) |
| pigz | Data | madler/pigz (3.0k, Zlib) |
| minisign | Dev Tools | jedisct1/minisign (2.8k, ISC) |
| sqlite-vec | Vector DB | asg017/sqlite-vec (8.0k, Apache-2.0) |
| Pixeltable | Data | pixeltable/pixeltable (1.6k, Apache-2.0) |

All files passed local `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Tools**
  - Added catalog entries for Pigz, a parallel gzip utility; Pixeltable, a multimodal data platform; Doggo, a command-line DNS client; Minisign, a file-signing tool; and SQLite-Vec, a SQLite vector-search extension.
  - Entries include descriptions, documentation and project links, installation instructions, licensing, pricing, categories, tags, and practical use cases.
  - SQLite-Vec now highlights local embedding storage and similarity search without requiring a separate vector database server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->