### PR TITLE
Add CodeSandbox to catalog

### DIFF
--- a/tools/dev-tools/codesandbox.yaml
+++ b/tools/dev-tools/codesandbox.yaml
@@ -1,0 +1,27 @@
+name: CodeSandbox
+description: Browser-based IDE for spinning up instant web development sandboxes from a repo, gist, or template. Teams prototype frontend and full-stack apps in isolated VMs, then share a live preview URL without local setup.
+tagline: Instant cloud sandboxes for web development
+
+github_url: https://github.com/codesandbox/codesandbox-client
+website_url: https://codesandbox.io
+docs_url: https://codesandbox.io/docs
+
+install_command: npm install -g codesandbox
+
+category: Dev Tools
+tags: [cloud-ide, sandbox, frontend, javascript, prototyping, saas]
+pricing: freemium
+is_open_source: true
+
+problem_solved: |
+  Sharing a running web app usually means cloning a repo, installing Node, and
+  debugging environment drift. CodeSandbox boots an isolated cloud sandbox from a
+  GitHub repo or template in seconds, with a live preview URL, so frontend and
+  full-stack prototypes can be edited, forked, and reviewed without a local
+  toolchain.
+
+use_cases:
+  - Open a GitHub frontend repo in a ready-to-run browser IDE with live preview
+  - Embed an editable React, Vue, or Node sandbox in docs and blog posts
+  - Prototype a UI experiment and share a URL instead of a local branch
+  - Use the CodeSandbox CLI to deploy a local template as a cloud sandbox


### PR DESCRIPTION
## Add CodeSandbox to the catalog

- **CodeSandbox** (Dev Tools) — Instant cloud sandboxes for web development (`codesandbox/codesandbox-client`, 13k+)

Remainder batch after PR #575. Local validation passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CodeSandbox to the developer tools catalog, including links, setup details, categorization, pricing, open-source status, and supported use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->