### PR TITLE
Add Kakoune, Cedar, xonsh, curlie, tmuxp to catalog

### DIFF
--- a/tools/dev-tools/cedar.yaml
+++ b/tools/dev-tools/cedar.yaml
@@ -1,0 +1,24 @@
+name: Cedar
+description: Open-source authorization policy language from AWS for fine-grained access control. Cedar separates policy from application code so ML platforms can express who may invoke models, datasets, and tools as readable rules.
+tagline: Authorization policy language for fine-grained access
+
+github_url: https://github.com/cedar-policy/cedar
+website_url: https://www.cedarpolicy.com
+docs_url: https://docs.cedarpolicy.com
+
+category: Dev Tools
+tags: [authorization, policy, aws, access-control, security, rust]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Who can call a model, read a dataset, or run a tool ends up hardcoded
+  in application if-statements. Cedar stores those rules as policies so
+  you can audit and change access without shipping a new app build.
+
+use_cases:
+  - Authorize which roles may invoke an inference API or GPU job
+  - Gate dataset and feature-store reads with readable Cedar policies
+  - Test authorization rules in CI before deploying an ML platform
+  - Share the same policy language across services instead of ad-hoc ACLs

--- a/tools/dev-tools/curlie.yaml
+++ b/tools/dev-tools/curlie.yaml
@@ -1,0 +1,25 @@
+name: curlie
+description: Frontend for curl that keeps curl's flags and adds HTTPie-style readable output. curlie is a drop-in for debugging model APIs and webhooks without learning a second HTTP client.
+tagline: curl power with HTTPie-style readable output
+
+github_url: https://github.com/rs/curlie
+website_url: https://rs.github.io/curlie
+docs_url: https://rs.github.io/curlie
+install_command: brew install curlie
+
+category: Dev Tools
+tags: [http, curl, cli, api, debugging, rest]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Raw curl output is hard to scan when you are hitting inference APIs all
+  day, and HTTPie does not accept every curl flag you already know. curlie
+  wraps curl with colorized, formatted responses so debugging stays familiar.
+
+use_cases:
+  - Call an inference endpoint and read JSON without a pager of headers
+  - Reuse existing curl flags against a staging model API
+  - Debug webhook payloads during agent tool-calling development
+  - Compare HTTP status and body from several model providers in the terminal

--- a/tools/dev-tools/kakoune.yaml
+++ b/tools/dev-tools/kakoune.yaml
@@ -1,0 +1,25 @@
+name: Kakoune
+description: Selection-based modal text editor that treats multiple cursors as the default editing model. Kakoune is a lightweight alternative to Vim for editing configs, YAML catalogs, and training scripts in the terminal.
+tagline: Selection-based modal editor with multiple cursors
+
+github_url: https://github.com/mawww/kakoune
+website_url: https://kakoune.org
+docs_url: https://kakoune.org/doc/html/
+install_command: brew install kakoune
+
+category: Dev Tools
+tags: [editor, modal, terminal, vim, multiple-cursors, cli]
+pricing: free
+is_open_source: true
+license: Unlicense
+
+problem_solved: |
+  Editing many similar lines in configs or generated code is slow in a
+  single-cursor modal editor. Kakoune makes selections the primitive so
+  you transform many cursors at once without a plugin layer.
+
+use_cases:
+  - Edit YAML catalog entries with multiple selections in the terminal
+  - Refactor training scripts without leaving a modal editor
+  - Pair Kakoune with tmux for a lightweight remote editing setup
+  - Transform repeated config keys across a file in one motion

--- a/tools/dev-tools/tmuxp.yaml
+++ b/tools/dev-tools/tmuxp.yaml
@@ -1,0 +1,25 @@
+name: tmuxp
+description: Session manager for tmux built on libtmux. tmuxp loads YAML or JSON layouts so GPU boxes, logs, and editors come back as the same pane set after a reboot.
+tagline: YAML session manager for tmux
+
+github_url: https://github.com/tmux-python/tmuxp
+website_url: https://tmuxp.git-pull.com
+docs_url: https://tmuxp.git-pull.com
+install_command: pip install tmuxp
+
+category: Dev Tools
+tags: [tmux, sessions, yaml, python, cli, terminal]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Rebuilding tmux panes after a disconnect wastes time on GPU hosts.
+  tmuxp stores window layouts in YAML so you reload the same splits for
+  training logs, SSH, and editors with one command.
+
+use_cases:
+  - Restore a GPU-box layout with logs, htop, and an editor after SSH drop
+  - Share a team tmux layout for demo and on-call sessions
+  - Load a YAML workspace that tails several training jobs at once
+  - Script session startup in CI or a jump-host login

--- a/tools/dev-tools/xonsh.yaml
+++ b/tools/dev-tools/xonsh.yaml
@@ -1,0 +1,24 @@
+name: xonsh
+description: Python-powered cross-platform shell that mixes Python with familiar shell syntax. xonsh lets you script GPU jobs, path munging, and data globs in Python without leaving the prompt.
+tagline: Python-powered shell for interactive and scripted work
+
+github_url: https://github.com/xonsh/xonsh
+website_url: https://xon.sh
+docs_url: https://xon.sh/contents.html
+install_command: pip install xonsh
+
+category: Dev Tools
+tags: [shell, python, cli, scripting, cross-platform, repl]
+pricing: free
+is_open_source: true
+
+problem_solved: |
+  Bash is awkward for Python-heavy ML workflows, so people bounce between
+  the shell and a REPL. xonsh runs Python at the prompt so you can glob
+  datasets, call libraries, and launch jobs in one language.
+
+use_cases:
+  - Glob training shards and pass them to a Python launcher from the prompt
+  - Write shell aliases that call Python libraries without a wrapper script
+  - Inspect environment variables and paths with Python at the CLI
+  - Run a mixed Python and subprocess workflow during experiment setup


### PR DESCRIPTION
## Summary

Adds five catalog entries:

- **Kakoune** (Dev Tools) — selection-based modal editor (`brew install kakoune`)
- **Cedar** (Dev Tools) — AWS authorization policy language
- **xonsh** (Dev Tools) — Python-powered shell (`pip install xonsh`)
- **curlie** (Dev Tools) — curl frontend with readable output (`brew install curlie`)
- **tmuxp** (Dev Tools) — tmux session manager (`pip install tmuxp`)

Local validation passed for all five YAML files.

## Test plan

- [x] `npx tsx scripts/validate-tool.ts` on each file
- [ ] CI "Validate tool YAML files" check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added five developer tools to the catalog: Cedar, curlie, Kakoune, tmuxp, and xonsh.
  - Added descriptions, tags, categories, pricing and licensing details, project links, and installation instructions where available.
  - Added practical use cases covering authorization policies, API and webhook debugging, terminal editing, tmux session management, and Python-powered shell workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->