### PR TITLE
Add Daft, libvips, Drizzle, ffuf to catalog

### DIFF
--- a/tools/data/daft.yaml
+++ b/tools/data/daft.yaml
@@ -1,0 +1,27 @@
+name: Daft
+description: High-performance dataframe engine for AI and multimodal workloads. Daft queries images, audio, video, and tabular data at scale with a Python API, so you can filter, embed, and transform mixed datasets without bolting a separate image pipeline onto Spark or pandas.
+tagline: Multimodal dataframe engine for AI workloads
+
+github_url: https://github.com/Eventual-Inc/Daft
+website_url: https://www.daft.ai
+docs_url: https://docs.daft.ai
+
+install_command: pip install daft
+
+category: Data
+tags: [dataframe, python, multimodal, spark, etl, images, rust]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  pandas and Spark struggle when rows are images, video, or nested tensors
+  instead of scalars. Daft is a dataframe engine built for multimodal AI
+  data, so you can filter, embed, and write those datasets with one API
+  instead of a custom sidecar pipeline.
+
+use_cases:
+  - Filter a billion-row image dataset before running an embedding job
+  - Join video metadata with frame tensors for a training export
+  - Run Python UDFs over object-store files without pulling them all locally
+  - Replace an ad-hoc Spark plus PIL pipeline with one multimodal dataframe

--- a/tools/data/libvips.yaml
+++ b/tools/data/libvips.yaml
@@ -1,0 +1,27 @@
+name: libvips
+description: Fast image processing library with a low memory footprint. libvips streams pixels instead of loading whole images, so dataset pipelines can resize, crop, and convert huge TIFFs and scientific images without blowing RAM the way ImageMagick or PIL often do.
+tagline: Fast, low-memory image processing library
+
+github_url: https://github.com/libvips/libvips
+website_url: https://www.libvips.org
+docs_url: https://www.libvips.org/API/current/
+
+install_command: brew install vips
+
+category: Data
+tags: [images, processing, c, python, datasets, computer-vision, performance]
+pricing: free
+is_open_source: true
+license: LGPL-2.1
+
+problem_solved: |
+  Resizing and converting large training images with PIL or ImageMagick
+  loads entire files into RAM and stalls dataset jobs. libvips streams
+  pixels through a demand-driven pipeline so you can thumbnail, crop, and
+  convert huge images with a fraction of the memory.
+
+use_cases:
+  - Thumbnail a folder of multi-gigabyte TIFFs for a vision dataset
+  - Convert scientific images to JPEG or PNG before labeling
+  - Build a Python ingest step with pyvips that will not OOM on 100MP photos
+  - Preprocess satellite or medical images in a streaming data loader

--- a/tools/dev-tools/drizzle.yaml
+++ b/tools/dev-tools/drizzle.yaml
@@ -1,0 +1,27 @@
+name: Drizzle
+description: TypeScript ORM with SQL-first schema and migrations. Drizzle maps Postgres, MySQL, SQLite, and more without a heavy runtime, so AI apps can store traces, users, and job state in typed queries instead of a bloated object mapper.
+tagline: SQL-first TypeScript ORM
+
+github_url: https://github.com/drizzle-team/drizzle-orm
+website_url: https://orm.drizzle.team
+docs_url: https://orm.drizzle.team/docs/overview
+
+install_command: npm install drizzle-orm
+
+category: Dev Tools
+tags: [typescript, orm, sql, postgres, sqlite, node, database]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Node AI apps still need a database for users, traces, and job queues, but
+  heavy ORMs hide SQL and slow cold starts. Drizzle keeps schema in
+  TypeScript and queries close to SQL, so you get type safety without a
+  large runtime.
+
+use_cases:
+  - Store agent traces and user sessions in Postgres from a TypeScript API
+  - Generate migrations for an SQLite cache beside a local LLM app
+  - Query job state for a fine-tuning queue with typed SQL
+  - Replace Prisma in a Next.js AI dashboard when you want thinner SQL

--- a/tools/dev-tools/ffuf.yaml
+++ b/tools/dev-tools/ffuf.yaml
@@ -1,0 +1,26 @@
+name: ffuf
+description: Fast web fuzzer written in Go. ffuf brute-forces URLs, headers, and forms so you can map API surfaces, find hidden model endpoints, and smoke-test auth on inference servers without a slow GUI scanner.
+tagline: Fast web fuzzer written in Go
+
+github_url: https://github.com/ffuf/ffuf
+website_url: https://github.com/ffuf/ffuf
+docs_url: https://github.com/ffuf/ffuf/blob/master/README.md
+
+install_command: brew install ffuf
+
+category: Dev Tools
+tags: [security, fuzzer, http, golang, pentest, cli, apis]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Model APIs and admin UIs often ship hidden paths and weak auth that a
+  browser never hits. ffuf fuzzes URLs and parameters quickly from the CLI
+  so you can find those endpoints before attackers do.
+
+use_cases:
+  - Discover hidden inference or admin routes on a model HTTP server
+  - Fuzz API parameters on a RAG gateway during a security review
+  - Wordlist-scan a staging playground before exposing it publicly
+  - Check that auth actually rejects unguessable paths on an LLM proxy


### PR DESCRIPTION
## Summary
Add four catalog entries for multimodal data, image processing, TypeScript persistence, and HTTP fuzzing:

- **Daft** — multimodal dataframe engine for AI workloads (`pip install daft`)
- **libvips** — fast low-memory image processing library
- **Drizzle** — SQL-first TypeScript ORM
- **ffuf** — fast web fuzzer written in Go

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all four files.
