### PR TITLE
Add CapRover, 1Password, chamber, ProtoPie to catalog

### DIFF
--- a/tools/dev-tools/1password.yaml
+++ b/tools/dev-tools/1password.yaml
@@ -1,0 +1,26 @@
+name: 1Password
+description: Password manager and secrets platform with a CLI that injects credentials into shells and CI. ML teams keep LLM API keys, cloud tokens, and SSH keys in a vault and load them at runtime instead of committing .env files.
+tagline: Vault and CLI for API keys, SSH, and CI secrets
+
+website_url: https://1password.com
+docs_url: https://developer.1password.com/docs/cli
+
+install_command: brew install --cask 1password-cli
+
+category: Dev Tools
+tags: [secrets, passwords, vault, cli, security, credentials]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Training laptops and GitHub Actions still paste OpenAI keys into .env files
+  and workflow YAML. 1Password stores those secrets in an encrypted vault and
+  the CLI injects them into a shell or CI job so credentials are never written
+  to disk in plaintext.
+
+use_cases:
+  - Load OpenAI and cloud tokens into a training shell with op run
+  - Inject Hugging Face tokens into GitHub Actions without repo secrets sprawl
+  - Store SSH keys for GPU boxes in a shared vault instead of copying pem files
+  - Autofill staging dashboards during demos from the 1Password browser extension
+  - Rotate an API key once in the vault instead of chasing local .env copies

--- a/tools/dev-tools/caprover.yaml
+++ b/tools/dev-tools/caprover.yaml
@@ -1,0 +1,27 @@
+name: CapRover
+description: Self-hosted PaaS that deploys Docker apps with nginx, HTTPS, and one-click databases. ML teams run agent APIs, MCP servers, and small inference backends on their own VPS without assembling Kubernetes.
+tagline: Self-hosted Heroku-style PaaS on Docker and nginx
+
+github_url: https://github.com/caprover/caprover
+website_url: https://caprover.com
+docs_url: https://caprover.com/docs
+
+install_command: npm install -g caprover
+
+category: Dev Tools
+tags: [paas, docker, nginx, self-hosted, deployment, cli]
+pricing: free
+is_open_source: true
+
+problem_solved: |
+  A private GPU box or cheap VPS still needs HTTPS, a reverse proxy, and a
+  deploy path for agent APIs. CapRover wraps Docker and nginx so you ship
+  from Git or an image with web UI and CLI, without running a full Kubernetes
+  control plane for a handful of services.
+
+use_cases:
+  - Deploy an agent or MCP HTTP server to a VPS with automatic HTTPS
+  - One-click Postgres or Redis next to a small inference API
+  - Push a Docker image of a model server and scale replicas from the CapRover UI
+  - Host a private Hugging Face Space-style demo on hardware you already rent
+  - Manage env vars for LLM keys without baking them into the container

--- a/tools/dev-tools/chamber.yaml
+++ b/tools/dev-tools/chamber.yaml
@@ -1,0 +1,27 @@
+name: chamber
+description: CLI that stores and reads secrets from AWS SSM Parameter Store. ML pipelines export LLM keys and database passwords as environment variables at job start without putting them in Terraform state or Docker images.
+tagline: AWS SSM Parameter Store CLI for app secrets
+
+github_url: https://github.com/segmentio/chamber
+docs_url: https://github.com/segmentio/chamber
+
+install_command: brew install chamber
+
+category: Dev Tools
+tags: [secrets, aws, ssm, cli, devops, credentials]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AWS shops still bake OpenAI keys and DB passwords into task definitions or
+  .env files on disk. chamber writes those values to SSM Parameter Store and
+  execs your process with them as env vars, so training jobs and model servers
+  get credentials without a second secrets product.
+
+use_cases:
+  - Export LLM API keys into a training job with chamber exec
+  - Store per-service database passwords in SSM instead of in Docker Compose files
+  - Share staging secrets across ECS tasks without copying .env between laptops
+  - Rotate a model-registry token in Parameter Store without rebuilding the image
+  - List and read namespaced secrets for an inference service from the CLI

--- a/tools/dev-tools/protopie.yaml
+++ b/tools/dev-tools/protopie.yaml
@@ -1,0 +1,24 @@
+name: ProtoPie
+description: Interaction design tool for high-fidelity prototypes with sensors, hardware, and conditional logic. Product teams mock agent UIs, voice flows, and on-device ML experiences before writing production code.
+tagline: High-fidelity prototypes with sensors, hardware, and logic
+
+website_url: https://www.protopie.io
+docs_url: https://www.protopie.io/learn
+
+category: Dev Tools
+tags: [prototyping, design, interaction, ux, hardware, no-code]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Agent and on-device ML products need realistic UI flows before the model
+  is ready. Static mockups cannot show voice, sensors, or conditional logic.
+  ProtoPie lets designers prototype those interactions and hand them to
+  engineers without waiting on a working inference backend.
+
+use_cases:
+  - Prototype a multimodal agent UI with voice, camera, and conditional responses
+  - Test on-device ML flows on a phone before the model ships
+  - Share an interactive demo of a copilot with stakeholders who cannot run the stack
+  - Connect hardware sensors to a prototype of an edge AI product
+  - Hand off interaction specs to engineers without rebuilding the flow in code


### PR DESCRIPTION
## Add CapRover, 1Password, chamber, ProtoPie to catalog

Remainder Dev Tools batch for the Agentic AI For Good catalog.

| Tool | Category | Why it belongs |
|---|---|---|
| CapRover | Dev Tools | Self-hosted Docker PaaS for agent APIs on a VPS |
| 1Password | Dev Tools | Vault and CLI for LLM keys and CI secrets |
| chamber | Dev Tools | AWS SSM Parameter Store CLI for app secrets |
| ProtoPie | Dev Tools | High-fidelity prototypes for agent and on-device ML UIs |

Local validation: all four files passed `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for 1Password, CapRover, chamber, and ProtoPie.
  - Included descriptions, links, installation guidance, classifications, licensing and pricing details, and practical use cases.
  - Documented applications including secret management, VPS deployment, AWS parameter storage, and prototyping agent or on-device ML interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->