### PR TITLE
Add GitLab, Fly.io, Render, Vaultwarden, KeePassXC to catalog

### DIFF
--- a/tools/dev-tools/fly-io.yaml
+++ b/tools/dev-tools/fly-io.yaml
@@ -1,0 +1,27 @@
+name: Fly.io
+description: Edge deployment platform that runs Docker images close to users across many regions. Package an agent API or model server as a container and launch it globally with one CLI, without assembling Kubernetes.
+tagline: Deploy Docker apps close to users with one CLI
+
+github_url: https://github.com/superfly/flyctl
+website_url: https://fly.io
+docs_url: https://fly.io/docs
+
+install_command: brew install flyctl
+
+category: Dev Tools
+tags: [paas, deployment, docker, edge, cli, hosting]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Agent APIs and small model servers need low-latency HTTPS in more than one
+  region, but standing up Kubernetes for that is overkill. Fly.io takes a
+  Docker image, places machines near users, and gives you logs, volumes, and
+  a private network so a two-person team can ship without a platform squad.
+
+use_cases:
+  - Deploy an agent or MCP HTTP server from a Dockerfile with flyctl
+  - Run a small inference API in multiple regions without managing Kubernetes
+  - Attach a volume for model weights next to a GPU or CPU Fly Machine
+  - Keep LLM API keys in Fly secrets instead of baking them into the image
+  - Scale a production agent backend up and down from the Fly CLI

--- a/tools/dev-tools/gitlab.yaml
+++ b/tools/dev-tools/gitlab.yaml
@@ -1,0 +1,26 @@
+name: GitLab
+description: DevOps platform that unifies Git hosting, CI/CD, package registries, and security scanning. ML teams run training pipelines, store model artifacts, and review agent code in one place instead of stitching GitHub, Jenkins, and a separate registry.
+tagline: Git, CI/CD, and package registry in one DevOps platform
+
+github_url: https://github.com/gitlabhq/gitlabhq
+website_url: https://about.gitlab.com
+docs_url: https://docs.gitlab.com
+
+category: Dev Tools
+tags: [git, ci-cd, devops, registry, security, self-hosted]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Shipping an ML product still means a Git host, a CI runner, a container registry,
+  and a place to review model-serving code. GitLab puts those in one platform so
+  training jobs, artifact publishes, and merge reviews share the same project
+  instead of five disconnected tools.
+
+use_cases:
+  - Run GPU training and eval jobs as GitLab CI pipelines on self-hosted runners
+  - Store model images and Python packages in the project container and package registry
+  - Review agent and MCP server changes with merge requests and CI quality gates
+  - Self-host source, CI, and artifacts when model weights cannot leave a private network
+  - Scan dependency and container images used by inference services before they ship

--- a/tools/dev-tools/keepassxc.yaml
+++ b/tools/dev-tools/keepassxc.yaml
@@ -1,0 +1,28 @@
+name: KeePassXC
+description: Cross-platform open-source password manager that stores credentials in a local encrypted database. ML engineers keep LLM API keys, cloud tokens, and SSH passphrases in a KeePass-compatible vault instead of plaintext files.
+tagline: Local encrypted password database for keys and credentials
+
+github_url: https://github.com/keepassxreboot/keepassxc
+website_url: https://keepassxc.org
+docs_url: https://keepassxc.org/docs/
+
+install_command: brew install --cask keepassxc
+
+category: Dev Tools
+tags: [passwords, secrets, vault, desktop, security, credentials]
+pricing: free
+is_open_source: true
+license: GPL-3.0
+
+problem_solved: |
+  Local shells and notebooks still pull OpenAI keys and cloud tokens from
+  unencrypted notes. KeePassXC keeps those secrets in a local KDBX database
+  with a desktop app and CLI, so credentials never sit in a repo or a chat
+  log and can travel on a USB key or encrypted volume.
+
+use_cases:
+  - Store OpenAI, Anthropic, and cloud tokens in a local encrypted KDBX file
+  - Unlock SSH passphrases and API keys from the KeePassXC desktop app during training
+  - Share a team KDBX over a private volume without a hosted password SaaS
+  - Autotype staging logins during demos without keeping passwords in a notes app
+  - Keep a portable credential database next to a laptop that is often offline

