### PR TITLE
Add VitePress, OctoSQL to catalog

### DIFF
--- a/tools/data/octosql.yaml
+++ b/tools/data/octosql.yaml
@@ -1,0 +1,25 @@
+name: OctoSQL
+description: CLI that runs SQL across files and databases so you can join CSV, JSON, Parquet, Postgres, and more in one query. OctoSQL is for ad-hoc analysis when standing up a warehouse is more work than the question.
+tagline: SQL over files and databases in one query
+
+github_url: https://github.com/cube2222/octosql
+website_url: https://github.com/cube2222/octosql
+docs_url: https://github.com/cube2222/octosql
+install_command: brew install octosql
+
+category: Data
+tags: [sql, csv, parquet, json, cli, data-analysis]
+pricing: free
+is_open_source: true
+license: MPL-2.0
+
+problem_solved: |
+  Eval dumps, crawls, and logs live in mixed CSV, JSON, and Parquet files
+  that you should not load into a warehouse just to join. OctoSQL queries
+  those sources with SQL in one process so you can inspect data in place.
+
+use_cases:
+  - Join a CSV of labels with a Parquet feature dump in one SQL query
+  - Query JSONL eval output without importing it into Postgres
+  - Compare a local file against a live Postgres table during debugging
+  - Script ad-hoc SQL over mixed files in a CI data-quality check

--- a/tools/dev-tools/vitepress.yaml
+++ b/tools/dev-tools/vitepress.yaml
@@ -1,0 +1,25 @@
+name: VitePress
+description: Vite and Vue static site generator for documentation. VitePress compiles Markdown into a fast docs site with Vue components, search, and a default theme so API and model docs ship without a heavy CMS.
+tagline: Vite and Vue static site generator for docs
+
+github_url: https://github.com/vuejs/vitepress
+website_url: https://vitepress.dev
+docs_url: https://vitepress.dev/guide/getting-started
+install_command: npm install -D vitepress
+
+category: Dev Tools
+tags: [documentation, vue, vite, markdown, static-site, docs]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Project docs stall when the site generator is slow or needs a CMS.
+  VitePress builds Markdown into a Vite-powered docs site with a default
+  theme so teams publish API guides and model cards from the repo.
+
+use_cases:
+  - Publish library and SDK docs from Markdown in the same repo
+  - Add Vue components to a docs page for interactive API examples
+  - Ship model cards and eval notes as a static documentation site
+  - Preview docs locally with Vite HMR while editing Markdown


### PR DESCRIPTION
## Summary

Adds two catalog entries:

- **VitePress** (Dev Tools) — Vite and Vue docs generator (`npm install -D vitepress`)
- **OctoSQL** (Data) — SQL over files and databases (`brew install octosql`)

Local validation passed for both YAML files.

## Test plan

- [x] `npx tsx scripts/validate-tool.ts` on each file
- [ ] CI "Validate tool YAML files" check
