### PR TITLE
Add GraphicsMagick, SoX, feroxbuster, Day.js, execa to catalog

### DIFF
--- a/tools/dev-tools/dayjs.yaml
+++ b/tools/dev-tools/dayjs.yaml
@@ -1,0 +1,26 @@
+name: Day.js
+description: 2kB immutable date-time library with a Moment.js-compatible API. Frontend and Node AI apps use Day.js to parse, format, and manipulate timestamps in logs, eval runs, and dashboard UIs without shipping a heavy date library.
+tagline: 2kB immutable date library alternative to Moment.js
+
+github_url: https://github.com/iamkun/dayjs
+website_url: https://day.js.org
+docs_url: https://day.js.org/docs/en/installation/installation
+install_command: npm install dayjs
+
+category: Dev Tools
+tags: [javascript, typescript, dates, npm, frontend, node]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Moment.js is large and mutable, which bloats AI dashboards and eval UIs that
+  only need parse, format, and timezone helpers. Day.js offers the same modern
+  API in about 2kB with immutable objects, so timestamp handling stays small
+  and predictable in browser and Node pipelines.
+
+use_cases:
+  - Format eval-run and experiment timestamps in an AI dashboard
+  - Parse mixed ISO and locale date strings from logs and traces
+  - Display relative times for agent job history in a web UI
+  - Convert timezones when aggregating usage metrics across regions

--- a/tools/dev-tools/execa.yaml
+++ b/tools/dev-tools/execa.yaml
@@ -1,0 +1,25 @@
+name: execa
+description: Better child-process execution for Node.js, with promise APIs, streaming, and cancellation. Agent runtimes and ML CLIs use execa to spawn Python, FFmpeg, and toolchain binaries without fighting Node's raw child_process API.
+tagline: Process execution for humans in Node.js
+
+github_url: https://github.com/sindresorhus/execa
+docs_url: https://github.com/sindresorhus/execa#readme
+install_command: npm install execa
+
+category: Dev Tools
+tags: [javascript, typescript, node, child-process, cli, npm]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Node's built-in child_process is verbose, error-prone, and awkward with
+  streaming, cancellation, and Windows quoting. execa wraps spawn with promises,
+  IPC, and sensible defaults so agent runtimes and ML CLIs can call Python,
+  FFmpeg, and other binaries without custom process plumbing.
+
+use_cases:
+  - Spawn Python training or eval scripts from a Node agent runtime
+  - Run FFmpeg or SoX as a subprocess in an audio preprocessing CLI
+  - Capture stdout/stderr from toolchain commands with proper cancellation
+  - Build a Node CLI that shells out to cargo, git, or docker safely

--- a/tools/dev-tools/feroxbuster.yaml
+++ b/tools/dev-tools/feroxbuster.yaml
@@ -1,0 +1,26 @@
+name: feroxbuster
+description: Fast, recursive content-discovery tool written in Rust. Teams use it to enumerate hidden paths, API routes, and static assets on web apps, including AI product surfaces and internal docs sites.
+tagline: Recursive content discovery written in Rust
+
+github_url: https://github.com/epi052/feroxbuster
+website_url: https://epi052.github.io/feroxbuster-docs/overview/
+docs_url: https://epi052.github.io/feroxbuster-docs/overview/
+install_command: cargo install feroxbuster
+
+category: Dev Tools
+tags: [rust, cli, content-discovery, http, security, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI products ship undocumented API routes, leftover static assets, and internal
+  docs that never appear in a sitemap. feroxbuster recursively brute-forces
+  directories and files over HTTP so security and platform teams can map the
+  real surface of an app instead of guessing from public docs.
+
+use_cases:
+  - Enumerate hidden API routes on an LLM or agent product before a security review
+  - Discover leftover docs, OpenAPI specs, and static assets on staging hosts
+  - Recursively map a large content tree with auto-tuning and wordlist filters
+  - Feed discovered endpoints into monitoring, allowlists, or integration tests

--- a/tools/dev-tools/graphicsmagick.yaml
+++ b/tools/dev-tools/graphicsmagick.yaml
@@ -1,0 +1,25 @@
+name: GraphicsMagick
+description: Open-source image processing suite derived from ImageMagick, with a smaller memory footprint for convert, resize, crop, and composite work. Teams use it to normalize vision datasets and generate thumbnails in ML pipelines.
+tagline: Lightweight image processing for dataset pipelines
+
+website_url: https://www.graphicsmagick.org/
+docs_url: https://www.graphicsmagick.org/GraphicsMagick.html
+install_command: brew install graphicsmagick
+
+category: Dev Tools
+tags: [images, conversion, cli, datasets, computer-vision, imagemagick]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Vision datasets arrive as mixed JPEG, PNG, TIFF, and WebP files at inconsistent
+  sizes, and ImageMagick can be heavy in tight CI workers. GraphicsMagick converts,
+  resizes, and composites images with a smaller memory footprint so you can
+  normalize training images without standing up a heavier convert stack.
+
+use_cases:
+  - Resize and convert a vision dataset to a single format before training
+  - Generate thumbnails for a dataset browser or labeling UI
+  - Strip metadata and composite overlays for evaluation galleries
+  - Batch-convert crawled images in CI with lower RAM than ImageMagick

--- a/tools/other/sox.yaml
+++ b/tools/other/sox.yaml
@@ -1,0 +1,26 @@
+name: SoX
+description: Command-line Swiss Army knife for converting, trimming, resampling, and applying effects to audio files across dozens of formats. ML teams use SoX to normalize speech datasets and prepare clips for ASR and TTS training.
+tagline: Universal sound sample translator for audio pipelines
+
+github_url: https://github.com/chirlu/sox
+website_url: https://sox.sourceforge.net/
+docs_url: https://sox.sourceforge.net/sox.html
+install_command: brew install sox
+
+category: Other
+tags: [audio, speech, cli, datasets, asr, tts, conversion]
+pricing: free
+is_open_source: true
+license: GPL-2.0-or-later
+
+problem_solved: |
+  Speech and audio datasets arrive as mixed WAV, MP3, FLAC, and OGG files at
+  inconsistent sample rates and channel counts. SoX converts, resamples, trims,
+  and applies effects in batch so you can normalize training audio without
+  writing a one-off FFmpeg script for every new crawl.
+
+use_cases:
+  - Resample a speech corpus to 16 kHz mono WAV before ASR fine-tuning
+  - Trim silence and normalize loudness across TTS training clips
+  - Convert mixed audio formats into a single codec for dataset packaging
+  - Apply simple effects when building audio augmentation pipelines


### PR DESCRIPTION
## Add 5 tools to the catalog

- **GraphicsMagick** (Dev Tools) — lightweight ImageMagick-derived image processing for dataset pipelines
- **SoX** (Other) — command-line audio conversion and resampling for speech/TTS datasets
- **feroxbuster** (Dev Tools) — recursive HTTP content discovery written in Rust
- **Day.js** (Dev Tools) — 2kB immutable date-time library (Moment.js alternative)
- **execa** (Dev Tools) — better child-process execution for Node.js agent runtimes and CLIs

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Day.js, execa, feroxbuster, GraphicsMagick, and SoX.
  * Each entry now includes descriptions, documentation and project links, installation guidance, categories, tags, pricing, and licensing details.
  * Added practical use cases covering date and time handling, subprocess execution, content discovery, image processing, and audio dataset normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->