### PR TITLE
Add Ghidra, radare2, binwalk, hexyl, presenterm to catalog

### DIFF
--- a/tools/dev-tools/binwalk.yaml
+++ b/tools/dev-tools/binwalk.yaml
@@ -1,0 +1,26 @@
+name: binwalk
+description: Firmware analysis tool that scans binary images for embedded files, filesystems, and executable code. binwalk extracts compressed archives and known signatures so you can unpack device images without guessing offsets.
+tagline: Firmware analysis and binary extraction tool
+
+github_url: https://github.com/ReFirmLabs/binwalk
+website_url: https://github.com/ReFirmLabs/binwalk
+docs_url: https://github.com/ReFirmLabs/binwalk
+
+install_command: brew install binwalk
+
+category: Dev Tools
+tags: [firmware, binaries, extraction, reverse-engineering, cli, security]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Device images hide filesystems and models inside opaque blobs. binwalk
+  scans for signatures and extracts embedded files so you can recover
+  kernels, weights, and configs from firmware without manual carving.
+
+use_cases:
+  - Extract filesystems from an IoT firmware image
+  - Find embedded models or configs inside a vendor binary
+  - Carve compressed archives out of a disk or flash dump
+  - Inventory executable code in a firmware blob before flashing

--- a/tools/dev-tools/ghidra.yaml
+++ b/tools/dev-tools/ghidra.yaml
@@ -1,0 +1,27 @@
+name: Ghidra
+description: NSA software reverse engineering framework with a disassembler, decompiler, and graph views. Ghidra lets you inspect binaries, recover types, and script analysis in Java or Python when you need to understand compiled code.
+tagline: Open-source software reverse engineering framework
+
+github_url: https://github.com/NationalSecurityAgency/ghidra
+website_url: https://ghidra-sre.org
+docs_url: https://ghidra-sre.org
+
+install_command: brew install ghidra
+
+category: Dev Tools
+tags: [reverse-engineering, disassembler, decompiler, java, security, binaries]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Understanding compiled binaries without source means expensive commercial
+  tools or ad-hoc objdump. Ghidra is a full SRE suite with decompilation,
+  graphs, and scripting so you can inspect models, native kernels, and
+  shipped binaries on your own machine.
+
+use_cases:
+  - Decompile a native inference library to see how it loads weights
+  - Inspect a third-party binary plugin before running it on a GPU box
+  - Recover data structures from firmware that ships with an edge device
+  - Script batch analysis of binaries in Java or Python

--- a/tools/dev-tools/hexyl.yaml
+++ b/tools/dev-tools/hexyl.yaml
@@ -1,0 +1,26 @@
+name: hexyl
+description: Command-line hex viewer with colored output and ASCII alongside the bytes. hexyl makes binary dumps readable in the terminal so you can inspect file headers, embeddings on disk, and mystery blobs without a GUI hex editor.
+tagline: Colored command-line hex viewer
+
+github_url: https://github.com/sharkdp/hexyl
+website_url: https://github.com/sharkdp/hexyl
+docs_url: https://github.com/sharkdp/hexyl
+
+install_command: brew install hexyl
+
+category: Dev Tools
+tags: [cli, hex, binary, rust, terminal, developer-tools]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  xxd and od print dense hex that is hard to scan. hexyl colorizes bytes by
+  type and shows ASCII so you can read magic numbers, headers, and binary
+  checkpoints from a terminal session.
+
+use_cases:
+  - Inspect file magic and headers before writing a parser
+  - Peek at a binary checkpoint or protobuf dump over SSH
+  - Compare raw bytes of two exported model files
+  - Teach binary formats with a readable hex dump

--- a/tools/dev-tools/presenterm.yaml
+++ b/tools/dev-tools/presenterm.yaml
@@ -1,0 +1,26 @@
+name: presenterm
+description: Markdown terminal slideshow tool. presenterm renders slides from Markdown in the terminal with code highlighting, images, and speaker notes so you can give talks over SSH without a GUI deck.
+tagline: Markdown slideshows in the terminal
+
+github_url: https://github.com/mfontanini/presenterm
+website_url: https://mfontanini.github.io/presenterm
+docs_url: https://mfontanini.github.io/presenterm
+
+install_command: brew install presenterm
+
+category: Dev Tools
+tags: [cli, markdown, presentations, terminal, rust, talks]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+problem_solved: |
+  Slide decks usually need a GUI and a heavy format. presenterm turns
+  Markdown into a terminal slideshow with highlighting and notes so you can
+  present from a laptop or remote session without PowerPoint.
+
+use_cases:
+  - Give a technical talk from Markdown files in the terminal
+  - Demo code snippets with syntax highlighting over SSH
+  - Keep speaker notes next to slides without a second window
+  - Version-control talk decks as plain Markdown in git

--- a/tools/dev-tools/radare2.yaml
+++ b/tools/dev-tools/radare2.yaml
@@ -1,0 +1,26 @@
+name: radare2
+description: UNIX-like reverse engineering framework and command-line toolset. radare2 disassembles, debugs, and patches binaries from a scriptable CLI so you can inspect native code without a heavyweight GUI.
+tagline: UNIX-like reverse engineering framework for the CLI
+
+github_url: https://github.com/radareorg/radare2
+website_url: https://www.radare.org
+docs_url: https://book.rada.re
+
+install_command: brew install radare2
+
+category: Dev Tools
+tags: [reverse-engineering, cli, disassembler, debugger, binaries, security]
+pricing: free
+is_open_source: true
+license: LGPL-3.0
+
+problem_solved: |
+  GUI reverse-engineering tools are heavy on remote boxes. radare2 is a
+  scriptable UNIX-style toolkit for disassembly, debugging, and patching so
+  you can inspect native libraries and model runtimes from SSH.
+
+use_cases:
+  - Disassemble a native extension that wraps a CUDA kernel
+  - Debug a crashing CLI tool without attaching a GUI debugger
+  - Patch a binary flag or string in a shipped utility
+  - Script binary analysis as part of a CI security check


### PR DESCRIPTION
## Catalog additions

Adds 5 tools to the Agentic AI For Good catalog:

| Tool | Category | Stars | Why |
|---|---|---|---|
| Ghidra | Dev Tools | 74k | NSA reverse engineering framework |
| radare2 | Dev Tools | 25k | UNIX-like RE toolkit |
| binwalk | Dev Tools | 14k | Firmware analysis and extraction |
| hexyl | Dev Tools | 10k | Colored CLI hex viewer |
| presenterm | Dev Tools | 8.8k | Markdown slideshows in the terminal |

All files passed local `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Binwalk, Ghidra, Hexyl, Presenterm, and Radare2.
  * Each entry includes descriptions, installation instructions, project links, categories, tags, licensing, pricing, and practical use cases.
  * Expanded the developer tools catalog with firmware analysis, reverse engineering, binary inspection, terminal presentations, and security analysis tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->