### PR TITLE
Add Passbolt, Next.js, code-server, Nhost to catalog

### DIFF
--- a/tools/data/nhost.yaml
+++ b/tools/data/nhost.yaml
@@ -1,0 +1,28 @@
+name: Nhost
+description: Open-source Firebase alternative with Postgres, GraphQL, auth, and storage. AI teams store app data, user accounts, and file uploads for agent products without assembling a custom backend.
+tagline: Open-source Firebase alternative on Postgres and GraphQL
+
+github_url: https://github.com/nhost/nhost
+website_url: https://nhost.io
+docs_url: https://docs.nhost.io
+
+install_command: npm install @nhost/nhost-js
+
+category: Data
+tags: [postgres, graphql, auth, storage, backend, firebase]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  An agent product still needs users, a database, and file storage before
+  the model work starts. Nhost gives Postgres, Hasura GraphQL, auth, and
+  storage so a small team can persist chat history and uploads without
+  building a custom backend.
+
+use_cases:
+  - Store chat history and user accounts for an agent app on Postgres
+  - Upload documents for RAG into Nhost storage and query metadata over GraphQL
+  - Add email auth in front of a private inference demo
+  - Self-host a Firebase-style backend when data cannot leave your VPC
+  - Prototype an AI SaaS data layer without writing CRUD by hand

--- a/tools/dev-tools/code-server.yaml
+++ b/tools/dev-tools/code-server.yaml
@@ -1,0 +1,28 @@
+name: code-server
+description: VS Code that runs on a remote machine and opens in the browser. ML engineers edit training code and notebooks on a GPU box over HTTPS instead of copying files back to a laptop.
+tagline: Browser VS Code on a remote GPU or cloud box
+
+github_url: https://github.com/coder/code-server
+website_url: https://coder.com
+docs_url: https://coder.com/docs/code-server
+
+install_command: npm install -g code-server
+
+category: Dev Tools
+tags: [editor, vscode, remote, browser, gpu, devops]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Training still happens on a GPU box you SSH into, while the editor stays
+  on a laptop with stale files. code-server runs VS Code on that machine
+  and serves it in the browser so you edit, debug, and run jobs where the
+  data and GPUs already live.
+
+use_cases:
+  - Edit training scripts on a GPU server from a browser instead of scp loops
+  - Debug a failing eval job with VS Code on the same box that has the dataset
+  - Share a remote IDE URL with a teammate during an incident on a cluster node
+  - Keep model weights on the server and still use VS Code extensions
+  - Develop an agent API on a cloud VM without a local GPU

--- a/tools/dev-tools/next-js.yaml
+++ b/tools/dev-tools/next-js.yaml
@@ -1,0 +1,28 @@
+name: Next.js
+description: React framework for production web apps with App Router, server components, and API routes. AI product teams ship agent consoles, chat UIs, and docs sites with SSR and serverless routes in front of model backends.
+tagline: React framework for production apps, APIs, and SSR
+
+github_url: https://github.com/vercel/next.js
+website_url: https://nextjs.org
+docs_url: https://nextjs.org/docs
+
+install_command: npm install next
+
+category: Dev Tools
+tags: [react, javascript, typescript, ssr, frontend, vercel]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Agent products need a web UI, auth, and a server route that talks to an
+  LLM without exposing keys in the browser. Next.js gives App Router, server
+  components, and API routes so a small team can ship a chat console and
+  keep inference calls on the server.
+
+use_cases:
+  - Build a chat or agent console with server-side calls to an LLM API
+  - Host product docs and a playground for an MCP server on the same app
+  - Keep API keys off the client by proxying inference through a Route Handler
+  - Stream model tokens to the browser with React server and client components
+  - Deploy a production AI frontend to Vercel or any Node host

--- a/tools/dev-tools/passbolt.yaml
+++ b/tools/dev-tools/passbolt.yaml
@@ -1,0 +1,26 @@
+name: Passbolt
+description: Open-source password manager for teams with a self-hosted vault and browser extension. ML groups share LLM API keys, cloud logins, and SSH credentials with access control instead of a spreadsheet or Slack.
+tagline: Self-hosted team password manager with access control
+
+github_url: https://github.com/passbolt/passbolt_api
+website_url: https://www.passbolt.com
+docs_url: https://www.passbolt.com/docs
+
+category: Dev Tools
+tags: [secrets, passwords, vault, self-hosted, security, credentials]
+pricing: freemium
+is_open_source: true
+license: AGPL-3.0
+
+problem_solved: |
+  Small ML teams still share OpenAI keys and GPU box passwords in chat.
+  Passbolt stores those secrets in a self-hosted vault with users, groups,
+  and an audit trail so credentials rotate in one place and never live in
+  a spreadsheet.
+
+use_cases:
+  - Share LLM API keys with a research group without pasting them in Slack
+  - Self-host a team vault for cloud console logins on a private network
+  - Audit who accessed a production inference credential last week
+  - Rotate a Hugging Face token once and notify every teammate who uses it
+  - Keep SSH passphrases for GPU boxes out of onboarding docs


### PR DESCRIPTION
## Add Passbolt, Next.js, code-server, Nhost to catalog

Remainder batch for the Agentic AI For Good catalog.

| Tool | Category | Why it belongs |
|---|---|---|
| Passbolt | Dev Tools | Self-hosted team vault for API keys and logins |
| Next.js | Dev Tools | React framework for agent consoles and API routes |
| code-server | Dev Tools | Browser VS Code on remote GPU boxes |
| Nhost | Data | Open-source Firebase alternative on Postgres |

Local validation: all four files passed `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Nhost to the tools catalog, including installation details, links, pricing, licensing, and use cases.
  - Added code-server, Next.js, and Passbolt to the development tools catalog with descriptions, resources, setup information, and practical use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->