### PR TITLE
Add Framer, Webflow, Canva, lint-staged, Changesets to catalog

### DIFF
--- a/tools/dev-tools/changesets.yaml
+++ b/tools/dev-tools/changesets.yaml
@@ -1,0 +1,27 @@
+name: Changesets
+description: Versioning and changelog tool for JavaScript monorepos. Contributors add a changeset per PR; CI versions packages, writes changelogs, and publishes without a manual bump ritual.
+tagline: Monorepo versioning and changelogs from PR changesets
+
+github_url: https://github.com/changesets/changesets
+website_url: https://github.com/changesets/changesets
+docs_url: https://github.com/changesets/changesets
+
+install_command: npm install @changesets/cli
+
+category: Dev Tools
+tags: [javascript, monorepo, versioning, changelog, npm, publishing, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Multi-package JS repos need coordinated version bumps and changelogs,
+  and doing that by hand misses dependents. Changesets lets each PR declare
+  a bump; CI versions packages, writes notes, and publishes so SDK and
+  agent-library monorepos stay consistent.
+
+use_cases:
+  - Add a changeset in a PR so CI versions an SDK package on merge
+  - Generate changelogs for a JS monorepo without editing CHANGELOG by hand
+  - Publish dependent packages with coordinated semantic versions
+  - Keep an open-source agent library's release notes tied to merged PRs

--- a/tools/dev-tools/framer.yaml
+++ b/tools/dev-tools/framer.yaml
@@ -1,0 +1,23 @@
+name: Framer
+description: Visual website builder that publishes production sites from a canvas. Designers ship marketing pages and AI product sites with CMS, breakpoints, and code components in one file, without a separate frontend repo.
+tagline: Visual site builder that publishes production web pages
+
+website_url: https://www.framer.com
+docs_url: https://www.framer.com/help
+
+category: Dev Tools
+tags: [website-builder, design, cms, no-code, react, hosting]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Marketing and product sites stall when every layout change needs an
+  engineer. Framer lets teams design on a canvas and publish a production
+  site with CMS and breakpoints, so AI product pages ship without a
+  separate Next.js marketing repo.
+
+use_cases:
+  - Publish a product marketing site from a visual canvas without a custom frontend
+  - Add a CMS collection for changelog or tool-catalog stories on a Framer site
+  - Mix designed sections with code components for an AI product landing page
+  - Iterate breakpoints and copy on a live URL without a deploy pipeline

--- a/tools/dev-tools/lint-staged.yaml
+++ b/tools/dev-tools/lint-staged.yaml
@@ -1,0 +1,27 @@
+name: lint-staged
+description: Runs linters and formatters only on git-staged files. Drop it in a pre-commit hook so Python and JS ML repos fail fast on the files you actually touched, not the whole monorepo.
+tagline: Run linters only on git-staged files
+
+github_url: https://github.com/lint-staged/lint-staged
+website_url: https://github.com/lint-staged/lint-staged
+docs_url: https://github.com/lint-staged/lint-staged#readme
+
+install_command: npm install lint-staged
+
+category: Dev Tools
+tags: [javascript, git, lint, pre-commit, monorepo, ci, open-source]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Full-repo lint on every commit is slow in JS and Python monorepos, so
+  people skip hooks. lint-staged runs formatters and linters only on
+  staged files, so pre-commit stays fast and still blocks bad diffs in
+  agent and web app repos.
+
+use_cases:
+  - Run Prettier and ESLint only on staged JS files before commit
+  - Keep a Python ML monorepo hook fast by linting touched files only
+  - Pair with Husky or leftover git hooks so CI style checks fail locally
+  - Avoid rewriting an entire generated folder when one source file changed

--- a/tools/dev-tools/webflow.yaml
+++ b/tools/dev-tools/webflow.yaml
@@ -1,0 +1,23 @@
+name: Webflow
+description: Visual web development platform for marketing sites and CMS content. Teams design in the browser, publish on Webflow hosting, and structure collections without writing the layout from scratch.
+tagline: Visual web development platform with CMS and hosting
+
+website_url: https://webflow.com
+docs_url: https://developers.webflow.com
+
+category: Dev Tools
+tags: [website-builder, cms, design, no-code, hosting, api]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Product sites need a CMS, hosting, and design control, but a custom
+  stack is slow for marketing. Webflow is a visual builder with
+  collections and an API, so teams publish branded pages and content
+  models without standing up WordPress or a headless CMS first.
+
+use_cases:
+  - Build a marketing site for an AI product with CMS collections for posts
+  - Publish landing pages on Webflow hosting without managing servers
+  - Pull Webflow CMS items into an app through the Data API
+  - Hand designers a visual canvas that still outputs production HTML and CSS

--- a/tools/other/canva.yaml
+++ b/tools/other/canva.yaml
@@ -1,0 +1,23 @@
+name: Canva
+description: Browser design platform for decks, social graphics, docs, and video. Magic Studio and Brand Kits let product and DevRel teams produce on-brand visuals without a dedicated designer on every asset.
+tagline: Browser design platform with Brand Kits and Magic Studio
+
+website_url: https://www.canva.com
+docs_url: https://www.canva.com/developers/
+
+category: Other
+tags: [design, graphics, presentations, collaboration, ai, brand]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  DevRel and product teams need slides, social cuts, and one-pagers on a
+  deadline, but Figma is heavy for that work. Canva ships templates, Brand
+  Kits, and Magic Studio so non-designers produce on-brand assets without
+  waiting on a design queue.
+
+use_cases:
+  - Build a talk deck or one-pager from a Brand Kit without a designer
+  - Generate social graphics for a product launch with Magic Studio
+  - Collaborate on event visuals in the browser with comments and sharing
+  - Export print and video assets from the same Canva file


### PR DESCRIPTION
## Adds 5 tools to the catalog

- **Framer** (Dev Tools) — Visual site builder that publishes production web pages
- **Webflow** (Dev Tools) — Visual web development platform with CMS and hosting
- **Canva** (Other) — Browser design platform with Brand Kits and Magic Studio
- **lint-staged** (Dev Tools) — Run linters only on git-staged files
- **Changesets** (Dev Tools) — Monorepo versioning and changelogs from PR changesets

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Changesets, Framer, lint-staged, Webflow, and Canva.
  * Each profile includes tool descriptions, categories, tags, pricing and licensing details, relevant links, and representative use cases.
  * Added practical guidance covering monorepo versioning, visual website creation, staged-file linting, CMS and marketing site workflows, and design asset creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->