### PR TITLE
Add Remotion, Lottie, Excalidraw, tldraw, Penpot to catalog

### DIFF
--- a/tools/dev-tools/excalidraw.yaml
+++ b/tools/dev-tools/excalidraw.yaml
@@ -1,0 +1,27 @@
+name: Excalidraw
+description: Open-source virtual whiteboard for hand-drawn style diagrams. Teams sketch architecture, flows, and wireframes in the browser, then embed or self-host the editor as a React component.
+tagline: Virtual whiteboard for hand-drawn diagrams
+
+github_url: https://github.com/excalidraw/excalidraw
+website_url: https://excalidraw.com
+docs_url: https://docs.excalidraw.com
+
+install_command: npm install @excalidraw/excalidraw
+
+category: Dev Tools
+tags: [diagrams, whiteboard, react, collaboration, sketching, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Architecture and product sketches die in slide decks or proprietary whiteboards
+  that are hard to embed. Excalidraw gives a hand-drawn canvas in the browser and
+  as a React component, so diagrams stay shareable, versionable, and embeddable
+  in docs and internal tools.
+
+use_cases:
+  - Sketch system architecture and sequence diagrams in a shareable browser board
+  - Embed an Excalidraw canvas in a React docs or wiki site
+  - Collaborate on wireframes without a heavy design suite
+  - Self-host the editor so diagram data stays inside a company network

--- a/tools/dev-tools/penpot.yaml
+++ b/tools/dev-tools/penpot.yaml
@@ -1,0 +1,25 @@
+name: Penpot
+description: Open-source design and prototyping platform for product teams. Designers and developers collaborate on files that use open web standards, self-hosted or in Penpot cloud, without a proprietary lock-in.
+tagline: Open-source design platform for product teams
+
+github_url: https://github.com/penpot/penpot
+website_url: https://penpot.app
+docs_url: https://help.penpot.app
+
+category: Dev Tools
+tags: [design, prototyping, self-hosted, collaboration, svg, open-source]
+pricing: freemium
+is_open_source: true
+license: MPL-2.0
+
+problem_solved: |
+  Design tools are usually closed SaaS, so files, plugins, and handoff live
+  outside the engineering stack. Penpot is an open, self-hostable design
+  platform built on web standards, so product teams can collaborate on UI
+  without giving up ownership of the source.
+
+use_cases:
+  - Self-host a Figma-style design tool so UI files stay on company infrastructure
+  - Collaborate on UI kits and prototypes with designers and developers in one file
+  - Export SVG and CSS-friendly assets that match the web stack
+  - Replace proprietary design SaaS for teams that need an open, inspectable format

--- a/tools/dev-tools/tldraw.yaml
+++ b/tools/dev-tools/tldraw.yaml
@@ -1,0 +1,26 @@
+name: tldraw
+description: React SDK and infinite canvas for building drawing and whiteboard products. Ships the tldraw editor, shapes, and collaboration primitives so teams can embed a best-in-class canvas in their own apps.
+tagline: Infinite canvas SDK for React apps
+
+github_url: https://github.com/tldraw/tldraw
+website_url: https://tldraw.dev
+docs_url: https://tldraw.dev
+
+install_command: npm install tldraw
+
+category: Dev Tools
+tags: [canvas, react, whiteboard, sdk, collaboration, javascript]
+pricing: freemium
+is_open_source: true
+
+problem_solved: |
+  Product teams that need a real infinite canvas usually rebuild selection,
+  shapes, undo, and multiplayer from scratch. tldraw is a React SDK with those
+  primitives, so you can ship a drawing, diagram, or spatial UI inside your app
+  instead of linking out to a separate whiteboard.
+
+use_cases:
+  - Embed a collaborative whiteboard inside a React product with the tldraw SDK
+  - Build a custom infinite-canvas editor with first-party shapes and tools
+  - Prototype spatial UIs and agent-drawn diagrams on a real canvas
+  - Add multiplayer drawing to an internal design or planning tool

--- a/tools/other/lottie.yaml
+++ b/tools/other/lottie.yaml
@@ -1,0 +1,27 @@
+name: Lottie
+description: Library for rendering After Effects animations natively on web, Android, iOS, and React Native. Designers export Bodymovin JSON; apps play the same vector animation without heavy video files or hand-coded motion.
+tagline: Play After Effects animations natively on any platform
+
+github_url: https://github.com/airbnb/lottie-web
+website_url: https://airbnb.io/lottie/
+docs_url: https://airbnb.io/lottie/
+
+install_command: npm install lottie-web
+
+category: Other
+tags: [animation, after-effects, vector, web, mobile, javascript]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Shipping motion from After Effects usually means giant GIFs, raster video, or
+  rewriting the animation in code. Lottie plays Bodymovin JSON natively on web
+  and mobile, so the same designer-authored animation stays sharp, small, and
+  interactive across platforms.
+
+use_cases:
+  - Drop a designer-exported Lottie JSON into a React or vanilla web app
+  - Ship the same vector loader or empty-state animation on iOS, Android, and web
+  - Replace GIF or MP4 UI motion with resolution-independent Lottie files
+  - Trigger, loop, and seek animations from application state without recoding them

--- a/tools/other/remotion.yaml
+++ b/tools/other/remotion.yaml
@@ -1,0 +1,26 @@
+name: Remotion
+description: Framework for creating videos programmatically with React. Developers compose scenes as React components, then render deterministic MP4s locally or in the cloud for product explainers, social clips, and data-driven motion.
+tagline: Make videos programmatically with React
+
+github_url: https://github.com/remotion-dev/remotion
+website_url: https://www.remotion.dev
+docs_url: https://www.remotion.dev/docs
+
+install_command: npm install remotion
+
+category: Other
+tags: [video, react, programmatic, animation, rendering, javascript]
+pricing: freemium
+is_open_source: true
+
+problem_solved: |
+  Product and content teams need repeatable video from code and data, not from
+  timeline editors. Remotion lets you write React components that describe every
+  frame, then render MP4s in CI or the cloud, so explainers, parameterized clips,
+  and generated social video stay in version control next to the app.
+
+use_cases:
+  - Generate product explainer videos from React components in a CI pipeline
+  - Render personalized MP4s from templates filled with user or analytics data
+  - Build social and launch clips that stay in Git beside the product codebase
+  - Preview compositions in the Remotion Studio and render locally or on Lambda


### PR DESCRIPTION
## Add 5 tools to the catalog

- **Remotion** (Other) — Programmatic React video (`remotion-dev/remotion`, 58k+)
- **Lottie** (Other) — After Effects animations on web and mobile (`airbnb/lottie-web`, 32k+)
- **Excalidraw** (Dev Tools) — Hand-drawn virtual whiteboard (`excalidraw/excalidraw`, 131k+)
- **tldraw** (Dev Tools) — Infinite canvas React SDK (`tldraw/tldraw`, 50k+)
- **Penpot** (Dev Tools) — Open-source design platform (`penpot/penpot`, 59k+)

Local validation passed for all five YAML files.