--- a/tools/dev-tools/render.yaml
+++ b/tools/dev-tools/render.yaml
@@ -1,0 +1,23 @@
+name: Render
+description: Cloud platform that deploys web services, background workers, and Postgres from Git. ML teams host agent APIs, MCP servers, and small inference backends with HTTPS and logs, without operating a cluster.
+tagline: Git-based hosting for web services, workers, and databases
+
+website_url: https://render.com
+docs_url: https://render.com/docs
+
+category: Dev Tools
+tags: [paas, deployment, hosting, git, postgres, workers]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  A prototype agent API still needs HTTPS, a worker, a database, and logs.
+  Render builds from Git, provisions Postgres and Redis, and runs background
+  workers so small AI products can go live without assembling AWS or Kubernetes.
+
+use_cases:
+  - Deploy an agent or MCP server from a GitHub repo with automatic HTTPS
+  - Run a background worker that processes embedding or eval jobs
+  - Provision Postgres next to a model-serving API without a separate cloud account
+  - Preview pull requests that change a chat or inference web app
+  - Store LLM API keys as Render environment groups instead of in source

--- a/tools/dev-tools/vaultwarden.yaml
+++ b/tools/dev-tools/vaultwarden.yaml
@@ -1,0 +1,25 @@
+name: Vaultwarden
+description: Unofficial Bitwarden-compatible server written in Rust. Self-host an encrypted password vault for API keys and cloud credentials with a lighter footprint than the official Bitwarden server, using existing Bitwarden clients.
+tagline: Lightweight self-hosted Bitwarden-compatible vault server
+
+github_url: https://github.com/dani-garcia/vaultwarden
+docs_url: https://github.com/dani-garcia/vaultwarden/wiki
+
+category: Dev Tools
+tags: [secrets, passwords, vault, self-hosted, rust, bitwarden]
+pricing: free
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Official Bitwarden server is heavy for a small lab that just needs a private
+  vault for OpenAI keys and cloud creds. Vaultwarden speaks the Bitwarden API
+  in a single Rust binary so teams self-host with existing browser extensions
+  and CLI, without running the full Bitwarden stack.
+
+use_cases:
+  - Self-host a team vault for LLM API keys on a single Docker host
+  - Use Bitwarden browser extensions against a private Vaultwarden server
+  - Keep Hugging Face and cloud tokens off Slack and plaintext .env files
+  - Run an air-gapped credential vault for on-prem training clusters
+  - Share staging logins with Bitwarden clients without a SaaS password vendor


### PR DESCRIPTION
## Add GitLab, Fly.io, Render, Vaultwarden, KeePassXC to catalog

Dev Tools batch for the Agentic AI For Good catalog.

| Tool | Category | Why it belongs |
|---|---|---|
| GitLab | Dev Tools | Unified Git, CI/CD, and package registry for ML pipelines |
| Fly.io | Dev Tools | Edge Docker hosting for agent APIs without Kubernetes |
| Render | Dev Tools | Git-based PaaS for web services, workers, and Postgres |
| Vaultwarden | Dev Tools | Lightweight self-hosted Bitwarden-compatible vault |
| KeePassXC | Dev Tools | Local encrypted KDBX vault for API keys and credentials |

Local validation: all five files passed `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fly.io, GitLab, KeePassXC, Render, and Vaultwarden to the developer tools catalog.
  * Included descriptions, links, installation details, pricing, licensing, categories, tags, and practical use cases for each tool.
  * Added guidance covering deployment, CI/CD, credential management, infrastructure, hosting, and database workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->