### PR TITLE
Add Hugo, Bitwarden, WezTerm to catalog

### DIFF
--- a/tools/dev-tools/bitwarden.yaml
+++ b/tools/dev-tools/bitwarden.yaml
@@ -1,0 +1,28 @@
+name: Bitwarden
+description: Open-source password manager with a self-hostable vault, CLI, and browser extensions. ML teams keep API keys, cloud credentials, and Hugging Face tokens in an encrypted vault instead of Slack pastes or plaintext .env files.
+tagline: Encrypted vault and CLI for API keys and credentials
+
+github_url: https://github.com/bitwarden/server
+website_url: https://bitwarden.com
+docs_url: https://bitwarden.com/help/
+
+install_command: brew install bitwarden-cli
+
+category: Dev Tools
+tags: [secrets, passwords, vault, cli, security, credentials]
+pricing: freemium
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Training jobs and local shells still pull OpenAI keys, cloud creds,
+  and Hugging Face tokens from Slack or unencrypted .env files. Bitwarden
+  stores those secrets in an encrypted vault with a CLI so CI, laptops,
+  and GPU nodes can fetch credentials without committing them.
+
+use_cases:
+  - Store OpenAI and Hugging Face tokens in a shared encrypted vault
+  - Inject cloud credentials into a training job from the Bitwarden CLI
+  - Self-host a team vault for API keys instead of a password spreadsheet
+  - Autofill staging logins from the browser extension during demos
+  - Rotate an API key once in the vault instead of chasing .env copies

--- a/tools/dev-tools/hugo.yaml
+++ b/tools/dev-tools/hugo.yaml
@@ -1,0 +1,28 @@
+name: Hugo
+description: Go static site generator that compiles Markdown into documentation sites, landing pages, and experiment reports in milliseconds. AI teams use Hugo to publish model cards, eval writeups, and internal wikis without a CMS or Node toolchain.
+tagline: Fast static sites for docs, model cards, and reports
+
+github_url: https://github.com/gohugoio/hugo
+website_url: https://gohugo.io
+docs_url: https://gohugo.io/documentation/
+
+install_command: brew install hugo
+
+category: Dev Tools
+tags: [static-site, go, markdown, documentation, docs, cli]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Model cards, eval reports, and internal docs stall when a CMS or JS
+  toolchain is required just to ship Markdown. Hugo builds those sites
+  from Git in milliseconds so teams can publish experiment writeups
+  and API docs without waiting on a Node build or a hosted wiki.
+
+use_cases:
+  - Publish model cards and eval reports as a Git-backed static site
+  - Host internal ML documentation without a CMS or Node toolchain
+  - Generate a project landing page from Markdown in CI
+  - Rebuild docs on every merge as a fast static artifact
+  - Serve experiment writeups locally while iterating on content

--- a/tools/dev-tools/wezterm.yaml
+++ b/tools/dev-tools/wezterm.yaml
@@ -1,0 +1,28 @@
+name: WezTerm
+description: GPU-accelerated cross-platform terminal emulator and multiplexer written in Rust. WezTerm runs SSH sessions, splits, and high-volume training logs in one Lua-configured window without the lag of CPU-bound terminals.
+tagline: GPU-accelerated terminal emulator and multiplexer
+
+github_url: https://github.com/wezterm/wezterm
+website_url: https://wezterm.org/
+docs_url: https://wezterm.org/
+
+install_command: brew install --cask wezterm
+
+category: Dev Tools
+tags: [terminal, rust, gpu, multiplexer, ssh, cli]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  CPU-bound terminals stutter when training logs flood stdout or many
+  SSH panes are open on a GPU box. WezTerm renders with the GPU, multiplexes
+  tabs and splits in-process, and is configured in Lua so long-running
+  jobs stay readable without a separate tmux layer.
+
+use_cases:
+  - Tail high-volume training logs without terminal lag
+  - SSH into a GPU box with persistent splits in one window
+  - Configure fonts, keys, and panes in Lua for a shared team setup
+  - Multiplex local shells and remote sessions without a separate tmux
+  - Keep a readable scrollback while several jobs print at once


### PR DESCRIPTION
## Summary

Adds three catalog entries left from a prior run:

- **Hugo** (Dev Tools) — Go static site generator (`brew install hugo`)
- **Bitwarden** (Dev Tools) — encrypted vault and CLI for credentials (`brew install bitwarden-cli`)
- **WezTerm** (Dev Tools) — GPU-accelerated terminal emulator (`brew install --cask wezterm`)

Local validation passed for all three YAML files.

## Test plan

- [x] `npx tsx scripts/validate-tool.ts` on each file
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Bitwarden to the developer tools catalog, including installation details, links, licensing, and credential-management use cases.
  - Added Hugo to the developer tools catalog with installation information, resources, and common use cases.
  - Added WezTerm to the developer tools catalog with installation details, resources, and terminal workflow use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->