### PR TITLE
Add Three.js, Zustand, OBS Studio, Blender to catalog

### DIFF
--- a/tools/dev-tools/zustand.yaml
+++ b/tools/dev-tools/zustand.yaml
@@ -1,0 +1,24 @@
+name: Zustand
+description: Small, hook-based state library for React. Zustand stores global state in a single store with selectors, so dashboards for chats, traces, and eval runs stay simple without Redux boilerplate or Context provider trees.
+tagline: Bear necessities for React state
+
+github_url: https://github.com/pmndrs/zustand
+website_url: https://zustand-demo.pmnd.rs/
+docs_url: https://docs.pmnd.rs/zustand/getting-started/introduction
+install_command: npm install zustand
+
+category: Dev Tools
+tags: [javascript, typescript, react, state-management, hooks]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI product UIs juggle streaming tokens, tool-call panels, and eval filters. Redux is heavy and
+  Context re-renders too much. Zustand is a tiny store with selectors so React apps can share
+  chat and trace state without boilerplate or wrapping the tree in providers.
+
+use_cases:
+  - Hold streaming chat and tool-call state in a React agent console
+  - Share eval filters and selected runs across dashboard panels without Context
+  - Persist UI preferences for model playgrounds with a few lines of store code

--- a/tools/other/blender.yaml
+++ b/tools/other/blender.yaml
@@ -1,0 +1,24 @@
+name: Blender
+description: Open-source 3D creation suite for modeling, animation, simulation, rendering, and video editing. Blender is a full desktop DCC used to prepare 3D datasets, inspect generated meshes, and produce visualization for research and product demos.
+tagline: Open-source 3D creation suite
+
+github_url: https://github.com/blender/blender
+website_url: https://www.blender.org
+docs_url: https://docs.blender.org
+install_command: brew install --cask blender
+
+category: Other
+tags: [3d, modeling, animation, rendering, open-source, desktop]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Preparing 3D training data and reviewing generated meshes often requires a paid DCC. Blender
+  models, rigs, simulates, and renders on every major OS, so research teams can clean assets,
+  bake labels, and inspect NeRF or mesh outputs without a Maya or 3ds Max license.
+
+use_cases:
+  - Clean and label 3D meshes before they enter a generative or reconstruction pipeline
+  - Inspect generated geometry, materials, and animations from 3D foundation models
+  - Render dataset previews and paper figures from scenes without a commercial DCC

--- a/tools/other/obs-studio.yaml
+++ b/tools/other/obs-studio.yaml
@@ -1,0 +1,25 @@
+name: OBS Studio
+description: Free open-source software for live streaming and screen recording. OBS captures displays, windows, and cameras, composites scenes, and streams or records locally, which is the default way teams film agent demos, model launches, and workshop talks.
+tagline: Open-source live streaming and screen recording
+
+github_url: https://github.com/obsproject/obs-studio
+website_url: https://obsproject.com
+docs_url: https://obsproject.com/kb
+install_command: brew install --cask obs
+
+category: Other
+tags: [streaming, recording, video, open-source, desktop]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Recording a local agent run, a GPU demo, or a workshop usually means fighting OS capture
+  tools that drop frames or lack scenes. OBS composites displays, windows, and cameras, then
+  records or streams at production quality so DevRel and research teams can ship demos without
+  a studio stack.
+
+use_cases:
+  - Record agent and model demos from a local GPU box for talks and launch videos
+  - Stream workshops and office hours with scene layouts for slides plus a terminal
+  - Capture high-quality screen recordings of playground UIs without a paid encoder

--- a/tools/other/threejs.yaml
+++ b/tools/other/threejs.yaml
@@ -1,0 +1,25 @@
+name: Three.js
+description: JavaScript 3D library for rendering scenes in the browser with WebGL. Three.js gives cameras, lights, materials, and loaders so product UIs can show generated meshes, Gaussian-splat previews, and spatial agent environments without a native graphics stack.
+tagline: WebGL 3D library for the browser
+
+github_url: https://github.com/mrdoob/three.js
+website_url: https://threejs.org/
+docs_url: https://threejs.org/docs/
+install_command: npm install three
+
+category: Other
+tags: [javascript, webgl, 3d, graphics, visualization, browser]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Showing generated 3D assets, robot simulations, or spatial agent worlds in a web app usually
+  means wrapping a game engine. Three.js is the standard WebGL layer for cameras, meshes, and
+  materials in the browser, so ML demos can render models and scenes with a few hundred lines
+  of JavaScript.
+
+use_cases:
+  - Preview generated meshes and textures from 3D generative models in a web UI
+  - Visualize spatial agent environments and robot trajectories in the browser
+  - Build interactive product demos that load glTF scenes without a native 3D runtime


### PR DESCRIPTION
## Add 4 tools to the catalog

- **Three.js** (Other) — WebGL 3D library (mrdoob/three.js, MIT, ~115k stars)
- **Zustand** (Dev Tools) — Small React state library (pmndrs/zustand, MIT, ~59k stars)
- **OBS Studio** (Other) — Live streaming and screen recording (obsproject/obs-studio, GPL-2.0, ~76k stars)
- **Blender** (Other) — Open-source 3D creation suite (blender/blender, GPL-3.0, ~20k stars)

All four YAML files passed local `validate-tool.ts`.
