### PR TITLE
Add D3.js, Apache ECharts, Recharts, Undici to catalog

### DIFF
--- a/tools/dev-tools/undici.yaml
+++ b/tools/dev-tools/undici.yaml
@@ -1,0 +1,26 @@
+name: Undici
+description: HTTP/1.1 client written from scratch for Node.js and used as Node's built-in fetch backend. Agent runtimes use Undici for high-throughput LLM API calls with pooling, pipelining, and streaming.
+tagline: High-performance HTTP client for Node.js
+
+github_url: https://github.com/nodejs/undici
+website_url: https://undici.nodejs.org/
+docs_url: https://undici.nodejs.org/#/
+install_command: npm install undici
+
+category: Dev Tools
+tags: [javascript, typescript, http, node, fetch, npm]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Node agent runtimes that fire many LLM and embedding requests need
+  connection pooling and streaming without a browser-oriented client.
+  Undici is Node's HTTP client with keep-alive, pipelining, and fetch, so
+  high-QPS inference calls stay fast and standards-compliant.
+
+use_cases:
+  - Call LLM and embedding APIs at high QPS from a Node gateway
+  - Stream SSE token responses with Node's fetch implementation
+  - Pool connections across parallel eval jobs
+  - Replace slower HTTP clients in a Node agent worker

--- a/tools/other/apache-echarts.yaml
+++ b/tools/other/apache-echarts.yaml
@@ -1,0 +1,26 @@
+name: Apache ECharts
+description: Powerful interactive charting library for the browser. AI product dashboards use ECharts to render large eval, usage, and latency series with zoom, tooltips, and canvas rendering.
+tagline: Interactive browser charts for large metric series
+
+github_url: https://github.com/apache/echarts
+website_url: https://echarts.apache.org
+docs_url: https://echarts.apache.org/handbook/en/get-started/
+install_command: npm install echarts
+
+category: Other
+tags: [javascript, visualization, charts, apache, frontend, npm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  LLM gateways and eval platforms accumulate long time-series that bog down
+  naive SVG charts. Apache ECharts renders interactive line, bar, and heatmap
+  charts on canvas so usage, latency, and score dashboards stay responsive
+  with large datasets.
+
+use_cases:
+  - Chart token usage and latency over weeks for an LLM gateway
+  - Render zoomable eval-score time series on an ops dashboard
+  - Show heatmaps of model quality across datasets and versions
+  - Embed interactive charts in a static HTML experiment report

--- a/tools/other/d3js.yaml
+++ b/tools/other/d3js.yaml
@@ -1,0 +1,26 @@
+name: D3.js
+description: Data-driven documents library for binding data to SVG, Canvas, and HTML. AI dashboards use D3.js to build custom eval charts, embedding plots, and interactive experiment reports in the browser.
+tagline: Bring data to life with SVG, Canvas, and HTML
+
+github_url: https://github.com/d3/d3
+website_url: https://d3js.org
+docs_url: https://d3js.org/getting-started
+install_command: npm install d3
+
+category: Other
+tags: [javascript, visualization, svg, charts, frontend, npm]
+pricing: free
+is_open_source: true
+license: ISC
+
+problem_solved: |
+  Off-the-shelf chart widgets cannot show custom embedding scatterplots,
+  token-flow diagrams, or eval heatmaps. D3.js binds data to SVG and Canvas
+  so teams can draw exactly the visualization an experiment needs instead of
+  forcing metrics into a generic bar chart.
+
+use_cases:
+  - Plot embedding scatterplots and clustering results in a browser
+  - Build custom eval heatmaps and confusion matrices
+  - Animate token or latency distributions for experiment reports
+  - Create interactive axes and brushes for filtering model-run metrics

--- a/tools/other/recharts.yaml
+++ b/tools/other/recharts.yaml
@@ -1,0 +1,26 @@
+name: Recharts
+description: Composable React charting library built on D3. AI dashboards use Recharts to drop line, bar, and scatter charts into React eval UIs with declarative components instead of raw SVG.
+tagline: React charts composed from D3 primitives
+
+github_url: https://github.com/recharts/recharts
+website_url: https://recharts.github.io
+docs_url: https://recharts.github.io/en-US/guide
+install_command: npm install recharts
+
+category: Other
+tags: [javascript, react, charts, visualization, d3, npm]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  React AI dashboards need charts that compose like components, not D3
+  selections mixed into JSX. Recharts wraps D3 in declarative React charts
+  so eval scores, usage, and scatter plots drop into existing layouts with
+  props instead of manual SVG.
+
+use_cases:
+  - Add line charts of eval scores to a React experiment dashboard
+  - Plot token usage and cost in a React admin console
+  - Render scatter plots of retrieval quality in a RAG UI
+  - Compose responsive bar charts for model comparison pages


### PR DESCRIPTION
## Add 4 tools to the catalog

- **D3.js** (Other) — data-driven documents for custom SVG/Canvas visualizations
- **Apache ECharts** (Other) — interactive browser charts for large metric series
- **Recharts** (Other) — composable React charting built on D3
- **Undici** (Dev Tools) — Node.js HTTP/1.1 client and fetch backend

Local validation passed for all four YAML files.
