### PR TITLE
Add zstd, brotli, Capstone, Rizin, YARA to catalog

### DIFF
--- a/tools/dev-tools/brotli.yaml
+++ b/tools/dev-tools/brotli.yaml
@@ -1,0 +1,27 @@
+name: brotli
+description: Google's Brotli compression format and CLI, used across HTTP and static assets. brotli often beats gzip on web bundles, JSON, and documentation so model UIs, API responses, and static sites ship fewer bytes without a new file format.
+tagline: Google compression format for web and API payloads
+
+github_url: https://github.com/google/brotli
+website_url: https://github.com/google/brotli
+docs_url: https://github.com/google/brotli
+
+install_command: brew install brotli
+
+category: Dev Tools
+tags: [compression, http, cli, web, google, assets]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Serving model playgrounds, OpenAPI docs, and JS bundles with gzip still
+  wastes bandwidth on text-heavy payloads. Brotli is the compression browsers
+  already understand, so you cut transfer size for APIs and static sites
+  without changing clients.
+
+use_cases:
+  - Precompress static docs and playground assets for a model API
+  - Shrink JSON inference responses on a public HTTP endpoint
+  - Replace gzip in a CDN pipeline for text-heavy ML demos
+  - Compress OpenAPI specs and HTML reports before shipping them

--- a/tools/dev-tools/capstone.yaml
+++ b/tools/dev-tools/capstone.yaml
@@ -1,0 +1,27 @@
+name: Capstone
+description: Multi-architecture disassembly framework with bindings for Python, C, and more. Capstone turns machine code into assembly for ARM, x86, RISC-V, and other ISAs so you can inspect kernels, CUDA binaries, and native extensions without a full reverse-engineering GUI.
+tagline: Multi-architecture disassembly framework
+
+github_url: https://github.com/capstone-engine/capstone
+website_url: https://www.capstone-engine.org
+docs_url: https://www.capstone-engine.org/documentation.html
+
+install_command: pip install capstone
+
+category: Dev Tools
+tags: [disassembly, reverse-engineering, python, arm, x86, binaries, security]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Inspecting compiled kernels, native ops, and shipped binaries usually means
+  a heavy GUI or architecture-specific tools. Capstone is a library you embed
+  in scripts to disassemble many ISAs, so analysis pipelines can read machine
+  code the same way they parse source.
+
+use_cases:
+  - Disassemble a native PyTorch/CUDA extension when a crash dump has no symbols
+  - Script ARM and x86 analysis of an on-device inference binary
+  - Build a lightweight binary linter that flags unexpected instruction sequences
+  - Teach or document ISA output from a compiler without opening Ghidra

--- a/tools/dev-tools/rizin.yaml
+++ b/tools/dev-tools/rizin.yaml
@@ -1,0 +1,27 @@
+name: Rizin
+description: UNIX-like reverse engineering framework and CLI forked from radare2. Rizin disassembles, debugs, and patches binaries from the terminal with a stable API, so you can script analysis of native ML runtimes, firmware, and shipped libraries without a GUI.
+tagline: UNIX-like reverse engineering framework and CLI
+
+github_url: https://github.com/rizinorg/rizin
+website_url: https://www.rizin.re
+docs_url: https://book.rizin.re
+
+install_command: brew install rizin
+
+category: Dev Tools
+tags: [reverse-engineering, disassembler, cli, security, binaries, debugging]
+pricing: free
+is_open_source: true
+license: LGPL-3.0
+
+problem_solved: |
+  GUI reverse-engineering suites are slow to script and heavy on remote
+  boxes. Rizin is a CLI-first framework with a cleaner API than radare2, so
+  you can disassemble, debug, and patch native inference binaries in
+  terminals and CI.
+
+use_cases:
+  - Inspect a native tokenizer or runtime binary on a GPU box over SSH
+  - Script opcode searches across firmware that ships with an edge model
+  - Patch a packed library enough to load it under a debugger
+  - Diff two builds of a native extension after a mysterious perf regression

--- a/tools/dev-tools/yara.yaml
+++ b/tools/dev-tools/yara.yaml
@@ -1,0 +1,27 @@
+name: YARA
+description: Pattern-matching tool for identifying malware, packed binaries, and known file families. YARA rules combine strings and byte patterns so security and ML ops teams can scan model artifacts, uploaded datasets, and CI binaries for threats before they reach training or serving hosts.
+tagline: Pattern matching swiss knife for binaries and malware
+
+github_url: https://github.com/VirusTotal/yara
+website_url: https://virustotal.github.io/yara/
+docs_url: https://yara.readthedocs.io
+
+install_command: brew install yara
+
+category: Dev Tools
+tags: [security, malware, pattern-matching, binaries, scanning, yara]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Model zoos, dataset drops, and CI artifacts can hide malware or packed
+  droppers that antivirus misses. YARA lets you write readable rules for
+  strings and byte patterns and scan files in bulk before they land on
+  training or inference machines.
+
+use_cases:
+  - Scan uploaded checkpoints and Python wheels in a model registry
+  - Flag packed or obfuscated binaries in a dataset ingest pipeline
+  - Share detection rules for a known malicious notebook or wheel
+  - Gate CI so unexpected packers never reach a GPU node

--- a/tools/dev-tools/zstd.yaml
+++ b/tools/dev-tools/zstd.yaml
@@ -1,0 +1,27 @@
+name: zstd
+description: Meta's Zstandard compression algorithm and CLI. zstd shrinks training datasets, model checkpoints, and logs with gzip-beating ratios at much higher speed, and streams so pipelines can compress and decompress on the fly.
+tagline: Fast real-time compression for datasets and checkpoints
+
+github_url: https://github.com/facebook/zstd
+website_url: https://facebook.github.io/zstd/
+docs_url: https://facebook.github.io/zstd/zstd_manual.html
+
+install_command: brew install zstd
+
+category: Dev Tools
+tags: [compression, cli, datasets, checkpoints, c, performance]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  gzip is too slow for multi-gigabyte checkpoints and dataset shards, while
+  uncompressed artifacts waste disk and network. zstd compresses and
+  decompresses in real time so training jobs, artifact stores, and log
+  pipelines move less data without waiting on CPU.
+
+use_cases:
+  - Compress model checkpoints before uploading them to object storage
+  - Shard and compress training datasets for faster cluster copies
+  - Stream-decompress logs in an ML debugging pipeline
+  - Replace gzip in CI artifact archives to cut build-cache size


### PR DESCRIPTION
## Summary
Add five catalog entries used in ML artifact pipelines and native binary analysis:

- **zstd** — Meta Zstandard compression CLI for datasets, checkpoints, and logs
- **brotli** — Google Brotli compression for HTTP and static assets
- **Capstone** — multi-architecture disassembly library (pip)
- **Rizin** — UNIX-like reverse engineering CLI (radare2 fork)
- **YARA** — pattern matching for malware and packed binaries

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Brotli and Zstandard compression tools, including installation details, licensing, links, and practical use cases.
  - Added Capstone and Rizin entries for multi-architecture disassembly and reverse-engineering workflows.
  - Added a YARA entry for pattern matching and security scanning of files, artifacts, and datasets.
  - Included problem statements and use cases to help users evaluate each tool for compression, analysis, and security tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->