### PR TITLE
Add RustFS, gron, htmlq, navi, tealdeer to catalog

### DIFF
--- a/tools/data/rustfs.yaml
+++ b/tools/data/rustfs.yaml
@@ -1,0 +1,25 @@
+name: RustFS
+description: Open-source S3-compatible object storage written in Rust. RustFS targets high-performance small-object workloads and can migrate or coexist with other S3 platforms such as MinIO and Ceph.
+tagline: High-performance S3-compatible object storage in Rust
+
+github_url: https://github.com/rustfs/rustfs
+website_url: https://rustfs.com
+docs_url: https://docs.rustfs.com
+
+category: Data
+tags: [object-storage, s3, rust, distributed-storage, minio-alternative, data]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI datasets, checkpoints, and inference artifacts need S3-compatible storage
+  that stays fast on small objects without a Java or Go stack. RustFS provides
+  an Apache-2.0 object store that speaks the S3 API, runs as a container, and
+  can sit alongside MinIO or Ceph during migration.
+
+use_cases:
+  - Store model checkpoints and training datasets on S3-compatible local object storage
+  - Run an S3 endpoint for AI pipelines that need high throughput on small objects
+  - Migrate workloads from MinIO or Ceph while keeping existing S3 clients
+  - Self-host object storage for feature stores and experiment artifacts

--- a/tools/dev-tools/gron.yaml
+++ b/tools/dev-tools/gron.yaml
@@ -1,0 +1,26 @@
+name: gron
+description: Command-line tool that flattens JSON into discrete assignments so you can grep, filter, and then convert back. Makes nested API payloads greppable without writing jq programs.
+tagline: Make JSON greppable
+
+github_url: https://github.com/tomnomnom/gron
+website_url: https://github.com/tomnomnom/gron
+docs_url: https://github.com/tomnomnom/gron#readme
+
+install_command: brew install gron
+
+category: Dev Tools
+tags: [json, cli, grep, go, developer-tools, api]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Nested JSON from APIs is hard to search with grep. gron transforms JSON into
+  line-oriented assignments you can filter with familiar Unix tools, then
+  ungron the result back into valid JSON for the next step in a pipeline.
+
+use_cases:
+  - Grep through large API responses to find nested fields without writing jq
+  - Diff JSON configs by flattening both sides into comparable assignment lines
+  - Extract a subset of JSON with grep and sed, then convert it back with ungron
+  - Explore LLM and vector-DB JSON dumps from the terminal

--- a/tools/dev-tools/htmlq.yaml
+++ b/tools/dev-tools/htmlq.yaml
@@ -1,0 +1,26 @@
+name: htmlq
+description: jq-like command-line tool for HTML. htmlq uses CSS selectors to extract, filter, and pretty-print content from HTML documents and scraped pages.
+tagline: Like jq, but for HTML
+
+github_url: https://github.com/mgdm/htmlq
+website_url: https://github.com/mgdm/htmlq
+docs_url: https://github.com/mgdm/htmlq#readme
+
+install_command: brew install htmlq
+
+category: Dev Tools
+tags: [html, css-selectors, cli, scraping, rust, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Extracting structured bits from HTML usually means a Python script or brittle
+  regex. htmlq lets you pipe HTML through CSS selectors on the command line,
+  similar to jq, so scraping and page inspection stay in Unix pipelines.
+
+use_cases:
+  - Extract article text or links from HTML with CSS selectors in a pipeline
+  - Pretty-print and filter scraped docs before feeding them to an LLM
+  - Pull metadata tags from pages during dataset collection
+  - Prototype web scrapers without writing a full parser

--- a/tools/dev-tools/navi.yaml
+++ b/tools/dev-tools/navi.yaml
@@ -1,0 +1,27 @@
+name: navi
+description: Interactive command-line cheatsheet tool. navi finds snippets from community and personal cheat sheets, fills in arguments, and runs the resulting command without leaving the terminal.
+tagline: Interactive cheatsheet tool for the command line
+
+github_url: https://github.com/denisidoro/navi
+website_url: https://github.com/denisidoro/navi
+docs_url: https://github.com/denisidoro/navi#readme
+
+install_command: brew install navi
+
+category: Dev Tools
+tags: [cli, cheatsheet, productivity, shell, rust, developer-tools]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Useful CLI commands are easy to forget and hard to reconstruct from man pages.
+  navi surfaces community and personal cheatsheets interactively, prompts for
+  arguments, and executes the command so you reuse known-good snippets instead
+  of searching Stack Overflow mid-task.
+
+use_cases:
+  - Look up git, kubectl, or docker snippets and fill arguments interactively
+  - Store team cheatsheets for internal CLIs and ML training jobs
+  - Bind navi to a shell shortcut as an interactive command palette
+  - Share parameterized recipes for data and infra commands across a team

--- a/tools/dev-tools/tealdeer.yaml
+++ b/tools/dev-tools/tealdeer.yaml
@@ -1,0 +1,26 @@
+name: tealdeer
+description: Very fast Rust implementation of tldr, the simplified man-page client. tealdeer caches community examples locally so common CLI usage is a fraction of a second away.
+tagline: Fast tldr client written in Rust
+
+github_url: https://github.com/dbrgn/tealdeer
+website_url: https://docs.tealdeer.org
+docs_url: https://docs.tealdeer.org
+
+install_command: brew install tealdeer
+
+category: Dev Tools
+tags: [tldr, man-pages, cli, rust, documentation, developer-tools]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Full man pages bury the one example you need. tealdeer is a fast local tldr
+  client that caches community examples so you get practical command snippets
+  instantly, even offline, without waiting on a network tldr client.
+
+use_cases:
+  - Look up common usage examples for CLI tools without opening a man page
+  - Keep a local cache of tldr pages for offline work on training clusters
+  - Replace slower tldr clients with a Rust binary in developer dotfiles
+  - Onboard teammates to git, docker, and data CLIs with short examples


### PR DESCRIPTION
## Summary
Adds five tools to the Agentic AI For Good catalog:

- **RustFS** (Data) — S3-compatible object storage in Rust (~31k stars, Apache-2.0)
- **gron** (Dev Tools) — flatten JSON for grep (~14k stars, MIT)
- **htmlq** (Dev Tools) — jq-like CSS selectors for HTML (~7.5k stars, MIT)
- **navi** (Dev Tools) — interactive CLI cheatsheets (~17k stars, Apache-2.0)
- **tealdeer** (Dev Tools) — fast Rust tldr client (~6.5k stars, Apache-2.0)

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added RustFS to the data tools catalog, including storage capabilities, licensing, links, and use cases.
  - Added catalog entries for gron, htmlq, navi, and tealdeer with descriptions, installation instructions, documentation links, licensing, pricing, and practical developer use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->