### PR TITLE
Add Gemini Code Assist, You.com, Rive to catalog

### DIFF
--- a/tools/dev-tools/gemini-code-assist.yaml
+++ b/tools/dev-tools/gemini-code-assist.yaml
@@ -1,0 +1,23 @@
+name: Gemini Code Assist
+description: Google's IDE coding assistant for VS Code, JetBrains, and Android Studio. It completes code, chats over open files, and runs agent mode so ML teams get Gemini help without leaving the editor.
+tagline: Gemini coding assistant inside VS Code and JetBrains
+
+website_url: https://developers.google.com/gemini-code-assist
+docs_url: https://developers.google.com/gemini-code-assist/docs
+
+category: Dev Tools
+tags: [ide, code-generation, google, vscode, jetbrains, pair-programming, agents]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Terminal Gemini CLI does not cover the IDE loop of completions, inline
+  chat, and multi-file agent edits. Gemini Code Assist sits in VS Code,
+  JetBrains, and Android Studio, with optional Enterprise customization
+  on private repos so suggestions match internal APIs and style.
+
+use_cases:
+  - Complete Python training and serving code inline in VS Code or PyCharm
+  - Chat over open files to explain, test, and debug an agent service
+  - Run agent mode for multi-step refactors with MCP tools attached
+  - Point Enterprise customization at private libraries for in-house APIs

--- a/tools/dev-tools/you-com.yaml
+++ b/tools/dev-tools/you-com.yaml
@@ -1,0 +1,25 @@
+name: You.com
+description: Enterprise web search APIs built for RAG and agents. Search, Contents, and Research endpoints return cited, real-time results so LLM apps ground answers on the live web instead of stale training data.
+tagline: Real-time web search APIs for RAG and agents
+
+website_url: https://you.com
+docs_url: https://you.com/docs/welcome
+
+install_command: pip install youdotcom
+
+category: Dev Tools
+tags: [search, rag, api, agents, python, web, grounding]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  LLM agents hallucinate when they cannot query the live web, and generic
+  search APIs return noisy snippets. You.com exposes Search, Contents, and
+  Research APIs plus an MCP server so RAG pipelines and coding agents get
+  cited, low-latency results instead of stale training-cut knowledge.
+
+use_cases:
+  - Ground an agent with live web search and citations via the Python SDK
+  - Fetch clean Markdown from known URLs with the Contents API
+  - Attach the You.com MCP server to Claude Code or Cursor for web search
+  - Run deep research queries that return source-backed answers for RAG

--- a/tools/other/rive.yaml
+++ b/tools/other/rive.yaml
@@ -1,0 +1,26 @@
+name: Rive
+description: Editor, file format, and runtimes for interactive vector animation. Designers build state machines in the browser; apps play the same .riv file on web, iOS, Android, Flutter, and games without video or GIF exports.
+tagline: Interactive vector animation with a tiny runtime
+
+github_url: https://github.com/rive-app/rive-runtime
+website_url: https://rive.app
+docs_url: https://rive.app/docs
+
+install_command: npm install @rive-app/react-canvas
+
+category: Other
+tags: [animation, vector, react, flutter, web, mobile, design]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Lottie plays timeline motion, but interactive UI needs states, mixing, and
+  data binding. Rive ships an editor plus open runtimes so the same .riv
+  file responds to input on web and mobile, without recoding the animation
+  as CSS or a game engine scene.
+
+use_cases:
+  - Drive a button or mascot with a Rive state machine in a React app
+  - Ship the same interactive graphic on iOS, Android, Flutter, and web
+  - Bind animation properties to app data instead of exporting a new video
+  - Replace GIF loaders with a small .riv runtime on a product site


### PR DESCRIPTION
## Adds 3 tools to the catalog

- **Gemini Code Assist** (Dev Tools) — Google IDE coding assistant for VS Code and JetBrains
- **You.com** (Dev Tools) — Real-time web search APIs for RAG and agents
- **Rive** (Other) — Interactive vector animation editor and runtimes

Skipped **Terrascan** (tenable/terrascan is archived).

Local validation passed for all three YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Gemini Code Assist to the Dev Tools catalog, including links, pricing, tags, and supported use cases.
  - Added You.com’s enterprise web search API with installation details, documentation, and integration use cases.
  - Added Rive to the tools catalog with setup information, resources, and animation-focused use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->