### PR TITLE
Add PlanetScale, peco to catalog

### DIFF
--- a/tools/data/planetscale.yaml
+++ b/tools/data/planetscale.yaml
@@ -1,0 +1,23 @@
+name: PlanetScale
+description: Serverless MySQL and PostgreSQL platform with database branching, non-blocking schema changes, and Vitess-backed horizontal scale. Teams ship schema like code without managing shards, failovers, or connection pooling.
+tagline: Serverless MySQL and Postgres with database branching
+
+website_url: https://planetscale.com
+docs_url: https://planetscale.com/docs
+
+category: Data
+tags: [mysql, postgresql, serverless, database, vitess, branching, schema]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Application databases outgrow a single MySQL or Postgres instance, and schema
+  changes on production are risky. PlanetScale hosts Vitess and Postgres clusters
+  with branching, deploy requests, and non-blocking migrations so teams scale
+  writes and ship schema like pull requests without operating shards or failovers.
+
+use_cases:
+  - Branch a production schema, test migrations, then merge via a deploy request
+  - Run MySQL-compatible backends for AI apps that need connection pooling at serverless scale
+  - Shard a growing product or feature-store database without rewriting application SQL
+  - Host Postgres with HA replicas and query insights without managing failover

--- a/tools/dev-tools/peco.yaml
+++ b/tools/dev-tools/peco.yaml
@@ -1,0 +1,27 @@
+name: peco
+description: Simplistic interactive filtering tool for the command line. peco lets you pipe any text into an incremental selector and hand the chosen lines to the next command, similar in spirit to fzf but with a smaller Go-based design.
+tagline: Interactive command-line filtering tool
+
+github_url: https://github.com/peco/peco
+website_url: https://github.com/peco/peco
+docs_url: https://github.com/peco/peco#readme
+
+install_command: brew install peco
+
+category: Dev Tools
+tags: [cli, fuzzy-finder, interactive, filtering, go, terminal, productivity]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Filtering long command output, history, or file lists on the terminal usually
+  means grep with exact patterns. peco turns any piped input into an interactive
+  incremental filter so you pick the matching lines visually, then pass them to
+  the next command without writing a regex.
+
+use_cases:
+  - Interactively filter git branches, process lists, or history and act on the selection
+  - Pipe find or ls output into peco to pick files for editing or deletion
+  - Build shell workflows that let you choose rows from logs or kubectl output
+  - Replace ad-hoc grep loops with an interactive selector in scripts and aliases


### PR DESCRIPTION
## Summary
Adds two tools to the Agentic AI For Good catalog:

- **PlanetScale** (Data) — serverless MySQL and PostgreSQL platform with database branching and Vitess-backed scale
- **peco** (Dev Tools) — interactive command-line filtering tool (MIT, ~7.9k stars)

Soda Core from this tracker batch was skipped: it is already cataloged as `tools/data/soda.yaml`.

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for both files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added PlanetScale platform information, including pricing, resources, capabilities, and common use cases.
  - Added peco tool information, including installation details, licensing, resources, and supported use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->