### PR TITLE
Add superfile, gallery-dl, streamlink, MozJPEG, joshuto to catalog

### DIFF
--- a/tools/dev-tools/joshuto.yaml
+++ b/tools/dev-tools/joshuto.yaml
@@ -1,0 +1,26 @@
+name: joshuto
+description: Ranger-like terminal file manager written in Rust. joshuto uses a three-column miller layout with async I/O, previews, and configurable keybindings so you can navigate files without leaving the terminal.
+tagline: Ranger-like terminal file manager written in Rust
+
+github_url: https://github.com/kamiyaa/joshuto
+website_url: https://github.com/kamiyaa/joshuto
+docs_url: https://github.com/kamiyaa/joshuto
+
+install_command: brew install joshuto
+
+category: Dev Tools
+tags: [cli, tui, file-manager, rust, ranger, terminal]
+pricing: free
+is_open_source: true
+license: LGPL-3.0
+
+problem_solved: |
+  ranger is a classic TUI file manager but Python can feel slow on huge trees.
+  joshuto keeps the miller-column workflow in Rust with async listing and
+  previews so you can move through datasets and repos without a GUI.
+
+use_cases:
+  - Navigate project trees with a ranger-style miller column layout
+  - Preview images and text files on a remote SSH session
+  - Copy, move, and bulk-select checkpoint files from the TUI
+  - Customize keybindings to match an existing ranger muscle memory

--- a/tools/dev-tools/mozjpeg.yaml
+++ b/tools/dev-tools/mozjpeg.yaml
@@ -1,0 +1,27 @@
+name: MozJPEG
+description: Improved JPEG encoder from Mozilla that produces smaller files at similar visual quality. MozJPEG is a libjpeg-turbo fork with better quantization and progressive scans for web and dataset image delivery.
+tagline: Smaller JPEGs at similar visual quality
+
+github_url: https://github.com/mozilla/mozjpeg
+website_url: https://github.com/mozilla/mozjpeg
+docs_url: https://github.com/mozilla/mozjpeg
+
+install_command: brew install mozjpeg
+
+category: Dev Tools
+tags: [jpeg, image, optimization, compression, cli, web-performance]
+pricing: free
+is_open_source: true
+license: NOASSERTION
+
+problem_solved: |
+  Baseline JPEG encoders waste bytes on photos you ship on the web or store
+  in datasets. MozJPEG improves quantization and progressive encoding so you
+  keep visual quality while cutting file size for faster delivery and cheaper
+  storage.
+
+use_cases:
+  - Re-encode product photos for faster page loads
+  - Shrink JPEG datasets before training or archival
+  - Produce progressive JPEGs for web image pipelines
+  - Replace libjpeg in a build that needs smaller output files

--- a/tools/dev-tools/superfile.yaml
+++ b/tools/dev-tools/superfile.yaml
@@ -1,0 +1,27 @@
+name: superfile
+description: Pretty fancy and modern terminal file manager written in Go. superfile shows a three-panel TUI with previews, metadata, and plugins so you can browse project trees and datasets without leaving the terminal.
+tagline: Modern three-panel terminal file manager
+
+github_url: https://github.com/yorukot/superfile
+website_url: https://superfile.dev
+docs_url: https://superfile.dev
+
+install_command: brew install superfile
+
+category: Dev Tools
+tags: [cli, tui, file-manager, golang, terminal, productivity]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Default terminal file browsing is ls plus cd, which is slow for nested
+  experiment dirs and datasets. superfile is a visual TUI file manager with
+  previews and plugins so you can inspect files, copy paths, and move artifacts
+  without opening a GUI.
+
+use_cases:
+  - Browse nested experiment and dataset directories on a remote GPU box
+  - Preview images, JSON, and logs before copying them into a pipeline
+  - Move or copy model checkpoints without a graphical file manager
+  - Pin frequently used project folders and jump between them in the TUI

--- a/tools/other/gallery-dl.yaml
+++ b/tools/other/gallery-dl.yaml
@@ -1,0 +1,27 @@
+name: gallery-dl
+description: Command-line program to download image galleries and collections from many image hosting sites. gallery-dl pulls albums, artist pages, and boards with metadata so you can build visual datasets without a browser.
+tagline: CLI downloader for image galleries and collections
+
+github_url: https://github.com/mikf/gallery-dl
+website_url: https://github.com/mikf/gallery-dl
+docs_url: https://github.com/mikf/gallery-dl#readme
+
+install_command: pip install gallery-dl
+
+category: Other
+tags: [images, downloader, cli, python, datasets, media]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Collecting public image galleries for datasets or archival means clicking
+  through site-specific players and rate limits. gallery-dl downloads albums
+  and collections from many hosts with metadata and filename templates so you
+  get files, not browser tabs.
+
+use_cases:
+  - Download public image albums into a local vision dataset
+  - Archive artist or board collections with metadata JSON
+  - Pull tagged galleries for classification or captioning pipelines
+  - Resume interrupted gallery downloads with site-specific extractors

--- a/tools/other/streamlink.yaml
+++ b/tools/other/streamlink.yaml
@@ -1,0 +1,26 @@
+name: streamlink
+description: CLI utility that pipes live video streams from many services into a local player. streamlink extracts stream URLs from sites like Twitch and YouTube so you can watch or record without a browser plugin.
+tagline: Pipe live video streams from the web into a local player
+
+github_url: https://github.com/streamlink/streamlink
+website_url: https://streamlink.github.io
+docs_url: https://streamlink.github.io
+
+install_command: pip install streamlink
+
+category: Other
+tags: [streaming, video, cli, python, livestream, media]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+problem_solved: |
+  Live streams sit behind player pages that are hard to automate. streamlink
+  extracts the stream and pipes it to VLC or ffmpeg so you can watch, record,
+  or sample livestreams for datasets without a browser plugin.
+
+use_cases:
+  - Pipe a Twitch or YouTube livestream into VLC from the terminal
+  - Record public livestreams with ffmpeg for later transcription
+  - Sample live video for computer vision or event-detection pipelines
+  - Watch streams on headless machines without a browser player


### PR DESCRIPTION
## Catalog additions

Adds 5 tools to the Agentic AI For Good catalog:

| Tool | Category | Stars | Why |
|---|---|---|---|
| superfile | Dev Tools | 23k | Modern Go TUI file manager |
| gallery-dl | Other | 19k | CLI image gallery downloader |
| streamlink | Other | 12k | Pipe live streams into a local player |
| MozJPEG | Dev Tools | 5.7k | Mozilla JPEG encoder for smaller files |
| joshuto | Dev Tools | 3.7k | Ranger-like Rust TUI file manager |

All files passed local `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Joshuto and Superfile terminal file managers.
  * Added catalog entries for MozJPEG image optimization, gallery-dl media downloading, and Streamlink livestream access.
  * Included installation instructions, project links, licensing, categories, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->