### PR TITLE
Add NetCDF, Quarto, Looker, gping, Typst to catalog

### DIFF
--- a/tools/data/looker.yaml
+++ b/tools/data/looker.yaml
@@ -1,0 +1,23 @@
+name: Looker
+description: Google Cloud business intelligence platform with a LookML semantic layer for governed metrics, dashboards, and embedded analytics. Teams expose warehouse data to analysts and LLM agents without copying SQL into every app.
+tagline: Governed BI and semantic layer on Google Cloud
+
+website_url: https://cloud.google.com/looker
+docs_url: https://cloud.google.com/looker/docs
+
+category: Data
+tags: [business-intelligence, semantic-layer, dashboards, google-cloud, analytics, lookml]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Warehouse metrics get redefined in every dashboard and LLM prompt, so
+  numbers drift and agents hallucinate KPIs. Looker defines business logic
+  once in LookML and serves the same governed metrics to analysts, embeds,
+  and conversational agents.
+
+use_cases:
+  - Define revenue and model-quality metrics once in LookML for every dashboard
+  - Embed governed analytics into an AI product without duplicating SQL
+  - Let analysts ask warehouse questions in natural language on trusted metrics
+  - Power executive dashboards on BigQuery or Snowflake through a semantic layer

--- a/tools/data/netcdf.yaml
+++ b/tools/data/netcdf.yaml
@@ -1,0 +1,26 @@
+name: NetCDF
+description: Network Common Data Form libraries and a self-describing binary format for array-oriented scientific data. Climate, geospatial, and ML pipelines store multidimensional arrays with portable metadata and partial reads.
+tagline: Self-describing array format for scientific datasets
+
+github_url: https://github.com/Unidata/netcdf-c
+website_url: https://www.unidata.ucar.edu/software/netcdf/
+docs_url: https://docs.unidata.ucar.edu/netcdf-c/current/
+install_command: pip install netCDF4
+
+category: Data
+tags: [scientific-computing, arrays, climate, geospatial, hdf5, datasets]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Climate, satellite, and simulation data arrive as huge multidimensional
+  arrays that CSV and raw NumPy dumps cannot describe or slice efficiently.
+  NetCDF stores those arrays with units, coordinates, and chunked access so
+  training jobs can read subsets without loading the whole file.
+
+use_cases:
+  - Load climate or satellite NetCDF cubes into NumPy or Xarray for training
+  - Store geospatial features with lat, lon, and time coordinates in one file
+  - Stream a slice of a multi-gigabyte scientific dataset without full download
+  - Exchange array datasets between Python, C, Fortran, and R research stacks

--- a/tools/data/quarto.yaml
+++ b/tools/data/quarto.yaml
@@ -1,0 +1,26 @@
+name: Quarto
+description: Open-source scientific publishing system built on Pandoc that turns Markdown, Jupyter, and R into HTML, PDF, and slides. Research and ML teams publish papers, model cards, and reproducible reports from a single source.
+tagline: Scientific publishing from Markdown, Jupyter, and R
+
+github_url: https://github.com/quarto-dev/quarto-cli
+website_url: https://quarto.org
+docs_url: https://quarto.org/docs/guide/
+install_command: brew install --cask quarto
+
+category: Data
+tags: [publishing, markdown, jupyter, reports, documentation, pandoc]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Model cards, papers, and eval writeups live in notebooks that do not
+  become HTML or PDF without a one-off export script. Quarto compiles
+  Markdown, Jupyter, and R into websites, PDFs, and slides so the same
+  source publishes a reproducible report.
+
+use_cases:
+  - Publish a Jupyter experiment as an HTML report with executed outputs
+  - Build a research site from Markdown chapters with citations and figures
+  - Turn model cards and eval notes into PDF or slides for stakeholders
+  - Render parameterized reports for recurring training or data-quality runs

--- a/tools/dev-tools/typst.yaml
+++ b/tools/dev-tools/typst.yaml
@@ -1,0 +1,25 @@
+name: Typst
+description: Markup-based typesetting system that compiles to PDF faster than LaTeX with a simpler syntax. Teams write papers, model cards, and technical reports in Typst when a full LaTeX toolchain is too heavy.
+tagline: Fast markup typesetting for papers and reports
+
+github_url: https://github.com/typst/typst
+website_url: https://typst.app
+docs_url: https://typst.app/docs/
+install_command: brew install typst
+
+category: Dev Tools
+tags: [typesetting, pdf, markup, latex, documents, rust]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Technical PDFs still depend on a slow LaTeX install and brittle macros.
+  Typst compiles a small markup language to PDF in milliseconds so papers,
+  model cards, and internal reports iterate without a TeX distribution.
+
+use_cases:
+  - Compile a research paper or model card to PDF from Typst markup
+  - Generate formatted eval reports from templates in a CI pipeline
+  - Write technical docs that need equations without installing LaTeX
+  - Preview typeset output live while editing a methods section

--- a/tools/monitoring/gping.yaml
+++ b/tools/monitoring/gping.yaml
@@ -1,0 +1,25 @@
+name: gping
+description: Command-line ping with a live terminal graph of latency over time. Operators watch packet loss and RTT to model APIs, GPU hosts, and inference endpoints without leaving the shell.
+tagline: Ping with a live latency graph in the terminal
+
+github_url: https://github.com/orf/gping
+website_url: https://github.com/orf/gping
+docs_url: https://github.com/orf/gping
+install_command: brew install gping
+
+category: Monitoring
+tags: [ping, latency, networking, cli, rust, observability]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Plain ping dumps numbers that are hard to scan when an API or GPU box
+  is flaky. gping plots RTT as a live graph in the terminal so you can
+  see spikes, packet loss, and recovery while debugging inference hosts.
+
+use_cases:
+  - Graph latency to an inference API while a rollout is in progress
+  - Compare RTT across several GPU hosts or regions in one terminal
+  - Watch packet loss to a remote training box during a long job
+  - Diagnose slow model-serving endpoints without opening a metrics UI


### PR DESCRIPTION
## Summary

Adds five catalog entries:

- **NetCDF** (Data) — Unidata array format and libraries for scientific datasets (`pip install netCDF4`)
- **Quarto** (Data) — scientific publishing from Markdown, Jupyter, and R (`brew install --cask quarto`)
- **Looker** (Data) — Google Cloud BI platform with LookML semantic layer (SaaS)
- **gping** (Monitoring) — ping with a live latency graph (`brew install gping`)
- **Typst** (Dev Tools) — markup typesetting system (`brew install typst`)

Local validation passed for all five YAML files.

## Test plan

- [x] `npx tsx scripts/validate-tool.ts` on each file
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Tools**
  * Added catalog entries for Looker, NetCDF, Quarto, Typst, and gping.
  * Included descriptions, documentation and repository links, installation details, licensing, pricing, categories, tags, and supported use cases.
  * Added metadata highlighting semantic modeling, scientific data storage, publishing, technical documentation, and network latency monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->