### PR TITLE
Add Ghostty, Alacritty, Kitty, Datasette, Litestream to catalog

### DIFF
--- a/tools/data/datasette.yaml
+++ b/tools/data/datasette.yaml
@@ -1,0 +1,25 @@
+name: Datasette
+description: Open-source tool for exploring and publishing SQLite databases as a website with a JSON API, facets, and plugins. Datasette turns local datasets into a shareable, queryable app without standing up a custom backend.
+tagline: Explore and publish SQLite on the web
+
+github_url: https://github.com/simonw/datasette
+website_url: https://datasette.io
+docs_url: https://docs.datasette.io
+install_command: pip install datasette
+
+category: Data
+tags: [sqlite, data-exploration, publishing, python, json-api, plugins]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  SQLite dumps of evals, crawls, or features sit on disk with no UI or
+  API. Datasette serves those databases as a website with filters, SQL,
+  and JSON so teammates can explore and publish data without a custom app.
+
+use_cases:
+  - Publish an eval SQLite database as a browsable website with facets
+  - Expose crawl or labeling tables through Datasette's JSON API
+  - Explore a local feature store dump in the browser during research
+  - Plugin custom views for ML metadata without building a dashboard

--- a/tools/data/litestream.yaml
+++ b/tools/data/litestream.yaml
@@ -1,0 +1,25 @@
+name: Litestream
+description: Streaming replication for SQLite that continuously copies WAL changes to S3 or another object store. Litestream gives SQLite apps disaster recovery and read replicas without running a full database cluster.
+tagline: Streaming SQLite replication to object storage
+
+github_url: https://github.com/benbjohnson/litestream
+website_url: https://litestream.io
+docs_url: https://litestream.io/docs/
+install_command: brew install litestream
+
+category: Data
+tags: [sqlite, replication, s3, backup, disaster-recovery, go]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  SQLite is simple until a disk dies and the only copy is on that box.
+  Litestream streams WAL pages to S3 so you can restore or replica-read
+  without operating Postgres just to keep a small app durable.
+
+use_cases:
+  - Replicate a local SQLite feature cache to S3 continuously
+  - Restore an eval database from object storage after a host failure
+  - Run a small ML metadata app on SQLite with off-box backups
+  - Point a read replica at replicated SQLite for reporting queries

--- a/tools/dev-tools/alacritty.yaml
+++ b/tools/dev-tools/alacritty.yaml
@@ -1,0 +1,25 @@
+name: Alacritty
+description: Cross-platform OpenGL terminal emulator focused on speed and simplicity. Alacritty is configured in TOML and stays out of the way so you pair it with tmux or a window manager instead of built-in tabs.
+tagline: OpenGL terminal emulator focused on speed
+
+github_url: https://github.com/alacritty/alacritty
+website_url: https://alacritty.org
+docs_url: https://alacritty.org/config-alacritty.html
+install_command: brew install --cask alacritty
+
+category: Dev Tools
+tags: [terminal, gpu, opengl, rust, cli, toml]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Heavy terminals add tabs, panes, and GPU features you may already get
+  from tmux. Alacritty renders with OpenGL and stays a fast emulator so
+  you keep multiplexing in your window manager or tmux without extra UI.
+
+use_cases:
+  - Run tmux inside a fast GPU-rendered terminal on a GPU workstation
+  - Config fonts and colors in TOML and share the file across machines
+  - Tail training logs without a heavy Electron terminal
+  - Use a minimal emulator over SSH jump hosts and local shells

--- a/tools/dev-tools/ghostty.yaml
+++ b/tools/dev-tools/ghostty.yaml
@@ -1,0 +1,26 @@
+name: Ghostty
+description: Fast cross-platform terminal emulator with platform-native UI and GPU acceleration. Ghostty keeps training logs, SSH sessions, and multiplexed panes readable without the lag of CPU-bound terminals.
+tagline: Native GPU-accelerated terminal emulator
+
+github_url: https://github.com/ghostty-org/ghostty
+website_url: https://ghostty.org
+docs_url: https://ghostty.org/docs
+install_command: brew install --cask ghostty
+
+category: Dev Tools
+tags: [terminal, gpu, rust, ssh, cli, macos]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  CPU-bound terminals stutter when training logs flood stdout or many
+  SSH sessions are open. Ghostty uses GPU rendering and native UI so
+  long-running jobs stay readable without switching to a multiplexer
+  just to keep up.
+
+use_cases:
+  - Tail high-volume training logs without terminal lag
+  - SSH into GPU boxes with native tabs and splits
+  - Run local shells and remote sessions in one GPU-rendered window
+  - Keep scrollback readable while several jobs print at once

--- a/tools/dev-tools/kitty.yaml
+++ b/tools/dev-tools/kitty.yaml
@@ -1,0 +1,26 @@
+name: Kitty
+description: GPU-based terminal emulator with tabs, splits, images, and kitten extras for people who live in the shell. Kitty renders on the GPU and scripts window layouts so training logs and remote sessions stay in one app.
+tagline: GPU terminal with tabs, images, and kitten extras
+
+github_url: https://github.com/kovidgoyal/kitty
+website_url: https://sw.kovidgoyal.net/kitty/
+docs_url: https://sw.kovidgoyal.net/kitty/
+install_command: brew install --cask kitty
+
+category: Dev Tools
+tags: [terminal, gpu, python, images, ssh, cli]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Plain terminals cannot show images, Unicode, or complex layouts while
+  remaining fast. Kitty renders on the GPU, supports graphics in the
+  terminal, and ships kitten tools so you can diff, SSH, and tile panes
+  without a separate multiplexer.
+
+use_cases:
+  - Show plots and images inline while iterating on a training script
+  - Tile SSH sessions and local shells with kitten layouts
+  - Diff files in the terminal without leaving the GPU emulator
+  - Keep Unicode and ligatures readable in high-volume log output


### PR DESCRIPTION
## Summary

Adds five catalog entries:

- **Ghostty** (Dev Tools) — native GPU terminal (`brew install --cask ghostty`)
- **Alacritty** (Dev Tools) — OpenGL terminal emulator (`brew install --cask alacritty`)
- **Kitty** (Dev Tools) — GPU terminal with kitten extras (`brew install --cask kitty`)
- **Datasette** (Data) — explore and publish SQLite (`pip install datasette`)
- **Litestream** (Data) — streaming SQLite replication (`brew install litestream`)

Local validation passed for all five YAML files.

## Test plan

- [x] `npx tsx scripts/validate-tool.ts` on each file
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Datasette and Litestream to the tools catalog, including descriptions, links, installation details, licensing, pricing, and example use cases.
  - Added Alacritty, Ghostty, and Kitty to the developer tools catalog with information about their terminal capabilities, supported platforms, installation options, licensing, and common workflows.
  - Tool listings now provide consistent metadata to help users compare and discover database and terminal utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->