### PR TITLE
Add Towhee, AgentVerse, BM25s, Featureform, FastMoE to catalog

### DIFF
--- a/tools/agent-frameworks/agentverse.yaml
+++ b/tools/agent-frameworks/agentverse.yaml
@@ -1,0 +1,27 @@
+name: AgentVerse
+description: Framework from OpenBMB for deploying multiple LLM-based agents in task-solving crews and multi-agent simulations. Provides orchestration for collaborative problem solving as well as environments where agents interact, making it useful for research and applied multi-agent apps.
+tagline: Multi-agent task solving and simulation for LLM crews
+
+github_url: https://github.com/OpenBMB/AgentVerse
+website_url: https://github.com/OpenBMB/AgentVerse
+docs_url: https://github.com/OpenBMB/AgentVerse
+install_command: pip install agentverse
+
+category: Agents
+tags: [python, agents, multi-agent, simulation, llm, orchestration]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Most agent libraries target a single assistant loop and do not model a society
+  of agents that debate, assign roles, or act in a shared environment. AgentVerse
+  ships two frameworks, task-solving crews and multi-agent simulation, so you can
+  study collaboration and deploy multi-agent applications without building the
+  orchestration layer from scratch.
+
+use_cases:
+  - Assemble a task-solving crew of LLM agents that divide work and merge results
+  - Simulate multi-agent environments to study cooperation, debate, and role play
+  - Prototype applied multi-agent apps where specialists hand off to each other
+  - Research agent societies with a shared environment instead of a single chatbot

--- a/tools/data/featureform.yaml
+++ b/tools/data/featureform.yaml
@@ -1,0 +1,26 @@
+name: Featureform
+description: Virtual feature store that turns existing data infrastructure into a feature platform. Define features in Python, version transformations, and serve training and inference features from warehouses and lakes you already run instead of copying data into a new store.
+tagline: Virtual feature store on top of your existing data stack
+
+github_url: https://github.com/featureform/featureform
+website_url: https://www.featureform.com
+docs_url: https://docs.featureform.com
+install_command: pip install featureform
+
+category: Data
+tags: [feature-store, mlops, python, training, inference, data-platform]
+pricing: freemium
+is_open_source: true
+license: MPL-2.0
+
+problem_solved: |
+  Feature engineering often lives in notebooks that do not match production
+  serving, so training-serving skew creeps in. Featureform virtualizes a feature
+  store over your warehouse and lake so the same feature definitions version,
+  train, and serve without duplicating data into a proprietary store.
+
+use_cases:
+  - Define versioned features in Python and serve them for both training and inference
+  - Point a virtual feature store at an existing warehouse instead of copying tables
+  - Reduce training-serving skew by reusing the same feature transformations
+  - Organize ML features across teams without standing up a separate feature database

--- a/tools/data/towhee.yaml
+++ b/tools/data/towhee.yaml
@@ -1,0 +1,26 @@
+name: Towhee
+description: Framework for building neural data processing pipelines that turn raw images, video, audio, and text into embeddings with composable operators. Designed so teams can assemble embedding and multimodal ETL flows without writing custom model-serving glue for every modality.
+tagline: Neural data pipelines that turn media into embeddings
+
+github_url: https://github.com/towhee-io/towhee
+website_url: https://towhee.io
+docs_url: https://towhee.readthedocs.io
+install_command: pip install towhee
+
+category: Data
+tags: [embeddings, multimodal, python, data-pipeline, etl, computer-vision, nlp]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Getting from raw images, video, or text to embeddings usually means one-off
+  scripts, ad-hoc model loaders, and brittle batch jobs. Towhee lets you compose
+  neural operators into a pipeline so embedding generation, preprocessing, and
+  multimodal ETL stay in one reusable Python flow instead of scattered notebooks.
+
+use_cases:
+  - Encode images and video frames into embeddings for a vector search index
+  - Build a multimodal ETL pipeline that preprocesses text and media before training
+  - Prototype embedding operators locally then reuse the same pipeline in production
+  - Extract audio and document features without writing a custom model-serving stack

