### PR TITLE
Add MemoRAG, CLIP as Service, Algolia, Amazon Kendra, Kinetica to catalog

### DIFF
--- a/tools/other/algolia.yaml
+++ b/tools/other/algolia.yaml
@@ -1,0 +1,24 @@
+name: Algolia
+description: Hosted search API with typo-tolerant full-text search, faceting, and ranking rules. Used to add instant search to apps and docs, including AI product catalogs, without operating Elasticsearch yourself.
+tagline: Hosted search API with typo-tolerant ranking and faceting
+
+website_url: https://www.algolia.com
+docs_url: https://www.algolia.com/doc/
+install_command: pip install algoliasearch
+
+category: Other
+tags: [search, saas, full-text-search, api, ranking, python]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Shipping fast, typo-tolerant search usually means running Elasticsearch or
+  writing ranking rules by hand. Algolia is a hosted search API with ranking,
+  facets, and SDKs so product, docs, and dataset catalogs get instant search
+  without operating a search cluster.
+
+use_cases:
+  - Add typo-tolerant search to an AI tool catalog or documentation site
+  - Facet and rank product or dataset listings from a hosted search index
+  - Prototype search UX in Python with the Algolia API client
+  - Offload full-text ranking so the app stack does not run Elasticsearch

--- a/tools/other/clip-as-service.yaml
+++ b/tools/other/clip-as-service.yaml
@@ -1,0 +1,26 @@
+name: CLIP as Service
+description: Scalable CLIP embedding service from Jina AI for images and sentences. Exposes encode, rank, and cross-modal search over gRPC or HTTP so teams can serve CLIP embeddings without wrapping the model themselves.
+tagline: Scalable CLIP embeddings for images and sentences
+
+github_url: https://github.com/jina-ai/clip-as-service
+website_url: https://clip-as-service.jina.ai
+docs_url: https://clip-as-service.jina.ai
+install_command: pip install clip-as-service
+
+category: Other
+tags: [clip, embeddings, multimodal, python, image-search, jina, serving]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Running CLIP for production image-text search means packaging the model,
+  batching, and exposing an API. CLIP as Service ships a client and server that
+  encode images and sentences, rank pairs, and scale across GPUs so you can
+  plug CLIP embeddings into search without building a serving stack.
+
+use_cases:
+  - Encode product images and captions into a shared CLIP space for visual search
+  - Rank candidate captions against an image from a gRPC or HTTP CLIP server
+  - Serve CLIP embeddings to a vector database without wrapping the model yourself
+  - Prototype cross-modal retrieval in Python with a one-line client encode call

--- a/tools/rag/amazon-kendra.yaml
+++ b/tools/rag/amazon-kendra.yaml
@@ -1,0 +1,23 @@
+name: Amazon Kendra
+description: AWS managed enterprise search and RAG service that indexes documents from S3, SharePoint, databases, and SaaS connectors. Returns ranked passages with filters so internal knowledge bases can power search and retrieval-augmented generation without a self-hosted index.
+tagline: Managed enterprise search and RAG on AWS
+
+website_url: https://aws.amazon.com/kendra/
+docs_url: https://docs.aws.amazon.com/kendra/
+
+category: RAG
+tags: [aws, enterprise-search, rag, managed, saas, retrieval]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Enterprise RAG needs connectors, access control, and ranked passages across
+  SharePoint, S3, and wikis. Building that index in-house is slow. Amazon Kendra
+  is a managed retriever that crawls those sources and returns passages you can
+  feed to an LLM without operating Elasticsearch or a vector cluster.
+
+use_cases:
+  - Index internal wikis, S3 docs, and SharePoint for enterprise question answering
+  - Use Kendra as the retriever in a RAG chatbot on AWS
+  - Filter search results by metadata and access control for regulated corpora
+  - Prototype document Q&A without standing up a self-hosted search index

--- a/tools/rag/memorag.yaml
+++ b/tools/rag/memorag.yaml
@@ -1,0 +1,27 @@
+name: MemoRAG
+description: Memory-augmented RAG framework that builds a global memory over long corpora, then recalls query-specific clues to improve retrieval. Handles hundreds of thousands of tokens so RAG can answer implicit questions that standard chunk search misses.
+tagline: Memory-inspired RAG for long-context knowledge discovery
+
+github_url: https://github.com/qhjqhj00/MemoRAG
+website_url: https://github.com/qhjqhj00/MemoRAG
+docs_url: https://arxiv.org/abs/2409.05591
+install_command: pip install memorag
+
+category: RAG
+tags: [rag, memory, long-context, python, retrieval, llm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Standard RAG only helps when the query names the evidence you need. On long
+  books, reports, or mixed corpora the right passage is often implied, not
+  keyword-matched. MemoRAG memorizes the whole context, generates clues from
+  that memory, then retrieves evidence so answers stay grounded on very long
+  documents.
+
+use_cases:
+  - Answer implicit questions over a book-length corpus that chunk search misses
+  - Summarize and query long reports after a single memorize pass with cached KV
+  - Build RAG over legal or research PDFs that exceed typical context windows
+  - Reuse encoded memory caches so repeated queries skip re-indexing the corpus

--- a/tools/vector-databases/kinetica.yaml
+++ b/tools/vector-databases/kinetica.yaml
@@ -1,0 +1,23 @@
+name: Kinetica
+description: GPU-accelerated analytics database with vector search, SQL, and geospatial functions. Runs similarity search beside real-time aggregations so teams can mix embeddings with operational analytics instead of adding a separate vector store.
+tagline: GPU analytics database with built-in vector search
+
+website_url: https://www.kinetica.com
+docs_url: https://docs.kinetica.com
+
+category: Vector DB
+tags: [gpu, analytics, vector-search, sql, geospatial, saas]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Mixing vector similarity with SQL analytics usually means a warehouse plus a
+  separate vector DB and glue jobs. Kinetica puts GPU-accelerated SQL, spatial
+  queries, and vector search in one engine so embeddings can be filtered and
+  joined with operational data without a sidecar index.
+
+use_cases:
+  - Run KNN over embeddings next to SQL filters on operational tables
+  - Combine geospatial analytics with vector similarity for location-aware search
+  - Query high-ingest telemetry with GPU-accelerated aggregations and embeddings
+  - Avoid a separate vector database when the warehouse already holds features


### PR DESCRIPTION
## Catalog batch

Add 5 tools to the Agentic AI For Good catalog:

| Tool | Category | Notes |
|------|----------|------|
| MemoRAG | RAG | qhjqhj00/MemoRAG (2.3k, Apache-2.0) |
| CLIP as Service | Other | jina-ai/clip-as-service (12.8k, Apache-2.0) |
| Algolia | Other | hosted search API (SaaS, pip SDK) |
| Amazon Kendra | RAG | AWS managed enterprise search (SaaS) |
| Kinetica | Vector DB | GPU analytics DB with vector search (SaaS) |

All files passed local `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Algolia, a hosted search API supporting typo-tolerant search, faceting, and ranking.
  - Added CLIP as Service for image-text embeddings, ranking, and cross-modal retrieval.
  - Added Amazon Kendra for enterprise search and retrieval-augmented applications.
  - Added MemoRAG for memory-augmented retrieval and long-document summarization.
  - Added Kinetica, a GPU-accelerated database for vector, geospatial, and telemetry queries.

- **Documentation**
  - Included metadata, links, pricing, installation details, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->