### PR TITLE
Add Unicorn Engine, WeasyPrint, oha, sd to catalog

### DIFF
--- a/tools/dev-tools/oha.yaml
+++ b/tools/dev-tools/oha.yaml
@@ -1,0 +1,26 @@
+name: oha
+description: HTTP load generator inspired by hey, with a TUI. oha slams endpoints so you can see latency and error rates on inference APIs and RAG gateways before you call the run a load test.
+tagline: HTTP load generator with a TUI
+
+github_url: https://github.com/hatoo/oha
+website_url: https://github.com/hatoo/oha
+docs_url: https://github.com/hatoo/oha
+
+install_command: brew install oha
+
+category: Dev Tools
+tags: [http, load-testing, rust, cli, performance, apis]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Checking whether an inference URL holds up still means wrk scripts or a
+  SaaS load tester. oha is a single binary that hammers HTTP and shows a
+  live TUI, so you can smoke-test QPS on a model API from your laptop.
+
+use_cases:
+  - Load-test a local vLLM or TGI endpoint before a demo
+  - Compare latency of two RAG gateway URLs with the same payload
+  - Find the QPS cliff on a new embedding HTTP service
+  - Smoke-test auth and timeouts on a public model playground

--- a/tools/dev-tools/sd.yaml
+++ b/tools/dev-tools/sd.yaml
@@ -1,0 +1,26 @@
+name: sd
+description: Intuitive find-and-replace CLI that works like a friendlier sed. sd uses string or regex replacements without the escaping maze, so you can rewrite configs, prompts, and generated code in scripts without reaching for Perl.
+tagline: Intuitive find and replace CLI
+
+github_url: https://github.com/chmln/sd
+website_url: https://github.com/chmln/sd
+docs_url: https://github.com/chmln/sd
+
+install_command: brew install sd
+
+category: Dev Tools
+tags: [cli, rust, sed, refactor, text, scripting]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Bulk text edits in repos and prompt files still trip over sed escaping.
+  sd does find-and-replace with a simpler syntax, so one-liners and CI
+  rewrite steps stay readable.
+
+use_cases:
+  - Rename a model id across YAML configs without sed escaping
+  - Rewrite placeholder API keys in example prompts before a demo
+  - Bulk-fix generated code comments in a post-processing script
+  - Replace deprecated import paths in a large Python tree

--- a/tools/dev-tools/unicorn-engine.yaml
+++ b/tools/dev-tools/unicorn-engine.yaml
@@ -1,0 +1,26 @@
+name: Unicorn Engine
+description: CPU emulator framework for ARM, AArch64, x86, RISC-V, and more. Unicorn lets you run fragments of native code in userspace so you can test shellcode, unpackers, and architecture-specific kernels without a full VM.
+tagline: Multi-architecture CPU emulator framework
+
+github_url: https://github.com/unicorn-engine/unicorn
+website_url: https://www.unicorn-engine.org
+docs_url: https://www.unicorn-engine.org/docs/
+
+install_command: pip install unicorn
+
+category: Dev Tools
+tags: [emulator, reverse-engineering, arm, x86, security, python, binaries]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Testing native snippets, packers, and ISA-specific kernels usually needs a
+  VM or hardware. Unicorn emulates those CPUs in a library you call from
+  Python or C, so analysis tools can run the bytes without booting a guest.
+
+use_cases:
+  - Emulate an ARM stub from an on-device inference binary
+  - Fuzz a native tokenizer in a sandbox without a full QEMU VM
+  - Teach CPU semantics for a compiler backend using short snippets
+  - Unpack a payload enough to dump model weights from a packed loader

--- a/tools/dev-tools/weasyprint.yaml
+++ b/tools/dev-tools/weasyprint.yaml
@@ -1,0 +1,26 @@
+name: WeasyPrint
+description: Python library that turns HTML and CSS into PDF. WeasyPrint is useful for model cards, eval reports, and invoice-style documents when you already have HTML and do not want a headless browser.
+tagline: HTML and CSS to PDF in Python
+
+github_url: https://github.com/Kozea/WeasyPrint
+website_url: https://weasyprint.org
+docs_url: https://doc.courtbouillon.org/weasyprint/
+
+install_command: pip install weasyprint
+
+category: Dev Tools
+tags: [pdf, html, css, python, documents, reports]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Generating PDFs from eval dashboards and model cards often means wkhtmltopdf
+  or a headless Chrome. WeasyPrint renders HTML and CSS in Python, so report
+  jobs stay in the same runtime as the rest of the pipeline.
+
+use_cases:
+  - Render a model card HTML template to a shareable PDF
+  - Export weekly eval reports from a Django or Flask app
+  - Produce invoices or certificates from HTML without a browser farm
+  - Snapshot a documentation page as PDF in CI


### PR DESCRIPTION
## Summary
Add four catalog entries for emulation, PDF generation, HTTP load testing, and text rewrite:

- **Unicorn Engine** — multi-architecture CPU emulator (`pip install unicorn`)
- **WeasyPrint** — HTML/CSS to PDF in Python
- **oha** — HTTP load generator with a TUI
- **sd** — intuitive find-and-replace CLI (sed alternative)

## Validation
Local `npx tsx scripts/validate-tool.ts` passed for all four files.
