### PR TITLE
Add mcfly, skim, delta, television to catalog

### DIFF
--- a/tools/dev-tools/delta.yaml
+++ b/tools/dev-tools/delta.yaml
@@ -1,0 +1,26 @@
+name: delta
+description: Syntax-highlighting pager for git, diff, grep, and blame output. delta makes patches readable in the terminal with side-by-side views, word-level highlighting, and Git integration.
+tagline: Syntax-highlighting pager for git and diffs
+
+github_url: https://github.com/dandavison/delta
+website_url: https://dandavison.github.io/delta/
+docs_url: https://dandavison.github.io/delta/
+
+install_command: brew install git-delta
+
+category: Dev Tools
+tags: [git, diff, pager, cli, rust, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Raw git diffs are hard to scan in a terminal. delta colorizes and structures
+  patches with word-level highlighting, line numbers, and optional side-by-side
+  layout so code review and local git workflows stay readable without a GUI.
+
+use_cases:
+  - Set git pager to delta for readable commits, diffs, and blame
+  - Review pull-request patches in the terminal with syntax highlighting
+  - Page ripgrep JSON or grep output with the same highlighter
+  - Diff ML config and code changes with word-level emphasis

--- a/tools/dev-tools/mcfly.yaml
+++ b/tools/dev-tools/mcfly.yaml
@@ -1,0 +1,27 @@
+name: mcfly
+description: Shell history search that uses a neural network to rank commands by context. mcfly replaces Ctrl-R with a smarter picker so the command you actually want surfaces first.
+tagline: Fly through your shell history
+
+github_url: https://github.com/cantino/mcfly
+website_url: https://github.com/cantino/mcfly
+docs_url: https://github.com/cantino/mcfly#readme
+
+install_command: brew install mcfly
+
+category: Dev Tools
+tags: [shell, history, cli, rust, productivity, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Default reverse-i-search ranks shell history by recency, so old commands from
+  other directories crowd out the one you need. mcfly trains a small network on
+  your history and current context to rank likely commands, then lets you pick
+  and run them from a full-screen UI.
+
+use_cases:
+  - Replace Ctrl-R with context-aware history search in bash, zsh, or fish
+  - Jump to prior ML training or docker commands without retyping long flags
+  - Keep a SQLite history database that works across machines
+  - Find rarely used but important commands faster than sequential history search

--- a/tools/dev-tools/skim.yaml
+++ b/tools/dev-tools/skim.yaml
@@ -1,0 +1,27 @@
+name: skim
+description: Fuzzy finder written in Rust, inspired by fzf. skim interactively filters any input stream, supports preview, and ships as a library plus a sk CLI for shell workflows.
+tagline: Fuzzy finder in Rust
+
+github_url: https://github.com/lotabout/skim
+website_url: https://crates.io/crates/skim
+docs_url: https://github.com/lotabout/skim#readme
+
+install_command: brew install sk
+
+category: Dev Tools
+tags: [fuzzy-finder, cli, rust, terminal, fzf, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Interactive filtering of files, history, and command output is dominated by
+  fzf. skim offers a Rust alternative with similar keybindings, preview, and
+  a reusable crate so you can embed a fuzzy picker in other Rust tools without
+  shelling out.
+
+use_cases:
+  - Interactively filter files, git branches, and process lists from the shell
+  - Embed a fuzzy picker in Rust CLIs via the skim crate
+  - Pipe kubectl or log output into sk and act on the selected lines
+  - Use as an fzf-compatible fuzzy finder on systems that prefer Rust binaries

--- a/tools/dev-tools/television.yaml
+++ b/tools/dev-tools/television.yaml
@@ -1,0 +1,27 @@
+name: television
+description: Fast, portable, hackable fuzzy finder TUI. television (tv) lets you interactively search files, text, and custom data sources with a modern terminal UI and a plugin-friendly design.
+tagline: Fast portable fuzzy finder TUI
+
+github_url: https://github.com/alexpasmantier/television
+website_url: https://alexpasmantier.github.io/television/
+docs_url: https://alexpasmantier.github.io/television/
+
+install_command: brew install television
+
+category: Dev Tools
+tags: [fuzzy-finder, tui, cli, rust, terminal, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Fuzzy finders are either tightly coupled to the shell or slow on large trees.
+  television is a fast, portable TUI that searches files and custom channels
+  with a modern UI, so you pick files, git history, or dataset paths without
+  wiring a one-off fzf script each time.
+
+use_cases:
+  - Interactively find files and text across a large monorepo
+  - Browse git history, shells, and custom channels from one TUI
+  - Pipe data into television and select rows for the next command
+  - Replace ad-hoc fzf wrappers with a hackable fuzzy finder


### PR DESCRIPTION
## Summary
Adds four tools to the Agentic AI For Good catalog:

- **mcfly** (Dev Tools) — neural-ranked shell history search (~7.8k stars, MIT)
- **skim** (Dev Tools) — Rust fuzzy finder / fzf alternative (~6.9k stars, MIT)
- **delta** (Dev Tools) — syntax-highlighting pager for git diffs (~32k stars, MIT)
- **television** (Dev Tools) — fast portable fuzzy finder TUI (~6.2k stars, MIT)

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all four files.
