### PR TITLE
Add Ramda, Nivo, ApexCharts, visx, Ajv to catalog

### DIFF
--- a/tools/dev-tools/ajv.yaml
+++ b/tools/dev-tools/ajv.yaml
@@ -1,0 +1,25 @@
+name: Ajv
+description: Fast JSON Schema validator for Node and the browser. Agent APIs use Ajv to validate LLM structured output, tool-call arguments, and config files against JSON Schema and JSON Type Definition.
+tagline: Fast JSON Schema validator for Node and browsers
+
+github_url: https://github.com/ajv-validator/ajv
+website_url: https://ajv.js.org
+docs_url: https://ajv.js.org/guide/getting-started.html
+install_command: npm install ajv
+
+category: Dev Tools
+tags: [javascript, json-schema, validation, npm, node, typescript]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  LLM structured output and tool-call JSON often fail silently until a later
+  step crashes. Ajv compiles JSON Schema into fast validators so agent APIs
+  reject invalid payloads at the boundary instead of after a model round-trip.
+
+use_cases:
+  - Validate LLM structured output against a JSON Schema before persisting
+  - Check tool-call arguments from an agent before executing side effects
+  - Compile config schemas for local agent YAML and JSON files
+  - Enforce JSON Type Definition on webhook payloads from eval runners

--- a/tools/dev-tools/ramda.yaml
+++ b/tools/dev-tools/ramda.yaml
@@ -1,0 +1,26 @@
+name: Ramda
+description: Practical functional JavaScript library of immutable, auto-curried helpers. Agent backends and Node ML CLIs use Ramda to compose data transforms on eval traces, tool-call payloads, and prompt templates without mutating state.
+tagline: Practical functional JavaScript for immutable data pipelines
+
+github_url: https://github.com/ramda/ramda
+website_url: https://ramdajs.com
+docs_url: https://ramdajs.com/docs/
+install_command: npm install ramda
+
+category: Dev Tools
+tags: [javascript, functional, immutable, npm, node, utilities]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Agent services repeatedly map, filter, and compose JSON from traces, tool
+  calls, and configs. Imperative helpers mutate objects and leak side effects
+  across steps. Ramda supplies auto-curried, data-last functions so pipelines
+  stay composable and inputs stay unchanged.
+
+use_cases:
+  - Compose map and filter pipelines over eval traces before writing reports
+  - Transform LLM tool-call payloads without mutating the original request
+  - Build reusable prompt-template helpers with auto-curried functions
+  - Normalize nested agent config objects before merging environment overrides

--- a/tools/other/apexcharts.yaml
+++ b/tools/other/apexcharts.yaml
@@ -1,0 +1,26 @@
+name: ApexCharts
+description: Interactive JavaScript charts rendered as SVG. AI product dashboards use ApexCharts for zoomable line, bar, mixed, and candlestick charts of eval metrics, latency, and cost without a heavy BI stack.
+tagline: Interactive SVG charts for product dashboards
+
+github_url: https://github.com/apexcharts/apexcharts.js
+website_url: https://apexcharts.com
+docs_url: https://apexcharts.com/docs/
+install_command: npm install apexcharts
+
+category: Other
+tags: [javascript, charts, visualization, svg, frontend, npm]
+pricing: freemium
+is_open_source: true
+license: Community License
+
+problem_solved: |
+  AI dashboards need zoom, annotations, and mixed chart types for latency and
+  cost without embedding a BI product. ApexCharts renders interactive SVG
+  charts in the browser so eval and ops UIs can pan, zoom, and overlay series
+  with a small API.
+
+use_cases:
+  - Plot zoomable eval score trends on an internal AI dashboard
+  - Chart token usage and cost with mixed bar and line series
+  - Annotate latency spikes on an LLM gateway monitor
+  - Embed interactive charts in a static HTML model-run report

--- a/tools/other/nivo.yaml
+++ b/tools/other/nivo.yaml
@@ -1,0 +1,26 @@
+name: Nivo
+description: Rich React data visualization components built on D3. AI dashboards use Nivo for responsive bar, line, heatmap, and network charts of eval scores, token usage, and retrieval quality without hand-writing SVG.
+tagline: React data viz components built on D3
+
+github_url: https://github.com/plouc/nivo
+website_url: https://nivo.rocks
+docs_url: https://nivo.rocks/
+install_command: npm install @nivo/core
+
+category: Other
+tags: [javascript, react, charts, visualization, d3, npm]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  React AI dashboards need heatmaps, sankeys, and network graphs that Chart.js
+  does not cover well. Nivo ships a large set of D3-backed React charts so
+  teams can plot eval scores, token cost, and retrieval graphs with props
+  instead of custom SVG.
+
+use_cases:
+  - Add heatmap charts of eval scores across models and datasets
+  - Plot token usage and latency as responsive React line charts
+  - Render network graphs of agent tool-call traces
+  - Build a model comparison page with bar and radar charts

--- a/tools/other/visx.yaml
+++ b/tools/other/visx.yaml
@@ -1,0 +1,26 @@
+name: visx
+description: Low-level React visualization primitives from Airbnb, built on D3. Teams use visx to compose custom eval dashboards and embedding plots when Chart.js or Recharts are too opinionated for the layout.
+tagline: Low-level React visualization primitives from Airbnb
+
+github_url: https://github.com/airbnb/visx
+website_url: https://visx.airbnb.tech
+docs_url: https://airbnb.io/visx
+install_command: npm install @visx/visx
+
+category: Other
+tags: [javascript, react, visualization, d3, charts, npm]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  High-level chart libraries hide the SVG you need for custom AI dashboards.
+  visx exposes D3 scales, shapes, and axes as React components so teams can
+  compose embedding scatter plots and eval layouts without fighting a chart
+  theme system.
+
+use_cases:
+  - Compose a custom scatter plot of embedding clusters in React
+  - Build an eval dashboard with shared D3 scales across panels
+  - Render brush-and-zoom charts of token usage over time
+  - Drop visx axes and tooltips into an existing design system


### PR DESCRIPTION
## What

Add 5 catalog entries:

- **Ramda** (Dev Tools) — practical functional JavaScript library (`ramda/ramda`, 24k★, MIT)
- **Nivo** (Other) — React data visualization components on D3 (`plouc/nivo`, 14k★, MIT)
- **ApexCharts** (Other) — interactive SVG JavaScript charts (`apexcharts/apexcharts.js`, 15k★, Community License / freemium)
- **visx** (Other) — Airbnb React visualization primitives (`airbnb/visx`, 21k★, MIT)
- **Ajv** (Dev Tools) — fast JSON Schema validator (`ajv-validator/ajv`, 14k★, MIT)

## Validation

Local `npx tsx scripts/validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Ajv, Ramda, ApexCharts, Nivo, and visx to the tools catalog.
  - Added descriptions, installation details, documentation links, licensing, pricing, categories, tags, and supported use cases for each tool.
  - Added guidance highlighting applications such as JSON validation, data transformation, interactive charts, dashboards, and visualization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->