### PR TITLE
Add erdtree, jpegoptim to catalog

### DIFF
--- a/tools/dev-tools/erdtree.yaml
+++ b/tools/dev-tools/erdtree.yaml
@@ -1,0 +1,27 @@
+name: erdtree
+description: Modern, cross-platform, multi-threaded filesystem and disk-usage utility. erdtree draws a file tree that respects .gitignore and hidden-file rules so you can see what actually consumes space in a project.
+tagline: Gitignore-aware disk usage tree for the terminal
+
+github_url: https://github.com/solidiquis/erdtree
+website_url: https://github.com/solidiquis/erdtree
+docs_url: https://github.com/solidiquis/erdtree
+
+install_command: brew install erdtree
+
+category: Dev Tools
+tags: [cli, rust, disk-usage, filesystem, gitignore, terminal]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  du and tree dump every node including gitignored caches and node_modules,
+  which hides the files you actually care about. erdtree is a multi-threaded
+  disk-usage tree that respects .gitignore so you can find real bloat in
+  repos and datasets.
+
+use_cases:
+  - Find which directories consume disk on a GPU training box
+  - Visualize a project tree while ignoring gitignored caches
+  - Compare dataset folder sizes before copying to object storage
+  - Audit node_modules and checkpoint dirs that are eating disk

--- a/tools/dev-tools/jpegoptim.yaml
+++ b/tools/dev-tools/jpegoptim.yaml
@@ -1,0 +1,26 @@
+name: jpegoptim
+description: Utility to losslessly optimize and compress JPEG files. jpegoptim strips metadata, optimizes Huffman tables, and can apply a quality limit so photo pipelines ship smaller JPEGs without a full re-encode stack.
+tagline: Lossless JPEG optimizer for the command line
+
+github_url: https://github.com/tjko/jpegoptim
+website_url: https://github.com/tjko/jpegoptim
+docs_url: https://github.com/tjko/jpegoptim
+
+install_command: brew install jpegoptim
+
+category: Dev Tools
+tags: [jpeg, image, optimization, cli, compression, assets]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Camera and export JPEGs carry extra metadata and unoptimized Huffman tables.
+  jpegoptim strips that overhead and optionally caps quality so web and dataset
+  pipelines get smaller files without standing up a full encoder like MozJPEG.
+
+use_cases:
+  - Losslessly shrink JPEG assets before deploying a site
+  - Strip EXIF from dataset photos while keeping pixel data
+  - Batch-optimize product images in a CI image pipeline
+  - Cap JPEG quality for thumbnail generation from the CLI


### PR DESCRIPTION
## Catalog additions

Adds 2 remainder tools to the Agentic AI For Good catalog:

| Tool | Category | Stars | Why |
|---|---|---|---|
| erdtree | Dev Tools | 2.6k | Gitignore-aware disk usage tree |
| jpegoptim | Dev Tools | 1.8k | Lossless JPEG optimizer |

All files passed local `scripts/validate-tool.ts`.
