### PR TITLE
Add Hyperframes, Context Mode, Lovable, Replit, Gitpod to catalog

### DIFF
--- a/tools/dev-tools/context-mode.yaml
+++ b/tools/dev-tools/context-mode.yaml
@@ -1,0 +1,28 @@
+name: Context Mode
+description: MCP plugin that keeps large tool output out of the LLM context window by sandboxing it into a local FTS5 store. Agents search the store instead of re-sending raw logs, cutting context use by up to 98 percent across 17 coding platforms.
+tagline: Keep raw tool output out of the agent context window
+
+github_url: https://github.com/mksglu/context-mode
+website_url: https://context-mode.com
+docs_url: https://context-mode.com
+
+install_command: npm install -g context-mode
+
+category: Dev Tools
+tags: [mcp, context, coding-agents, claude-code, cursor, tokens, cli]
+pricing: freemium
+is_open_source: true
+license: Elastic-2.0
+
+problem_solved: |
+  Coding agents burn context on every grep, file read, and CLI dump, then resend
+  that payload every turn until the window is full. Context Mode intercepts large
+  tool output, stores it locally in FTS5, and lets the agent search it on demand,
+  so sessions stay cheap and long without changing how Claude Code, Cursor, or
+  Copilot work.
+
+use_cases:
+  - Cut token spend on Claude Code, Cursor, Codex, and Gemini CLI by sandboxing tool output
+  - Persist session knowledge in a local FTS5 store the agent can search instead of re-reading files
+  - Run the same MCP plugin across 17 adapters without sending source code to a cloud
+  - Add an org analytics layer on top of structural plugin events without shipping prompts off-machine

--- a/tools/dev-tools/gitpod.yaml
+++ b/tools/dev-tools/gitpod.yaml
@@ -1,0 +1,25 @@
+name: Gitpod
+description: Open-source platform for on-demand, API-first cloud development environments with OS-level isolation. Teams spin up preconfigured workspaces from a repo, with secrets, policies, and tooling ready in the cloud or self-hosted.
+tagline: On-demand cloud development environments from your repo
+
+github_url: https://github.com/gitpod-io/gitpod
+website_url: https://www.gitpod.io
+docs_url: https://www.gitpod.io/docs
+
+category: Dev Tools
+tags: [cloud-ide, dev-environments, kubernetes, self-hosted, workspaces, agpl]
+pricing: freemium
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Local machines drift, onboarding takes days, and AI coding agents need isolated
+  environments with the right secrets and tools. Gitpod provisions sandboxed
+  workspaces from a repository definition so every engineer and agent starts from
+  the same image, whether in Gitpod cloud or self-hosted infrastructure.
+
+use_cases:
+  - Spin up a ready-to-code workspace from a GitHub repo with dependencies preinstalled
+  - Give AI coding agents isolated, policy-controlled environments instead of a shared laptop
+  - Self-host cloud development environments on Kubernetes for source and secret control
+  - Standardize onboarding so new hires skip local setup and open a workspace URL

--- a/tools/dev-tools/lovable.yaml
+++ b/tools/dev-tools/lovable.yaml
@@ -1,0 +1,24 @@
+name: Lovable
+description: AI app builder that turns natural-language prompts into full-stack web products you can run and iterate in the browser. Teams describe an internal tool or startup product and Lovable generates, hosts, and evolves the software.
+tagline: Describe a product, ship a full-stack app
+
+website_url: https://lovable.dev
+docs_url: https://docs.lovable.dev
+
+category: Dev Tools
+tags: [ai-codegen, full-stack, no-code, vibe-coding, saas, web-apps]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Non-engineers and small teams often need production web apps without standing
+  up a frontend, backend, and hosting stack. Lovable generates full-stack software
+  from a prompt, then lets you iterate, deploy, and run the product on managed
+  infrastructure so internal tools and new products ship without a traditional
+  engineering cycle.
+
+use_cases:
+  - Build an internal dashboard or ops tool from a prompt and deploy it the same day
+  - Prototype a startup MVP as a hosted full-stack app without assembling a codebase first
+  - Let non-engineers iterate on production software with natural-language edits
+  - Replace point SaaS with custom Lovable-built tools that match a team's workflow

