### PR TITLE
Add gobuster, RustScan, jless, IINA, VLC to catalog

### DIFF
--- a/tools/dev-tools/gobuster.yaml
+++ b/tools/dev-tools/gobuster.yaml
@@ -1,0 +1,25 @@
+name: gobuster
+description: Directory, DNS, and virtual-host enumeration tool written in Go. Gobuster brute-forces hidden paths, subdomains, and vhosts against HTTP, DNS, and S3-style endpoints so teams can inventory undocumented APIs and service surfaces before they ship.
+tagline: Fast Go-based directory, DNS, and vhost enumeration
+
+github_url: https://github.com/OJ/gobuster
+website_url: https://github.com/OJ/gobuster
+docs_url: https://github.com/OJ/gobuster/blob/master/README.md
+install_command: go install github.com/OJ/gobuster/v3@latest
+
+category: Dev Tools
+tags: [go, cli, recon, enumeration, security, dns, http]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Web and ML services often expose undocumented paths, forgotten admin routes, and stale
+  subdomains that never show up in OpenAPI specs. Gobuster enumerates directories, DNS names,
+  and virtual hosts at high speed so teams can map the real surface of an API or inference
+  stack instead of trusting incomplete docs.
+
+use_cases:
+  - Inventory hidden HTTP paths on an inference API that are missing from OpenAPI docs
+  - Enumerate subdomains for a model-serving cluster before a security review
+  - Discover leftover S3-style buckets and vhosts that leak dataset or checkpoint files

--- a/tools/dev-tools/jless.yaml
+++ b/tools/dev-tools/jless.yaml
@@ -1,0 +1,25 @@
+name: jless
+description: Command-line JSON viewer for reading, exploring, and searching large JSON documents in a terminal. jless offers less-like navigation, pretty-printed trees, and fast search so API payloads and model traces stay readable without dumping them into an editor.
+tagline: less-like pager for JSON in the terminal
+
+github_url: https://github.com/PaulJuliusMartinez/jless
+website_url: https://jless.io
+docs_url: https://jless.io
+install_command: brew install jless
+
+category: Dev Tools
+tags: [json, cli, pager, rust, developer-tools, terminal]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  LLM traces, tool-call logs, and API responses arrive as huge JSON blobs that cat, less, and
+  jq struggle to browse interactively. jless paginates nested objects as a navigable tree with
+  search, so you can walk a 10 MB evaluation dump or webhook payload without pretty-printing
+  it into a file first.
+
+use_cases:
+  - Page through LLM trace JSON and tool-call payloads without opening an editor
+  - Search nested keys in evaluation dumps, dataset manifests, and webhook bodies
+  - Inspect pretty-printed API responses from model-serving endpoints in the terminal

--- a/tools/dev-tools/rustscan.yaml
+++ b/tools/dev-tools/rustscan.yaml
@@ -1,0 +1,25 @@
+name: RustScan
+description: Modern port scanner written in Rust that finds open ports in seconds, then hands them to nmap for deeper probing. RustScan uses asynchronous scanning so large host ranges finish quickly without drowning the network.
+tagline: Asynchronous port scanner that feeds nmap
+
+github_url: https://github.com/bee-san/RustScan
+website_url: https://github.com/bee-san/RustScan
+docs_url: https://github.com/bee-san/RustScan/wiki
+install_command: brew install rustscan
+
+category: Dev Tools
+tags: [rust, cli, port-scanner, networking, security, nmap]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Classic port scans against GPU clusters, inference hosts, and staging VPCs take minutes
+  and still miss the services that actually matter. RustScan finds open ports asynchronously
+  in seconds, then pipes them to nmap for version and script scans so you get a full picture
+  of what is listening without waiting on a slow sequential sweep.
+
+use_cases:
+  - Scan a Kubernetes node pool for unexpected listeners before exposing an inference API
+  - Inventory open ports on GPU workstations and training boxes during a security review
+  - Feed discovered ports into nmap for service fingerprinting of model-serving stacks

--- a/tools/other/iina.yaml
+++ b/tools/other/iina.yaml
@@ -1,0 +1,25 @@
+name: IINA
+description: Modern open-source media player for macOS built on mpv. IINA plays local and streaming video with a native Cocoa UI, hardware acceleration, picture-in-picture, and plugin support, making it a solid viewer for generated video, dataset clips, and training footage on Mac.
+tagline: Modern mpv-based media player for macOS
+
+github_url: https://github.com/iina/iina
+website_url: https://iina.io
+docs_url: https://docs.iina.io
+install_command: brew install --cask iina
+
+category: Other
+tags: [macos, video, media-player, mpv, open-source]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Reviewing generated video, dataset samples, and training clips on macOS often means fighting
+  QuickTime format limits or installing a pile of codecs. IINA wraps mpv in a native Mac UI with
+  hardware decode, subtitle support, and picture-in-picture so media from generative pipelines
+  just plays, locally, without a cloud player.
+
+use_cases:
+  - Preview locally generated video and animation clips from diffusion or video models
+  - Review dataset samples and training footage with frame-accurate seeking on macOS
+  - Play streamed demos and screen recordings of agent runs without extra codec packs

--- a/tools/other/vlc.yaml
+++ b/tools/other/vlc.yaml
@@ -1,0 +1,25 @@
+name: VLC
+description: Cross-platform open-source media player that plays nearly every audio and video format without extra codecs. VLC handles local files, discs, streams, and network sources, making it a reliable viewer for generated media, dataset samples, and model demo videos on any OS.
+tagline: Plays almost every media format on every platform
+
+github_url: https://github.com/videolan/vlc
+website_url: https://www.videolan.org/vlc/
+docs_url: https://www.videolan.org/vlc/documentation.html
+install_command: brew install --cask vlc
+
+category: Other
+tags: [video, audio, media-player, cross-platform, open-source]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Training datasets, generated clips, and model demos arrive in odd containers and codecs that
+  stock players refuse. VLC decodes almost every format on Windows, macOS, Linux, and mobile,
+  so researchers can inspect samples and review outputs without hunting for a codec pack or
+  converting files first.
+
+use_cases:
+  - Play unusual dataset video and audio formats without converting them first
+  - Review generated media from video and speech models across Windows, macOS, and Linux
+  - Stream or cast demo videos of agent and model outputs during reviews and talks


### PR DESCRIPTION
## Add 5 tools to the catalog

- **gobuster** (Dev Tools) — Directory/DNS/vhost enumeration in Go (OJ/gobuster, Apache-2.0, ~14k stars)
- **RustScan** (Dev Tools) — Asynchronous port scanner that feeds nmap (bee-san/RustScan, GPL-3.0, ~20k stars)
- **jless** (Dev Tools) — Command-line JSON viewer/pager (PaulJuliusMartinez/jless, MIT, ~5k stars)
- **IINA** (Other) — Modern mpv-based media player for macOS (iina/iina, GPL-3.0, ~46k stars)
- **VLC** (Other) — Cross-platform media player (videolan/vlc, GPL-2.0, ~20k stars)

All five YAML files passed local `validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for five developer and media tools: Gobuster, jless, RustScan, IINA, and VLC.
  * Added installation instructions, links, licensing, pricing, categories, tags, and practical use cases for each tool.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->