### PR TITLE
Add Doppler, Koyeb, Heroku, Netlify, Gogs to catalog

### DIFF
--- a/tools/dev-tools/doppler.yaml
+++ b/tools/dev-tools/doppler.yaml
@@ -1,0 +1,27 @@
+name: Doppler
+description: Secrets platform that syncs API keys and config across local shells, CI, and cloud runtimes. ML teams keep LLM tokens and cloud credentials in one vault and inject them at runtime instead of copying .env files.
+tagline: Sync secrets from a vault into shells, CI, and cloud
+
+github_url: https://github.com/DopplerHQ/cli
+website_url: https://www.doppler.com
+docs_url: https://docs.doppler.com
+
+install_command: brew install doppler
+
+category: Dev Tools
+tags: [secrets, env, cli, ci-cd, credentials, devops]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Agent APIs and training jobs still scatter OpenAI keys across .env files,
+  GitHub secrets, and cloud consoles. Doppler stores those values once and
+  injects them into a local shell, CI job, or container so credentials stay
+  out of git and stay in sync across environments.
+
+use_cases:
+  - Load LLM API keys into a training shell with doppler run
+  - Sync staging and production secrets for an agent API without hand-editing .env
+  - Inject Hugging Face tokens into GitHub Actions from Doppler
+  - Rotate a cloud credential once and have every runtime pick it up
+  - Share a project config with teammates without sending keys in Slack

--- a/tools/dev-tools/gogs.yaml
+++ b/tools/dev-tools/gogs.yaml
@@ -1,0 +1,26 @@
+name: Gogs
+description: Lightweight self-hosted Git service written in Go. Teams keep agent code, model cards, and experiment notes on a single binary with a GitHub-like UI, without running GitLab or GitHub Enterprise.
+tagline: Single-binary self-hosted Git with a GitHub-like UI
+
+github_url: https://github.com/gogs/gogs
+website_url: https://gogs.io
+docs_url: https://gogs.io/docs
+
+category: Dev Tools
+tags: [git, self-hosted, go, devops, source-control]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  On-prem ML labs still need Git with issues and a web UI, but GitLab is
+  heavy and GitHub cannot hold private model code. Gogs is a single Go
+  binary that hosts repos on a VPS so training code stays inside the
+  network without a full DevOps platform.
+
+use_cases:
+  - Self-host agent and training repos on a lab VPS with a GitHub-like UI
+  - Keep model cards and experiment notes next to code without a SaaS git host
+  - Mirror internal forks when weights and data cannot leave a private network
+  - Run a lightweight git forge for a small ML team that does not need GitLab CI
+  - Back up research code to a box you control instead of a public cloud

--- a/tools/dev-tools/heroku.yaml
+++ b/tools/dev-tools/heroku.yaml
@@ -1,0 +1,27 @@
+name: Heroku
+description: Classic PaaS that builds and runs apps from a Git push. ML teams still use it to host agent APIs, workers, and Postgres-backed prototypes with add-ons, without assembling AWS or Kubernetes.
+tagline: Git-push PaaS for apps, workers, and add-on databases
+
+github_url: https://github.com/heroku/cli
+website_url: https://www.heroku.com
+docs_url: https://devcenter.heroku.com
+
+install_command: npm install -g heroku
+
+category: Dev Tools
+tags: [paas, deployment, git, postgres, workers, cli]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Early agent products need a URL, a worker, and a database tonight, not a
+  cloud landing zone. Heroku builds from Git, attaches Postgres and Redis
+  add-ons, and runs dynos so a two-person team can ship an MCP server without
+  becoming a platform squad.
+
+use_cases:
+  - Git-push an agent API and get HTTPS without writing a Dockerfile first
+  - Attach Postgres or Redis for session memory next to a chat backend
+  - Run a background worker that processes embedding or eval jobs
+  - Manage LLM keys as Heroku config vars instead of committing .env files
+  - Scale a small production dyno up for a demo and down afterward

--- a/tools/dev-tools/koyeb.yaml
+++ b/tools/dev-tools/koyeb.yaml
@@ -1,0 +1,24 @@
+name: Koyeb
+description: Serverless platform that deploys apps and GPU workloads from Git or Docker. ML teams host agent APIs, MCP servers, and small inference services with autoscaling and global edge, without operating Kubernetes.
+tagline: Serverless Git and GPU deploys without Kubernetes
+
+website_url: https://www.koyeb.com
+docs_url: https://www.koyeb.com/docs
+
+category: Dev Tools
+tags: [paas, serverless, gpu, deployment, docker, hosting]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  A prototype inference API still needs HTTPS, autoscaling, and sometimes a
+  GPU, but a Kubernetes cluster is too much ops. Koyeb builds from Git or a
+  Docker image and runs CPU or GPU services so small AI products can ship
+  without a platform team.
+
+use_cases:
+  - Deploy an agent or MCP HTTP server from a GitHub repo
+  - Run a small GPU inference service without renting a full cloud VM
+  - Autoscale a production agent backend from zero when traffic is idle
+  - Host a private model demo with HTTPS and logs out of the box
+  - Store LLM API keys as Koyeb secrets instead of baking them into the image

--- a/tools/dev-tools/netlify.yaml
+++ b/tools/dev-tools/netlify.yaml
@@ -1,0 +1,27 @@
+name: Netlify
+description: Platform that builds and hosts frontend apps, serverless functions, and preview deploys from Git. AI product teams ship agent consoles, docs sites, and chat UIs with HTTPS and PR previews, without operating a web server.
+tagline: Git-based hosting for frontends, functions, and previews
+
+github_url: https://github.com/netlify/cli
+website_url: https://www.netlify.com
+docs_url: https://docs.netlify.com
+
+install_command: npm install -g netlify-cli
+
+category: Dev Tools
+tags: [paas, frontend, serverless, git, hosting, cli]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  An agent product still needs a public UI, docs, and preview URLs for every
+  pull request. Netlify builds from Git, serves the static app, and runs
+  functions at the edge so frontend and light backend ship together without
+  nginx or a container cluster.
+
+use_cases:
+  - Host a chat or agent console with automatic HTTPS from a Git repo
+  - Preview pull requests that change an ML demo UI before merge
+  - Run serverless functions that proxy an inference API without exposing keys
+  - Publish product docs for an MCP server next to the marketing site
+  - Store LLM keys as Netlify environment variables instead of in client code


### PR DESCRIPTION
## Add Doppler, Koyeb, Heroku, Netlify, Gogs to catalog

Dev Tools batch for the Agentic AI For Good catalog.

| Tool | Category | Why it belongs |
|---|---|---|
| Doppler | Dev Tools | Secrets sync for shells, CI, and cloud runtimes |
| Koyeb | Dev Tools | Serverless Git and GPU deploys for agent APIs |
| Heroku | Dev Tools | Git-push PaaS for apps, workers, and add-ons |
| Netlify | Dev Tools | Frontend, functions, and PR preview hosting |
| Gogs | Dev Tools | Lightweight self-hosted Git forge |

Local validation: all five files passed `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Doppler, Gogs, Heroku, Koyeb, and Netlify.
  * Included descriptions, links, installation details, pricing, licensing, categories, tags, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->