### PR TITLE
Add v0, Devin, Glean to catalog

### DIFF
--- a/tools/dev-tools/devin.yaml
+++ b/tools/dev-tools/devin.yaml
@@ -1,0 +1,23 @@
+name: Devin
+description: Autonomous AI software engineer from Cognition that picks up tickets, writes code, runs tests, and opens pull requests. Devin works across GitHub, Linear, and Slack on multi-repo tasks such as migrations, bug fixes, and PR review.
+tagline: AI software engineer that ships pull requests
+
+website_url: https://devin.ai
+docs_url: https://docs.devin.ai
+
+category: Dev Tools
+tags: [ai-codegen, agents, autonomous, github, enterprise, saas]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Engineering teams have a backlog of migrations, chores, and bugs that do not
+  need a senior in the loop for every line. Devin is an AI software engineer
+  that learns the codebase, works in its own environment, and opens PRs through
+  GitHub, Linear, and Slack so those tasks move without blocking the team.
+
+use_cases:
+  - Assign Linear tickets or Slack threads to Devin and review the resulting pull request
+  - Run code migrations and refactors across multiple repositories with a team of Devins
+  - Triage production bugs, reproduce them, and open a fix PR with tests
+  - Automate PR review, visual QA, and scheduled maintenance via the Devin API

--- a/tools/dev-tools/glean.yaml
+++ b/tools/dev-tools/glean.yaml
@@ -1,0 +1,23 @@
+name: Glean
+description: Enterprise AI platform for search, assistants, and agents grounded in company knowledge. Glean connects 250-plus workplace apps so employees can find answers, generate content, and run governed agents without leaking context.
+tagline: Enterprise AI search, assistant, and agents
+
+website_url: https://www.glean.com
+docs_url: https://docs.glean.com
+
+category: Dev Tools
+tags: [enterprise-search, agents, rag, workplace, saas, governance]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Company knowledge is scattered across Drive, Slack, tickets, and wikis, so
+  generic chatbots hallucinate or ignore permissions. Glean indexes workplace
+  apps with access control, then powers an assistant and agent builder so
+  answers and automations stay grounded in enterprise context.
+
+use_cases:
+  - Search across Slack, Google Drive, Jira, and Confluence with permission-aware results
+  - Ask a workplace assistant to draft content grounded in internal docs
+  - Build governed agents that take actions across 250-plus enterprise connectors
+  - Give engineering and support teams a shared AI gateway with usage and security controls

--- a/tools/dev-tools/v0.yaml
+++ b/tools/dev-tools/v0.yaml
@@ -1,0 +1,24 @@
+name: v0
+description: Vercel's AI builder that turns prompts into full-stack web apps you can edit, sync to GitHub, and deploy. v0 plans tasks, generates UI and backend code, and publishes live sites on Vercel in minutes.
+tagline: Prompt, build, and publish full-stack apps on Vercel
+
+website_url: https://v0.dev
+docs_url: https://v0.dev/docs
+
+category: Dev Tools
+tags: [ai-codegen, vercel, nextjs, ui, full-stack, saas]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Going from a UI idea to a deployed Next.js app still means scaffolding,
+  component work, and a separate deploy step. v0 generates working applications
+  from a prompt, lets you refine them in a visual editor, and publishes to
+  Vercel so product teams can ship landing pages, dashboards, and full-stack
+  apps without starting from a blank repo.
+
+use_cases:
+  - Generate a landing page or dashboard from a prompt and deploy it to Vercel
+  - Iterate on UI in design mode, then sync the generated code to GitHub
+  - Prototype full-stack apps that connect to APIs and databases from the chat
+  - Start from v0 templates for components, dashboards, and marketing sites


### PR DESCRIPTION
## Add 3 tools to the catalog

- **v0** (Dev Tools) — Vercel AI full-stack app builder (v0.dev)
- **Devin** (Dev Tools) — Cognition's AI software engineer (devin.ai)
- **Glean** (Dev Tools) — Enterprise AI search, assistant, and agents (glean.com)

Skipped **Firebase Studio** (sunset in progress; new signups already disabled).

Local validation passed.
