### PR TITLE
Add SvelteKit, Nuxt, Remix, Eleventy, Contentful to catalog

### DIFF
--- a/tools/dev-tools/contentful.yaml
+++ b/tools/dev-tools/contentful.yaml
@@ -1,0 +1,27 @@
+name: Contentful
+description: Contentful is a headless CMS with REST and GraphQL APIs, a hosted editorial UI, and SDKs for JavaScript and other languages. AI products pull structured copy, prompts, and localization from it instead of hardcoding content.
+tagline: Headless CMS APIs for structured content and copy
+
+github_url: https://github.com/contentful/contentful.js
+website_url: https://www.contentful.com
+docs_url: https://www.contentful.com/developers/docs/
+
+install_command: npm install contentful
+
+category: Dev Tools
+tags: [cms, headless-cms, content-platform, javascript, api, saas]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Product copy, prompts, and localized strings get hardcoded in repos
+  and then drift across apps. Contentful stores structured content in
+  a hosted CMS and serves it over REST or GraphQL so editors can change
+  text without a deploy while apps and agents consume a stable API.
+
+use_cases:
+  - Store marketing copy and help articles for an AI product in a headless CMS
+  - Let editors update prompts or UI strings without shipping a new frontend
+  - Localize agent onboarding content through Contentful locales and APIs
+  - Fetch structured entries in a Next.js or SvelteKit app via the JS SDK
+  - Trigger rebuilds or agent jobs from Contentful webhooks when content changes

--- a/tools/dev-tools/eleventy.yaml
+++ b/tools/dev-tools/eleventy.yaml
@@ -1,0 +1,28 @@
+name: Eleventy
+description: Eleventy is a simpler static site generator that turns templates and Markdown into HTML with no required JS runtime. AI teams publish model cards, eval reports, and docs without a heavy frontend framework.
+tagline: Simpler static sites from Markdown and templates
+
+github_url: https://github.com/11ty/eleventy
+website_url: https://www.11ty.dev
+docs_url: https://www.11ty.dev/docs/
+
+install_command: npm install @11ty/eleventy
+
+category: Dev Tools
+tags: [static-site, javascript, markdown, documentation, docs, ssg]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Docs and model cards stall when a SPA framework is required just to
+  turn Markdown into HTML. Eleventy builds static pages from many
+  template languages with no client JS required, so teams can publish
+  eval writeups and API docs from Git without a React toolchain.
+
+use_cases:
+  - Publish model cards and eval reports as a Git-backed static site
+  - Host product docs in Markdown without a SPA framework
+  - Mix Nunjucks, Liquid, and Markdown in one documentation build
+  - Rebuild docs in CI as plain HTML with no client runtime
+  - Serve experiment writeups locally while iterating on content

--- a/tools/dev-tools/nuxt.yaml
+++ b/tools/dev-tools/nuxt.yaml
@@ -1,0 +1,28 @@
+name: Nuxt
+description: Nuxt is a full-stack Vue.js framework with file-based routing, server routes, and Nitro for Node, serverless, and edge. Teams use it to ship Vue agent dashboards, docs, and APIs in front of model backends.
+tagline: Full-stack Vue framework for SSR apps and APIs
+
+github_url: https://github.com/nuxt/nuxt
+website_url: https://nuxt.com
+docs_url: https://nuxt.com/docs
+
+install_command: npm install nuxt
+
+category: Dev Tools
+tags: [vue, javascript, typescript, ssr, frontend, fullstack]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Vue teams still need SSR, API routes, and a place to hide LLM keys when
+  they ship an agent dashboard. Nuxt adds file-based routing and Nitro
+  server routes so a Vue app can call models on the server and deploy to
+  Node, serverless, or the edge without a separate backend.
+
+use_cases:
+  - Build a Vue agent dashboard with server routes that call an LLM API
+  - Keep model credentials on the server instead of in the browser
+  - Host docs and a Vue playground for an internal AI tool
+  - Deploy the same Nuxt app to Node, serverless, or edge via Nitro
+  - Add SSR for a public marketing site in front of an AI product