--- a/tools/dev-tools/replit.yaml
+++ b/tools/dev-tools/replit.yaml
@@ -1,0 +1,24 @@
+name: Replit
+description: Browser-based AI app builder and cloud IDE that turns prompts into hosted full-stack apps. Replit Agent writes, runs, and publishes code with built-in compute, databases, and deployment so teams skip local setup.
+tagline: Prompt-to-app cloud IDE with a built-in coding agent
+
+website_url: https://replit.com
+docs_url: https://docs.replit.com
+
+category: Dev Tools
+tags: [ai-codegen, cloud-ide, agents, full-stack, saas, deployment]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Turning an idea into a running app usually means local toolchains, hosting, and
+  a separate agent that cannot actually execute the code. Replit combines a cloud
+  IDE, runtime, and Agent that writes, tests, and publishes full-stack apps in
+  the browser so individuals and teams go from prompt to a live URL without
+  configuring machines.
+
+use_cases:
+  - Describe a web or mobile app and have Replit Agent generate, run, and publish it
+  - Prototype internal tools in a shared cloud IDE with databases and hosting included
+  - Teach or demo coding without installing a local development environment
+  - Route coding tasks across models and parallel agent work on one Replit project

--- a/tools/other/hyperframes.yaml
+++ b/tools/other/hyperframes.yaml
@@ -1,0 +1,28 @@
+name: Hyperframes
+description: Open-source framework from HeyGen for turning HTML, CSS, media, and seekable animations into deterministic MP4 videos. Agents write HTML, then the CLI lints, previews, and renders the same composition locally or in the cloud.
+tagline: Write HTML, render video, built for agents
+
+github_url: https://github.com/heygen-com/hyperframes
+website_url: https://hyperframes.heygen.com/introduction
+docs_url: https://hyperframes.heygen.com/quickstart
+
+install_command: npm install hyperframes
+
+category: Other
+tags: [video, html, agents, rendering, ffmpeg, motion-graphics, cli]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  AI agents can write HTML and CSS, but turning that into a deterministic MP4
+  usually means Remotion, After Effects, or brittle screenshot pipelines.
+  Hyperframes gives agents a composition contract, skills, and a CLI so they can
+  plan, lint, preview, and render frame-accurate video from HTML without a
+  proprietary editor.
+
+use_cases:
+  - Have a coding agent generate a promo video or motion graphic from HTML and CSS
+  - Render deterministic MP4s locally with headless Chrome and FFmpeg for automated content pipelines
+  - Port a Remotion composition to Hyperframes HTML and keep seekable animations
+  - Load Hyperframes skills in Claude Code, Cursor, Gemini CLI, or Codex to plan and render video


### PR DESCRIPTION
## Add 5 tools to the catalog

- **Hyperframes** (Other) — HTML-to-video renderer for agents (`heygen-com/hyperframes`, 47k+)
- **Context Mode** (Dev Tools) — MCP plugin that sandboxes tool output out of the LLM context window (`mksglu/context-mode`, 21k+)
- **Lovable** (Dev Tools) — AI full-stack app builder (lovable.dev)
- **Replit** (Dev Tools) — Cloud IDE and prompt-to-app agent platform
- **Gitpod** (Dev Tools) — On-demand cloud development environments (`gitpod-io/gitpod`, 13k+)

Skipped **Roo Code** (`RooCodeInc/Roo-Code` is archived).

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Context Mode, Gitpod, Lovable, and Replit, including descriptions, links, pricing, licensing, categories, and use cases.
  - Added a catalog entry for Hyperframes, highlighting its deterministic HTML-based video rendering capabilities, installation details, licensing, and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->