### PR TITLE
Add chokidar, winston, jsdom, Chart.js to catalog

### DIFF
--- a/tools/dev-tools/chokidar.yaml
+++ b/tools/dev-tools/chokidar.yaml
@@ -1,0 +1,26 @@
+name: chokidar
+description: Minimal, efficient cross-platform file watcher for Node.js. Agent CLIs, RAG indexers, and ML pipelines use chokidar to reload prompts, configs, and dataset files the moment they change on disk.
+tagline: Minimal cross-platform file watching for Node.js
+
+github_url: https://github.com/paulmillr/chokidar
+website_url: https://github.com/paulmillr/chokidar
+docs_url: https://github.com/paulmillr/chokidar#readme
+install_command: npm install chokidar
+
+category: Dev Tools
+tags: [javascript, typescript, node, filesystem, watch, npm]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Node fs.watch is inconsistent across macOS, Linux, and Windows, which breaks
+  hot-reload for agent configs and dataset folders. chokidar wraps native
+  watchers with a stable API so CLIs and indexers can react to file changes
+  without platform-specific bugs.
+
+use_cases:
+  - Hot-reload agent prompts and YAML configs when files change
+  - Watch a dataset or embeddings folder and re-index new documents
+  - Trigger eval reruns when test fixtures or goldens are updated
+  - Rebuild a local RAG corpus as markdown files land on disk

--- a/tools/dev-tools/jsdom.yaml
+++ b/tools/dev-tools/jsdom.yaml
@@ -1,0 +1,25 @@
+name: jsdom
+description: JavaScript implementation of web standards for Node.js, including DOM, HTML, and CSS. Teams use jsdom to scrape, test, and extract content from pages in RAG pipelines and agent browsers without launching a full browser.
+tagline: Web standards in Node.js without a real browser
+
+github_url: https://github.com/jsdom/jsdom
+docs_url: https://github.com/jsdom/jsdom#readme
+install_command: npm install jsdom
+
+category: Dev Tools
+tags: [javascript, typescript, node, dom, html, testing, npm]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Many RAG crawlers and agent tests need a DOM in Node, not a headed browser.
+  jsdom implements HTML parsing, the DOM, and enough browser APIs to query,
+  mutate, and extract page content in CI and data pipelines without Puppeteer
+  or Playwright overhead.
+
+use_cases:
+  - Parse HTML into a DOM for RAG chunking and content extraction
+  - Unit-test UI components that depend on document and window
+  - Extract metadata and article text from crawled pages in Node
+  - Simulate form and script behavior in agent evaluation fixtures

--- a/tools/dev-tools/winston.yaml
+++ b/tools/dev-tools/winston.yaml
@@ -1,0 +1,25 @@
+name: winston
+description: Flexible Node.js logger with transports for files, consoles, and HTTP. Agent runtimes and ML CLIs use winston to capture structured logs from tool calls, evals, and background jobs without rolling a custom logger.
+tagline: A logger for just about everything in Node.js
+
+github_url: https://github.com/winstonjs/winston
+docs_url: https://github.com/winstonjs/winston#readme
+install_command: npm install winston
+
+category: Dev Tools
+tags: [javascript, typescript, node, logging, observability, npm]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Agent runtimes and Node ML CLIs need structured logs that can fan out to
+  files, consoles, and remote sinks. winston provides levels, formats, and
+  transports so you can record tool calls, evals, and errors without writing
+  a custom logger for every service.
+
+use_cases:
+  - Log agent tool calls and LLM request metadata to rotating files
+  - Ship structured JSON logs from a Node eval runner to a log sink
+  - Separate debug, info, and error streams across CLI and daemon modes
+  - Attach request IDs when tracing multi-step agent jobs

--- a/tools/other/chartjs.yaml
+++ b/tools/other/chartjs.yaml
@@ -1,0 +1,26 @@
+name: Chart.js
+description: Simple HTML5 charting library using the canvas element. AI dashboards use Chart.js to plot eval scores, token usage, latency, and experiment metrics in the browser without a heavy visualization stack.
+tagline: Simple HTML5 charts using the canvas element
+
+github_url: https://github.com/chartjs/Chart.js
+website_url: https://www.chartjs.org/
+docs_url: https://www.chartjs.org/docs/latest/
+install_command: npm install chart.js
+
+category: Other
+tags: [javascript, charts, visualization, canvas, frontend, npm]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI product dashboards need line, bar, and scatter charts for eval scores,
+  latency, and token usage without pulling in D3 or a full BI suite. Chart.js
+  renders those charts on canvas with a small API so teams can ship metrics
+  UIs quickly in the browser.
+
+use_cases:
+  - Plot eval scores and experiment metrics on an internal AI dashboard
+  - Chart token usage and latency over time for an LLM gateway
+  - Show scatter plots of embedding quality or retrieval scores
+  - Embed lightweight charts in a static HTML report of model runs


### PR DESCRIPTION
## Add 4 tools to the catalog

- **chokidar** (Dev Tools) — cross-platform Node.js file watcher for agent configs and dataset folders
- **winston** (Dev Tools) — flexible Node.js logger with transports
- **jsdom** (Dev Tools) — web standards / DOM implementation for Node.js RAG and tests
- **Chart.js** (Other) — HTML5 canvas charting for AI dashboards

Local validation passed for all four YAML files.
