### PR TITLE
Add Nextcloud, Vitess, Patroni, PgBouncer, HDF5 to catalog

### DIFF
--- a/tools/data/hdf5.yaml
+++ b/tools/data/hdf5.yaml
@@ -1,0 +1,25 @@
+name: HDF5
+description: Hierarchical Data Format library for storing large numerical arrays, tables, and metadata in a portable binary file. The standard on-disk format for scientific and ML datasets that need chunking, compression, and partial reads.
+tagline: Hierarchical binary format for large scientific arrays
+
+github_url: https://github.com/HDFGroup/hdf5
+website_url: https://www.hdfgroup.org/solutions/hdf5/
+docs_url: https://docs.hdfgroup.org/hdf5/develop/
+install_command: brew install hdf5
+
+category: Data
+tags: [array-storage, scientific-computing, hdf5, numerical, datasets, compression]
+pricing: free
+is_open_source: true
+
+problem_solved: |
+  Large numerical datasets do not fit in CSV or a single NumPy save file, and
+  you still need partial reads, compression, and portable metadata. HDF5 stores
+  chunked arrays and groups in one file so training pipelines can stream
+  subsets without loading the whole dump into memory.
+
+use_cases:
+  - Store chunked training arrays with compression and named groups in one file
+  - Read slices of a multi-gigabyte scientific dataset without loading it all
+  - Exchange numerical datasets between Python, C++, and MATLAB pipelines
+  - Back h5py, PyTables, and TensorFlow data loaders with a portable file format

--- a/tools/data/nextcloud.yaml
+++ b/tools/data/nextcloud.yaml
@@ -1,0 +1,25 @@
+name: Nextcloud
+description: Self-hosted file sync, sharing, and collaboration platform. Stores datasets, model artifacts, and team documents with access control so ML groups can keep training data on their own servers instead of a public cloud drive.
+tagline: Self-hosted file sync and collaboration for team data
+
+github_url: https://github.com/nextcloud/server
+website_url: https://nextcloud.com
+docs_url: https://docs.nextcloud.com
+
+category: Data
+tags: [file-sync, self-hosted, collaboration, storage, datasets, agpl]
+pricing: freemium
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  ML teams need a place to share datasets and checkpoints without dumping them
+  on consumer cloud drives that lack access control. Nextcloud is a self-hosted
+  file platform with sharing, versions, and SSO so artifacts stay on your
+  infrastructure while still being easy to browse and sync.
+
+use_cases:
+  - Host shared training datasets and model checkpoints on your own servers
+  - Sync experiment folders across laptops with access-controlled sharing
+  - Replace consumer cloud drives for internal ML documentation and data drops
+  - Version and recover large files without putting them in git

--- a/tools/data/patroni.yaml
+++ b/tools/data/patroni.yaml
@@ -1,0 +1,26 @@
+name: Patroni
+description: Python template for PostgreSQL high availability using etcd, Consul, ZooKeeper, or Kubernetes. Automates leader election, failover, and replica management so Postgres clusters that hold ML metadata stay available.
+tagline: PostgreSQL high availability with automatic failover
+
+github_url: https://github.com/patroni/patroni
+website_url: https://patroni.readthedocs.io
+docs_url: https://patroni.readthedocs.io
+install_command: pip install patroni
+
+category: Data
+tags: [postgresql, high-availability, failover, python, kubernetes, etcd]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Postgres is the default store for embeddings metadata and experiment tracking,
+  but a single primary is a single point of failure. Patroni automates leader
+  election and failover with etcd, Consul, or Kubernetes so the cluster recovers
+  without a human running pg_ctl promote.
+
+use_cases:
+  - Run automatic failover for Postgres that stores ML experiment metadata
+  - Deploy a Patroni cluster on Kubernetes next to training workloads
+  - Keep replicas in sync with etcd or Consul as the DCS for leader election
+  - Fail over a feature-store Postgres without manual promotion scripts

--- a/tools/data/pgbouncer.yaml
+++ b/tools/data/pgbouncer.yaml
@@ -1,0 +1,26 @@
+name: PgBouncer
+description: Lightweight connection pooler for PostgreSQL. Multiplexes many app connections onto a smaller set of server connections so RAG services, agents, and notebooks do not exhaust Postgres max_connections.
+tagline: Lightweight PostgreSQL connection pooler
+
+github_url: https://github.com/pgbouncer/pgbouncer
+website_url: https://www.pgbouncer.org/
+docs_url: https://www.pgbouncer.org/usage.html
+install_command: brew install pgbouncer
+
+category: Data
+tags: [postgresql, connection-pooling, database, performance, cli]
+pricing: free
+is_open_source: true
+license: ISC
+
+problem_solved: |
+  Each agent, notebook, and RAG worker opens its own Postgres connections and
+  quickly hits max_connections. PgBouncer sits in front of Postgres, pools
+  sessions or transactions, and keeps the database from falling over under
+  bursty ML app traffic.
+
+use_cases:
+  - Pool connections from many RAG workers onto a small Postgres instance
+  - Protect a feature-store database from notebook connection storms
+  - Run transaction pooling in front of Patroni-managed Postgres primaries
+  - Cut connection overhead for short-lived agent queries against Postgres

--- a/tools/data/vitess.yaml
+++ b/tools/data/vitess.yaml
@@ -1,0 +1,25 @@
+name: Vitess
+description: CNCF database clustering system that shards MySQL for horizontal scale. Lets AI product backends and feature stores keep MySQL compatibility while spreading write and read load across many MySQL instances.
+tagline: Horizontal sharding for MySQL at CNCF scale
+
+github_url: https://github.com/vitessio/vitess
+website_url: https://vitess.io
+docs_url: https://vitess.io/docs/
+
+category: Data
+tags: [mysql, sharding, kubernetes, cncf, database, scalability]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Feature stores and product databases outgrow a single MySQL primary. Manual
+  sharding is brittle. Vitess sits in front of many MySQL instances, routes
+  queries, and reshard live so you keep the MySQL protocol while scaling writes
+  and reads for AI application backends.
+
+use_cases:
+  - Shard a MySQL-backed feature or metadata store without rewriting the app SQL
+  - Run Vitess on Kubernetes to scale AI product databases horizontally
+  - Reshard live tables when training-job metadata volume grows
+  - Keep MySQL compatibility for ORMs while adding connection pooling and routing


### PR DESCRIPTION
## Catalog batch

Add 5 tools to the Agentic AI For Good catalog:

| Tool | Category | Repo |
|------|----------|------|
| Nextcloud | Data | nextcloud/server (36.7k, AGPL-3.0) |
| Vitess | Data | vitessio/vitess (21.3k, Apache-2.0) |
| Patroni | Data | patroni/patroni (8.7k, MIT) |
| PgBouncer | Data | pgbouncer/pgbouncer (4.3k, ISC) |
| HDF5 | Data | HDFGroup/hdf5 (0.98k, official HDF5 library) |

Skipped MinIO (minio/minio is archived on GitHub).

All files passed local `npx tsx scripts/validate-tool.ts`.