--- a/tools/fine-tuning/fastmoe.yaml
+++ b/tools/fine-tuning/fastmoe.yaml
@@ -1,0 +1,25 @@
+name: FastMoE
+description: High-performance Mixture-of-Experts implementation for PyTorch that speeds expert parallelism across GPUs. Lets researchers train and serve sparse MoE models without writing custom CUDA communication kernels for expert routing.
+tagline: Fast Mixture-of-Experts training for PyTorch
+
+github_url: https://github.com/laekov/fastmoe
+website_url: https://fastmoe.ai
+docs_url: https://fastmoe.ai
+
+category: Fine-tuning
+tags: [moe, pytorch, gpu, distributed-training, sparse-models, cuda]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Mixture-of-Experts models need efficient expert routing and all-to-all GPU
+  communication that vanilla PyTorch does not provide. FastMoE implements a fast
+  MoE layer so you can train sparse expert models on multiple GPUs without
+  hand-rolling CUDA kernels or depending on a full Megatron stack.
+
+use_cases:
+  - Train PyTorch Mixture-of-Experts models with efficient expert parallelism
+  - Replace a dense FFN with a sparse MoE layer in an existing transformer
+  - Scale expert routing across multiple GPUs without a custom communication stack
+  - Prototype sparse LLM architectures before moving to a full Megatron trainer

--- a/tools/rag/bm25s.yaml
+++ b/tools/rag/bm25s.yaml
@@ -1,0 +1,26 @@
+name: BM25s
+description: Fast BM25 lexical search library for Python powered by NumPy and Numba. Indexes and ranks documents orders of magnitude faster than typical pure-Python BM25, with a small API suited to hybrid RAG that mixes keyword retrieval with embeddings.
+tagline: Fast BM25 search in Python via NumPy and Numba
+
+github_url: https://github.com/xhluca/bm25s
+website_url: https://bm25s.github.io
+docs_url: https://bm25s.github.io
+install_command: pip install bm25s
+
+category: RAG
+tags: [bm25, retrieval, python, rag, lexical-search, numpy, hybrid-search]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Hybrid RAG needs a fast lexical retriever beside the vector index, but classic
+  Python BM25 is too slow on large corpora and Java tools like Elasticsearch add
+  ops overhead. BM25s implements BM25 with NumPy and Numba so you can index and
+  rank documents in-process, then fuse keyword hits with embedding search.
+
+use_cases:
+  - Add BM25 keyword retrieval to a hybrid RAG pipeline next to vector search
+  - Benchmark lexical vs dense retrieval on a local corpus without Elasticsearch
+  - Rank documentation chunks by query terms inside a Python RAG service
+  - Prototype sparse retrieval for legal or medical corpora that need exact tokens


### PR DESCRIPTION
## Catalog batch

Add 5 tools to the Agentic AI For Good catalog:

| Tool | Category | Repo |
|------|----------|------|
| Towhee | Data | towhee-io/towhee (3.5k, Apache-2.0) |
| AgentVerse | Agents | OpenBMB/AgentVerse (5.1k, Apache-2.0) |
| BM25s | RAG | xhluca/bm25s (1.8k, MIT) |
| Featureform | Data | featureform/featureform (2.0k, MPL-2.0) |
| FastMoE | Fine-tuning | laekov/fastmoe (1.9k, Apache-2.0) |

Skipped GPT Engineer (AntonOsika/gpt-engineer is archived; precursor to lovable.dev).

All files passed local `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for AgentVerse, Featureform, Towhee, FastMoE, and BM25s.
  * AgentVerse is documented for multi-agent task solving and simulation.
  * Featureform is listed as a virtual feature store for machine learning workflows.
  * Towhee is cataloged for multimodal neural data pipelines and embeddings.
  * FastMoE is listed for PyTorch-based sparse Mixture-of-Experts fine-tuning.
  * BM25s is documented for fast lexical search and hybrid retrieval use cases.

* **Documentation**
  * Added installation details, project links, licensing, classifications, and representative use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->