--- a/tools/dev-tools/remix.yaml
+++ b/tools/dev-tools/remix.yaml
@@ -1,0 +1,28 @@
+name: Remix
+description: Remix is a full-stack React framework focused on web standards, nested routing, and progressive enhancement. AI teams use it for loaders, actions, and forms that keep LLM API keys off the client.
+tagline: Full-stack React with nested routes and web standards
+
+github_url: https://github.com/remix-run/remix
+website_url: https://remix.run
+docs_url: https://remix.run/docs
+
+install_command: npm install remix
+
+category: Dev Tools
+tags: [react, javascript, typescript, ssr, frontend, fullstack]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  React SPAs push data fetching and mutations into the client, which
+  exposes secrets and complicates forms. Remix uses nested routes,
+  loaders, and actions so LLM calls and writes stay on the server while
+  the UI still feels like a modern React app.
+
+use_cases:
+  - Build a React agent console with loaders that fetch model results on the server
+  - Submit prompts through Remix actions without putting API keys in the browser
+  - Nest layout routes for a dashboard, chat pane, and settings in one app
+  - Progressively enhance forms so the UI works even if client JS fails
+  - Deploy a Remix app to Node or a serverless adapter in front of an LLM API

--- a/tools/dev-tools/sveltekit.yaml
+++ b/tools/dev-tools/sveltekit.yaml
@@ -1,0 +1,28 @@
+name: SvelteKit
+description: SvelteKit is a full-stack Svelte framework with file-based routing, SSR, and adapters for Node, serverless, and static hosts. AI product teams ship agent consoles and docs sites with less client JavaScript than typical React stacks.
+tagline: Full-stack Svelte apps with SSR and tiny client JS
+
+github_url: https://github.com/sveltejs/kit
+website_url: https://svelte.dev/docs/kit
+docs_url: https://svelte.dev/docs/kit
+
+install_command: npm install @sveltejs/kit
+
+category: Dev Tools
+tags: [svelte, javascript, typescript, ssr, frontend, fullstack]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Agent UIs often ship too much client JavaScript and leak API keys if
+  inference runs in the browser. SvelteKit compiles to small bundles and
+  keeps loaders, form actions, and server routes on the server so model
+  calls stay private while the UI stays fast.
+
+use_cases:
+  - Build a chat or agent console in Svelte with server-side LLM calls
+  - Keep API keys off the client by proxying inference through a server route
+  - Ship product docs and a playground as a SvelteKit static or Node app
+  - Stream UI updates from a model backend without a heavy React runtime
+  - Deploy the same app to Node, serverless, or a static host via adapters


### PR DESCRIPTION
## Add 5 tools to the catalog

Web frameworks and a headless CMS used to ship AI product UIs and content.

| Tool | Category | Notes |
|---|---|---|
| SvelteKit | Dev Tools | sveltejs/kit (~21k★), MIT, `npm install @sveltejs/kit` |
| Nuxt | Dev Tools | nuxt/nuxt (~61k★), MIT, `npm install nuxt` |
| Remix | Dev Tools | remix-run/remix (~33k★), MIT, `npm install remix` |
| Eleventy | Dev Tools | 11ty/eleventy (~20k★), MIT, `npm install @11ty/eleventy` |
| Contentful | Dev Tools | Headless CMS (JS SDK contentful.js ~1.3k★), freemium, `npm install contentful` |

Local validation passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Contentful, Eleventy, Nuxt, Remix, and SvelteKit to the developer tools catalog.
  * Added descriptions, installation details, documentation links, licensing information, categories, and tags for each tool.
  * Added practical use cases covering content management, documentation, localization, server-side application development, API protection, streaming interfaces, and multi-target deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->