### PR TITLE
Add MindSearch, OpenChat, MiniCPM, HuggingChat, SiliconFlow to catalog

### DIFF
--- a/tools/llm/huggingchat.yaml
+++ b/tools/llm/huggingchat.yaml
@@ -1,0 +1,25 @@
+name: HuggingChat
+description: Open-source chat UI that powers Hugging Face Chat. Teams self-host HuggingChat to give users a multi-model chat front end on Hugging Face Inference, local providers, and OpenAI-compatible backends.
+tagline: Open-source chat UI that powers Hugging Face Chat
+
+github_url: https://github.com/huggingface/chat-ui
+website_url: https://huggingface.co/chat
+docs_url: https://github.com/huggingface/chat-ui
+
+category: LLM
+tags: [llm, chat, huggingface, open-source, self-hosted, ui]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Shipping a multi-model chat front end means rebuilding history, routing,
+  and provider adapters. HuggingChat is the open UI behind Hugging Face
+  Chat, so teams can self-host a familiar chat experience on Hugging Face
+  Inference or local models.
+
+use_cases:
+  - Self-host a multi-model chat UI for an internal LLM gateway
+  - Point HuggingChat at a local vLLM or llama.cpp backend
+  - Give users a Hugging Face Chat-style interface on private models
+  - Prototype a chat product without writing a custom message UI

--- a/tools/llm/minicpm.yaml
+++ b/tools/llm/minicpm.yaml
@@ -1,0 +1,25 @@
+name: MiniCPM
+description: On-device LLM family from OpenBMB that targets strong quality at small parameter counts. Teams run MiniCPM locally for chat, coding, and edge inference when cloud APIs are too costly or private data cannot leave the device.
+tagline: Small on-device LLMs with strong quality
+
+github_url: https://github.com/OpenBMB/MiniCPM
+website_url: https://github.com/OpenBMB/MiniCPM
+docs_url: https://github.com/OpenBMB/MiniCPM
+
+category: LLM
+tags: [llm, on-device, edge, open-source, transformers]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Cloud LLMs add latency, cost, and data-residency risk for on-device
+  products. MiniCPM ships small open models that run locally so teams can
+  keep private text on the device while still offering chat and coding
+  assistance.
+
+use_cases:
+  - Run a local chat model on a laptop without a cloud API
+  - Serve MiniCPM with vLLM for a private on-prem assistant
+  - Evaluate small open models against larger APIs on coding tasks
+  - Deploy an edge LLM where network access is limited

--- a/tools/llm/openchat.yaml
+++ b/tools/llm/openchat.yaml
@@ -1,0 +1,25 @@
+name: OpenChat
+description: Open-source chat LLM family trained with condition-based fine-tuning on mixed-quality data. Teams run OpenChat as a self-hosted assistant when they want open weights instead of a closed chat API.
+tagline: Open-weight chat models trained on mixed-quality data
+
+github_url: https://github.com/imoneoi/openchat
+website_url: https://openchat.team
+docs_url: https://github.com/imoneoi/openchat
+
+category: LLM
+tags: [llm, open-source, chat, self-hosted, apache]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Closed chat APIs lock quality behind usage fees and data-sharing terms.
+  OpenChat publishes open-weight chat models trained to use mixed-quality
+  data well, so teams can self-host a capable assistant without a vendor
+  API.
+
+use_cases:
+  - Self-host a chat assistant with open-weight OpenChat models
+  - Fine-tune an OpenChat checkpoint on internal support transcripts
+  - Compare open chat models against closed APIs on eval suites
+  - Serve OpenChat through vLLM for a private company chatbot

--- a/tools/llm/siliconflow.yaml
+++ b/tools/llm/siliconflow.yaml
@@ -1,0 +1,23 @@
+name: SiliconFlow
+description: Cloud LLM inference platform with OpenAI-compatible APIs for open models. Teams use SiliconFlow to serve Qwen, DeepSeek, and other open weights without operating their own GPU cluster.
+tagline: OpenAI-compatible APIs for open-weight models
+
+website_url: https://www.siliconflow.com
+docs_url: https://docs.siliconflow.cn/docs
+
+category: LLM
+tags: [llm, inference, api, cloud, openai-compatible]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Serving open-weight models still requires GPUs, batching, and an API
+  gateway. SiliconFlow hosts those models behind OpenAI-compatible
+  endpoints so teams can switch from a closed API to Qwen or DeepSeek
+  without running a cluster.
+
+use_cases:
+  - Call Qwen or DeepSeek through an OpenAI-compatible cloud API
+  - Offload GPU serving for a RAG app without self-hosting
+  - Compare open-model APIs against a closed vendor on the same client
+  - Prototype an agent that can swap model providers via base URL

--- a/tools/rag/mindsearch.yaml
+++ b/tools/rag/mindsearch.yaml
@@ -1,0 +1,25 @@
+name: MindSearch
+description: LLM multi-agent web search framework that plans, searches, and synthesizes cited answers. Teams use MindSearch to build Perplexity-style research agents that browse the web instead of answering from parametric memory alone.
+tagline: Multi-agent web search engine powered by LLMs
+
+github_url: https://github.com/InternLM/MindSearch
+website_url: https://github.com/InternLM/MindSearch
+docs_url: https://github.com/InternLM/MindSearch
+
+category: RAG
+tags: [python, rag, agents, web-search, multi-agent, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Single-shot RAG over a fixed corpus misses live web facts and cannot
+  decompose a research question. MindSearch runs planner and searcher
+  agents that break a query into web searches and synthesize cited
+  answers, so teams can ship a research engine without a closed search API.
+
+use_cases:
+  - Build a Perplexity-style research agent over the public web
+  - Decompose a complex question into parallel search sub-queries
+  - Cite web sources in an internal knowledge assistant
+  - Prototype a multi-agent search pipeline on InternLM or other LLMs


### PR DESCRIPTION
## What

Add 5 catalog entries:

- **MindSearch** (RAG) — multi-agent web search framework (`InternLM/MindSearch`, 6.9k★, Apache-2.0)
- **OpenChat** (LLM) — open-weight chat model family (`imoneoi/openchat`, 5.5k★, Apache-2.0)
- **MiniCPM** (LLM) — on-device LLM family (`OpenBMB/MiniCPM`, 10.6k★, Apache-2.0)
- **HuggingChat** (LLM) — open-source chat UI (`huggingface/chat-ui`, 10.9k★, Apache-2.0)
- **SiliconFlow** (LLM) — cloud inference platform with OpenAI-compatible APIs (SaaS)

## Validation

Local `npx tsx scripts/validate-tool.ts` passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for HuggingChat, MiniCPM, OpenChat, and SiliconFlow, including descriptions, links, categories, pricing, licensing, and use cases.
  * Added a catalog entry for MindSearch, an open-source multi-agent web search framework, with RAG classification and research-oriented use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->