### PR TITLE
Add Qwen-Agent, Voiceflow, Dialogflow, SwarmClaw, Camofox to catalog

### DIFF
--- a/tools/agent-frameworks/dialogflow.yaml
+++ b/tools/agent-frameworks/dialogflow.yaml
@@ -1,0 +1,26 @@
+name: Dialogflow
+description: Google Cloud natural language platform for building conversational agents that handle text and voice across apps, websites, devices, and contact centers. Dialogflow CX targets complex large-scale agents; Dialogflow ES covers simpler bots.
+tagline: Google Cloud platform for text and voice conversational agents
+
+website_url: https://cloud.google.com/dialogflow
+docs_url: https://cloud.google.com/dialogflow/docs
+
+install_command: pip install google-cloud-dialogflow
+
+category: Agents
+tags: [agents, conversational-ai, nlu, voice, gcp, contact-center]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Product and contact-center teams need conversational interfaces that understand
+  intent from text or audio and reply in text or speech across many channels.
+  Dialogflow provides NLU, agent design, and APIs for CX and ES virtual agents so
+  you can embed chat and IVR experiences without building language understanding
+  from scratch on Google Cloud.
+
+use_cases:
+  - Build a website or mobile chatbot that routes customer intents to fulfillment webhooks
+  - Deploy an IVR or voice agent that transcribes audio and replies with synthetic speech
+  - Design large, state-machine CX agents for multi-turn contact-center workflows
+  - Assist human agents with real-time suggestions via Dialogflow Agent Assist

--- a/tools/agent-frameworks/qwen-agent.yaml
+++ b/tools/agent-frameworks/qwen-agent.yaml
@@ -1,0 +1,28 @@
+name: Qwen-Agent
+description: Alibaba's open-source agent framework for Qwen models, with function calling, MCP, a sandboxed code interpreter, RAG, and example apps such as Browser Assistant. It is the backend that powers Qwen Chat.
+tagline: Agent framework for Qwen with tools, MCP, and code interpreter
+
+github_url: https://github.com/QwenLM/Qwen-Agent
+website_url: https://qwenlm.github.io/Qwen-Agent/en/
+docs_url: https://qwenlm.github.io/Qwen-Agent/en/guide/
+
+install_command: pip install qwen-agent
+
+category: Agents
+tags: [python, agents, qwen, function-calling, mcp, rag, code-interpreter]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Building reliable tool-using agents on Qwen models requires custom function-call
+  templates, MCP wiring, RAG over long documents, and a sandboxed code interpreter.
+  Qwen-Agent packages those primitives as reusable LLM, Tool, and Agent classes so
+  teams can ship assistants, browser helpers, and Gradio UIs without reinventing
+  Qwen-specific parsing and planning.
+
+use_cases:
+  - Build a Qwen assistant that calls custom tools, MCP servers, and a Docker-sandboxed code interpreter
+  - Run RAG over long PDFs and 1M-token document collections with the framework's retrieval helpers
+  - Ship a Gradio chat UI for a Browser Assistant or Custom Assistant on top of DashScope or local vLLM
+  - Add parallel, multi-step function calling to Qwen3, QwQ, and Qwen-Coder model deployments

--- a/tools/agent-frameworks/swarmclaw.yaml
+++ b/tools/agent-frameworks/swarmclaw.yaml
@@ -1,0 +1,28 @@
+name: SwarmClaw
+description: Self-hosted open-source AI agent runtime and multi-agent framework with durable memory, MCP tools, schedules, delegation, and 23-plus LLM providers. It orchestrates OpenClaw, Hermes, Claude Code, and other CLI backends from one control plane.
+tagline: Self-hosted runtime for autonomous agent swarms
+
+github_url: https://github.com/swarmclawai/swarmclaw
+website_url: https://www.swarmclaw.ai
+docs_url: https://swarmclaw.ai/docs
+
+install_command: npm install @swarmclawai/swarmclaw
+
+category: Agents
+tags: [agents, multi-agent, self-hosted, mcp, orchestration, nodejs, openclaw]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Running several autonomous agents across Claude Code, OpenClaw, Hermes, and local
+  models usually means separate dashboards, memories, and schedulers. SwarmClaw is
+  a self-hosted control plane with durable agent memory, MCP tools, cron schedules,
+  delegation, and connectors so teams can orchestrate agent swarms without a
+  managed SaaS lock-in.
+
+use_cases:
+  - Self-host a multi-agent control plane that delegates work to Claude Code, Codex, and OpenClaw
+  - Schedule heartbeat agents with durable memory, MCP tools, and a Kanban-style task board
+  - Connect the same swarm to Discord, Slack, Telegram, and WhatsApp with one runtime
+  - Deploy SwarmClaw on Docker, Render, Fly.io, or Railway with persistent agent state

