### PR TITLE
Add Knex, Sequelize, Ghostscript, scc to catalog

### DIFF
--- a/tools/dev-tools/ghostscript.yaml
+++ b/tools/dev-tools/ghostscript.yaml
@@ -1,0 +1,24 @@
+name: Ghostscript
+description: Interpreter for PostScript and PDF that renders, converts, and processes documents. Ghostscript rasterizes pages, converts formats, and drives print pipelines so teams can turn papers, reports, and scanned files into images or PDF without a proprietary RIP.
+tagline: PostScript and PDF interpreter for document pipelines
+
+github_url: https://github.com/ArtifexSoftware/ghostpdl
+website_url: https://www.ghostscript.com/
+docs_url: https://ghostscript.readthedocs.io/
+install_command: brew install ghostscript
+
+category: Dev Tools
+tags: [pdf, postscript, documents, conversion, cli, rasterization]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  RAG and document-AI pipelines need to rasterize PDFs, convert PostScript, and extract page
+  images before OCR or embedding. Ghostscript is the open-source RIP that turns those files into
+  PNG, JPEG, or cleaned PDF locally, so ingestion jobs do not depend on a paid document engine.
+
+use_cases:
+  - Rasterize PDF pages to PNG before OCR or vision-model embedding
+  - Convert PostScript and mixed print jobs into PDF for a document ingestion pipeline
+  - Downsample or repair PDFs so large paper corpora fit in a RAG preprocessing step

--- a/tools/dev-tools/knex.yaml
+++ b/tools/dev-tools/knex.yaml
@@ -1,0 +1,25 @@
+name: Knex
+description: SQL query builder for Node.js that works with PostgreSQL, MySQL, CockroachDB, SQL Server, SQLite, and Oracle. Knex gives a portable, composable API for queries, schema, and migrations without locking you into a full ORM.
+tagline: Flexible SQL query builder for Node.js
+
+github_url: https://github.com/knex/knex
+website_url: https://knexjs.org/
+docs_url: https://knexjs.org/guide/
+install_command: npm install knex
+
+category: Dev Tools
+tags: [javascript, typescript, sql, query-builder, nodejs, postgresql, mysql]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Node services that store embeddings, eval results, and experiment metadata often glue together
+  raw SQL strings or a heavy ORM they do not need. Knex builds parameterized queries and schema
+  migrations that run on Postgres, MySQL, SQLite, and more, so the same data layer works from
+  local notebooks to production without rewriting SQL per dialect.
+
+use_cases:
+  - Query Postgres feature stores and experiment tables from a Node evaluation service
+  - Write portable schema migrations for datasets, runs, and model-registry metadata
+  - Compose parameterized SQL for RAG document stores without embedding raw strings

--- a/tools/dev-tools/scc.yaml
+++ b/tools/dev-tools/scc.yaml
@@ -1,0 +1,25 @@
+name: scc
+description: Very fast code counter written in Go that reports SLOC, complexity, and COCOMO estimates. scc walks repositories in seconds so teams can size ML codebases, skip generated files, and compare language mix without waiting on slower cloc runs.
+tagline: Fast SLOC, complexity, and COCOMO code counter
+
+github_url: https://github.com/boyter/scc
+website_url: https://github.com/boyter/scc
+docs_url: https://github.com/boyter/scc/blob/master/README.md
+install_command: brew install scc
+
+category: Dev Tools
+tags: [go, cli, code-metrics, sloc, complexity, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Sizing an ML monorepo with cloc is slow, and generated protobufs, lockfiles, and notebooks
+  inflate the numbers. scc counts lines, complexity, and COCOMO cost in seconds, with accurate
+  language detection and ignore rules, so you can report real source size for training code and
+  agent services.
+
+use_cases:
+  - Measure SLOC and language mix across an ML monorepo before a planning review
+  - Estimate COCOMO cost for agent services while ignoring generated and vendor files
+  - Compare complexity of training code versus serving code in CI as a lightweight metric

--- a/tools/dev-tools/sequelize.yaml
+++ b/tools/dev-tools/sequelize.yaml
@@ -1,0 +1,25 @@
+name: Sequelize
+description: Feature-rich ORM for Node.js and TypeScript with support for PostgreSQL, MySQL, MariaDB, SQLite, SQL Server, Snowflake, Oracle, and DB2. Sequelize maps tables to models with associations, transactions, eager loading, and migrations.
+tagline: Promise-based ORM for Node.js and TypeScript
+
+github_url: https://github.com/sequelize/sequelize
+website_url: https://sequelize.org/
+docs_url: https://sequelize.org/docs/v6/
+install_command: npm install sequelize
+
+category: Dev Tools
+tags: [javascript, typescript, orm, sql, nodejs, postgresql, mysql]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI product backends need models for users, conversations, traces, and usage billing across
+  several SQL engines. Sequelize gives a typed model layer with associations, transactions, and
+  migrations so Node services can persist agent state and eval data without hand-rolling SQL for
+  every dialect.
+
+use_cases:
+  - Persist conversation history, traces, and usage records for an agent backend in Postgres
+  - Model associations between datasets, experiments, and model versions in TypeScript
+  - Run transactions around eval writes so partial results never leave the database half-applied


### PR DESCRIPTION
## Add 4 tools to the catalog

- **Knex** (Dev Tools) — SQL query builder for Node.js (knex/knex, MIT, ~20k stars)
- **Sequelize** (Dev Tools) — Node.js/TypeScript ORM (sequelize/sequelize, MIT, ~30k stars)
- **Ghostscript** (Dev Tools) — PostScript/PDF interpreter (ArtifexSoftware/ghostpdl, AGPL-3.0, brew formula)
- **scc** (Dev Tools) — Fast SLOC/complexity/COCOMO counter (boyter/scc, MIT, ~8.7k stars)

All four YAML files passed local `validate-tool.ts`.
