### PR TITLE
Add Koa, tRPC, date-fns, sharp, Cheerio to catalog

### DIFF
--- a/tools/dev-tools/cheerio.yaml
+++ b/tools/dev-tools/cheerio.yaml
@@ -1,0 +1,24 @@
+name: Cheerio
+description: Fast, flexible library for parsing and manipulating HTML and XML in Node.js with a jQuery-like API. Cheerio loads markup into a DOM you can query and edit without a browser, which is ideal for scraping docs, cleaning crawled pages, and extracting training text.
+tagline: jQuery-like HTML and XML parsing for Node.js
+
+github_url: https://github.com/cheeriojs/cheerio
+website_url: https://cheerio.js.org
+docs_url: https://cheerio.js.org/docs/intro
+install_command: npm install cheerio
+
+category: Dev Tools
+tags: [javascript, nodejs, html, xml, scraping, parsing, jquery]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Building RAG corpora and eval sets from HTML usually means regex or a full browser. Cheerio
+  parses markup server-side with CSS selectors so you can strip nav, pull article text, and
+  rewrite links without spinning up Chromium for every page.
+
+use_cases:
+  - Extract article text from crawled HTML before chunking it for a RAG index
+  - Strip scripts, nav, and ads from documentation sites used as LLM context
+  - Rewrite relative links in scraped pages so a knowledge base stores canonical URLs

--- a/tools/dev-tools/date-fns.yaml
+++ b/tools/dev-tools/date-fns.yaml
@@ -1,0 +1,25 @@
+name: date-fns
+description: Modern JavaScript date utility library with a functional, tree-shakeable API. date-fns provides immutable helpers for parsing, formatting, and comparing dates so time-based eval windows, schedules, and logs stay consistent across browsers and Node.
+tagline: Functional, tree-shakeable date helpers for JavaScript
+
+github_url: https://github.com/date-fns/date-fns
+website_url: https://date-fns.org
+docs_url: https://date-fns.org/docs/Getting-Started
+install_command: npm install date-fns
+
+category: Dev Tools
+tags: [javascript, typescript, dates, time, utilities, tree-shakeable]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Native Date objects are mutable, timezone-awkward, and easy to format wrong in logs and
+  dashboards. date-fns ships small, pure functions you can import one at a time, so experiment
+  timestamps, cron windows, and relative times in an AI product stay consistent without a
+  heavyweight date framework.
+
+use_cases:
+  - Format experiment and eval timestamps consistently in dashboards and logs
+  - Compute rolling windows for usage, cost, and latency reports without mutating Date objects
+  - Parse ISO timestamps from model traces and convert them for display in the UI

--- a/tools/dev-tools/koa.yaml
+++ b/tools/dev-tools/koa.yaml
@@ -1,0 +1,25 @@
+name: Koa
+description: Expressive Node.js web framework built on async middleware. Koa is a slimmer successor to Express that uses async functions for request handling, giving clean control flow for APIs that serve models, agents, and evaluation jobs.
+tagline: Async middleware framework for Node.js APIs
+
+github_url: https://github.com/koajs/koa
+website_url: https://koajs.com
+docs_url: https://koajs.com
+install_command: npm install koa
+
+category: Dev Tools
+tags: [javascript, nodejs, http, middleware, api, web-framework]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Express-style callbacks and monkey-patched request objects make it hard to compose auth,
+  tracing, and streaming around LLM endpoints. Koa uses a clean async middleware stack with
+  its own context object, so you can await model calls, set headers, and handle errors without
+  callback pyramids or surprising req/res mutation.
+
+use_cases:
+  - Serve a typed inference or agent API with async middleware for auth and tracing
+  - Stream token responses from an LLM endpoint without blocking the event loop
+  - Compose request logging and error handling around evaluation and webhook handlers

--- a/tools/dev-tools/sharp.yaml
+++ b/tools/dev-tools/sharp.yaml
@@ -1,0 +1,24 @@
+name: sharp
+description: High-performance Node.js image processing library built on libvips. sharp resizes, converts, and compresses JPEG, PNG, WebP, AVIF, and TIFF much faster than ImageMagick bindings, which makes it a default choice for dataset thumbnails and generated-image pipelines.
+tagline: Fast libvips-based image processing for Node.js
+
+github_url: https://github.com/lovell/sharp
+website_url: https://sharp.pixelplumbing.com
+docs_url: https://sharp.pixelplumbing.com/api-constructor
+install_command: npm install sharp
+
+category: Dev Tools
+tags: [javascript, nodejs, images, libvips, resize, webp, avif]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Generating, uploading, and serving AI images in Node often means shelling out to ImageMagick
+  or blocking on slow Canvas code. sharp streams decode, resize, and encode through libvips so
+  thumbnail, WebP, and AVIF jobs keep up with a generation queue without extra processes.
+
+use_cases:
+  - Resize and convert generated images to WebP or AVIF before storing them
+  - Build dataset thumbnails and preview strips in a Node ingestion worker
+  - Strip metadata and compress user uploads before they enter a vision-model pipeline

--- a/tools/dev-tools/trpc.yaml
+++ b/tools/dev-tools/trpc.yaml
@@ -1,0 +1,26 @@
+name: tRPC
+description: End-to-end typesafe API layer for TypeScript. tRPC shares procedure types between server and client so frontend apps call backend routers like local functions, catching contract breaks at compile time instead of in production.
+tagline: End-to-end typesafe APIs for TypeScript
+
+github_url: https://github.com/trpc/trpc
+website_url: https://trpc.io
+docs_url: https://trpc.io/docs
+install_command: |
+  npm install @trpc/server @trpc/client
+
+category: Dev Tools
+tags: [typescript, api, rpc, nodejs, typesafe, full-stack]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Hand-written REST contracts between a Next.js UI and an agent backend drift the moment a
+  procedure argument changes. tRPC infers client types from the server router, so adding a
+  field to a chat, tool-call, or eval endpoint updates callers at compile time with no codegen
+  step.
+
+use_cases:
+  - Expose typed procedures for chat, tool calls, and eval jobs from a TypeScript backend
+  - Share input and output types between a Next.js app and an agent API without OpenAPI codegen
+  - Catch breaking changes to model-serving routes at compile time instead of in production


### PR DESCRIPTION
## Add 5 tools to the catalog

- **Koa** (Dev Tools) — Async Node.js web framework (koajs/koa, MIT, ~36k stars)
- **tRPC** (Dev Tools) — End-to-end typesafe TypeScript APIs (trpc/trpc, MIT, ~41k stars)
- **date-fns** (Dev Tools) — Functional JavaScript date library (date-fns/date-fns, MIT, ~37k stars)
- **sharp** (Dev Tools) — High-performance Node.js image processing via libvips (lovell/sharp, Apache-2.0, ~33k stars)
- **Cheerio** (Dev Tools) — jQuery-like HTML/XML parser for Node.js (cheeriojs/cheerio, MIT, ~30k stars)

All five YAML files passed local `validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added five developer-tool catalog entries: Cheerio, date-fns, Koa, sharp, and tRPC.
  - Catalog entries include descriptions, documentation and repository links, installation commands, licensing, pricing, categories, and tags.
  - Added practical use cases covering HTML/XML parsing, date handling, async APIs, image processing, and type-safe API development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->