--- a/tools/agent-frameworks/voiceflow.yaml
+++ b/tools/agent-frameworks/voiceflow.yaml
@@ -1,0 +1,24 @@
+name: Voiceflow
+description: Enterprise conversational AI platform for designing, launching, and iterating customer-facing chat and voice agents. Teams use a visual agent builder, observability, and hosted production environments without locking to a single LLM.
+tagline: Visual platform for production customer-facing AI agents
+
+website_url: https://www.voiceflow.com
+docs_url: https://docs.voiceflow.com
+
+category: Agents
+tags: [agents, conversational-ai, voice, cx, no-code, enterprise]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  CX and conversation-design teams need to ship production chat and voice agents
+  without rebuilding orchestration for every channel, model, or environment.
+  Voiceflow provides a collaborative visual builder, guardrails, evaluations, and
+  hosted staging-to-production pipelines so designers and engineers can iterate
+  agents that resolve support tickets at scale.
+
+use_cases:
+  - Design and publish omnichannel support agents that mix deterministic flows with LLM playbooks
+  - Prototype conversational UX with real-time testing before handing flows to engineering
+  - Evaluate production conversations with LLM-powered insights and iterate without full rebuilds
+  - Connect agents to Zendesk, Salesforce, Shopify, and custom APIs while swapping LLM providers

--- a/tools/dev-tools/camofox.yaml
+++ b/tools/dev-tools/camofox.yaml
@@ -1,0 +1,27 @@
+name: Camofox
+description: Stealth headless browser for AI agents that wraps Camoufox, a Firefox fork with C++ fingerprint spoofing. It exposes a REST API with accessibility snapshots and element refs as a drop-in path when Playwright and Chrome get blocked.
+tagline: Anti-detection browser API for AI agents
+
+github_url: https://github.com/jo-inc/camofox-browser
+website_url: https://github.com/jo-inc/camofox-browser
+
+install_command: npm install @askjo/camofox-browser
+
+category: Dev Tools
+tags: [browser-automation, anti-detection, scraping, playwright, puppeteer, agents, nodejs]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI agents that browse the live web get blocked by Cloudflare, bot detection, and
+  headless-Chrome fingerprints. Camofox wraps Camoufox's C++-level Firefox spoofing
+  in a REST API with accessibility snapshots and stable element refs, so agents can
+  click, search, and extract pages without Playwright stealth plugins becoming the
+  fingerprint.
+
+use_cases:
+  - Give an AI agent a stealth browser that bypasses Cloudflare and common bot checks
+  - Replace Playwright or Puppeteer navigation with accessibility snapshots and element refs
+  - Extract YouTube transcripts, search macros, and structured JSON from pages without an API key
+  - Deploy an anti-detection browser server on Docker, Fly.io, or Railway for agent workloads


### PR DESCRIPTION
## Add 5 tools to the catalog

- **Qwen-Agent** (Agents) — Alibaba agent framework for Qwen with function calling, MCP, RAG, and code interpreter (`QwenLM/Qwen-Agent`, 17k+)
- **Voiceflow** (Agents) — Enterprise conversational AI platform for chat and voice agents
- **Dialogflow** (Agents) — Google Cloud NLU platform for CX/ES virtual agents
- **SwarmClaw** (Agents) — Self-hosted multi-agent runtime (`swarmclawai/swarmclaw`)
- **Camofox** (Dev Tools) — Stealth headless browser API for AI agents (`jo-inc/camofox-browser`, 10k+)

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Dialogflow, Qwen-Agent, SwarmClaw, and Voiceflow to the agent frameworks catalog.
  - Added Camofox to the developer tools catalog.
  - Catalog entries now include descriptions, use cases, categories, tags, pricing, licensing, documentation links, and installation guidance.
  - Added visibility into conversational AI, agent orchestration, browser automation, voice experiences, and customer-support use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->