### PR TITLE
Add Yup, Immutable.js, fp-ts, Valibot to catalog

### DIFF
--- a/tools/dev-tools/fp-ts.yaml
+++ b/tools/dev-tools/fp-ts.yaml
@@ -1,0 +1,26 @@
+name: fp-ts
+description: Functional programming library for TypeScript with Option, Either, and Task types. Agent backends use fp-ts to model LLM failures, missing tool results, and async pipelines as typed data instead of thrown exceptions.
+tagline: Typed functional programming for TypeScript
+
+github_url: https://github.com/gcanti/fp-ts
+website_url: https://gcanti.github.io/fp-ts/
+docs_url: https://gcanti.github.io/fp-ts/
+install_command: npm install fp-ts
+
+category: Dev Tools
+tags: [typescript, functional, either, option, npm, node]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Agent code paths mix thrown errors, nulls, and promises when a model or
+  tool fails. fp-ts models those cases as Option, Either, and Task so
+  TypeScript can force handling of missing tool results and failed LLM
+  calls before they leak into downstream steps.
+
+use_cases:
+  - Wrap LLM calls in TaskEither so timeouts become typed failures
+  - Model missing retrieval hits as Option instead of null checks
+  - Pipe tool-call results through Either maps in a Node agent
+  - Compose validation and IO steps without nested try/catch

--- a/tools/dev-tools/immutable-js.yaml
+++ b/tools/dev-tools/immutable-js.yaml
@@ -1,0 +1,26 @@
+name: Immutable.js
+description: Persistent immutable collections for JavaScript. Agent UIs and Node pipelines use Immutable.js Lists, Maps, and Records so eval traces and config trees can be updated without mutating shared state.
+tagline: Persistent immutable collections for JavaScript
+
+github_url: https://github.com/immutable-js/immutable-js
+website_url: https://immutable-js.com
+docs_url: https://immutable-js.com/docs/latest/
+install_command: npm install immutable
+
+category: Dev Tools
+tags: [javascript, immutable, data-structures, npm, node, frontend]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Shared eval traces and config objects get mutated across React state and
+  Node workers, causing hard-to-debug races. Immutable.js persistent Lists
+  and Maps return new versions on write so agent UIs can compare snapshots
+  cheaply without cloning entire trees.
+
+use_cases:
+  - Store eval traces in an Immutable Map for cheap React re-renders
+  - Update nested agent config without mutating the previous snapshot
+  - Diff two Immutable Lists of tool-call events in a debugger
+  - Share persistent collections across web workers in a local agent runtime

--- a/tools/dev-tools/valibot.yaml
+++ b/tools/dev-tools/valibot.yaml
@@ -1,0 +1,26 @@
+name: Valibot
+description: Modular, tree-shakable TypeScript schema library for validating structural data. Agent CLIs and edge workers use Valibot to type-check LLM output and config with a smaller bundle than Zod.
+tagline: Modular type-safe schemas with a small bundle
+
+github_url: https://github.com/fabian-hiller/valibot
+website_url: https://valibot.dev
+docs_url: https://valibot.dev/guides/introduction/
+install_command: npm install valibot
+
+category: Dev Tools
+tags: [typescript, validation, schema, npm, edge, tree-shaking]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Full schema libraries pull a large runtime into edge agent workers and
+  browser UIs. Valibot ships modular, tree-shakable validators so teams can
+  check LLM structured output and config with TypeScript types without a
+  heavy schema bundle.
+
+use_cases:
+  - Validate LLM structured output in an edge worker with a small bundle
+  - Parse agent CLI config files into typed objects
+  - Share schemas between a browser eval UI and a Node API
+  - Replace ad-hoc typeof checks on tool-call arguments

--- a/tools/dev-tools/yup.yaml
+++ b/tools/dev-tools/yup.yaml
@@ -1,0 +1,26 @@
+name: Yup
+description: Dead-simple JavaScript object schema validation with async checks and type inference. Agent APIs use Yup to validate LLM structured output, form payloads, and tool-call arguments before they hit business logic.
+tagline: Dead-simple object schema validation for JavaScript
+
+github_url: https://github.com/jquense/yup
+website_url: https://github.com/jquense/yup
+docs_url: https://github.com/jquense/yup
+install_command: npm install yup
+
+category: Dev Tools
+tags: [javascript, typescript, validation, schema, npm, node]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Agent endpoints accept nested JSON from models and UIs that is easy to
+  shape-check by hand and easy to get wrong. Yup describes object schemas
+  with chainable rules so invalid tool-call and form payloads fail at the
+  boundary instead of deep in a handler.
+
+use_cases:
+  - Validate LLM structured output before writing it to a database
+  - Check agent form payloads in a Next.js API route
+  - Coerce and default tool-call arguments from an LLM
+  - Share the same schema between a React form and a Node agent service


### PR DESCRIPTION
## What

Add 4 catalog entries (sqlite-vss skipped as predecessor of sqlite-vec):

- **Yup** (Dev Tools) — JavaScript object schema validation (`jquense/yup`, 23k★, MIT)
- **Immutable.js** (Dev Tools) — persistent immutable collections (`immutable-js/immutable-js`, 33k★, MIT)
- **fp-ts** (Dev Tools) — functional programming for TypeScript (`gcanti/fp-ts`, 11k★, MIT)
- **Valibot** (Dev Tools) — modular type-safe schema library (`fabian-hiller/valibot`, 8.9k★, MIT)

## Validation

Local `npx tsx scripts/validate-tool.ts` passed for all four files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fp-ts, Immutable.js, Valibot, and Yup to the developer tools catalog.
  * Added searchable metadata including descriptions, documentation links, installation commands, licensing, pricing, categories, and relevant use cases for each library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->