### PR TITLE
Add PyCharm, IntelliJ IDEA, cloudflared to catalog

### DIFF
--- a/tools/dev-tools/cloudflared.yaml
+++ b/tools/dev-tools/cloudflared.yaml
@@ -1,0 +1,28 @@
+name: cloudflared
+description: cloudflared is the Cloudflare Tunnel client that exposes a local port through Cloudflare without opening inbound firewall holes. AI teams use it to demo local agent servers, receive webhooks, and share MCP or API endpoints from a laptop.
+tagline: Cloudflare Tunnel client for local services
+
+github_url: https://github.com/cloudflare/cloudflared
+website_url: https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/
+docs_url: https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/
+
+install_command: brew install cloudflared
+
+category: Dev Tools
+tags: [tunnel, networking, cloudflare, cli, devops, webhooks]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Local agent servers and webhook receivers cannot accept public traffic
+  without port forwarding or a VPN. cloudflared opens an outbound
+  Cloudflare Tunnel so a laptop or GPU box can serve HTTPS to the
+  internet without exposing inbound ports.
+
+use_cases:
+  - Demo a local agent or chat UI over HTTPS without opening a firewall port
+  - Receive provider webhooks on a development machine during integration
+  - Share an MCP or inference endpoint running on a laptop with a teammate
+  - Expose a GPU box behind NAT for remote evaluation traffic
+  - Replace ad-hoc ngrok sessions with a named Cloudflare Tunnel

--- a/tools/dev-tools/intellij-idea.yaml
+++ b/tools/dev-tools/intellij-idea.yaml
@@ -1,0 +1,28 @@
+name: IntelliJ IDEA
+description: IntelliJ IDEA is JetBrains Java and Kotlin IDE with deep code analysis, a debugger, and the IntelliJ Platform plugin ecosystem. JVM teams building AI backends, Spark jobs, and Android clients use it as the primary editor and refactor tool.
+tagline: JetBrains IDE for Java, Kotlin, and the JVM
+
+github_url: https://github.com/JetBrains/intellij-community
+website_url: https://www.jetbrains.com/idea/
+docs_url: https://www.jetbrains.com/help/idea/
+
+install_command: brew install --cask intellij-idea
+
+category: Dev Tools
+tags: [java, kotlin, ide, jetbrains, jvm, editor]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  JVM AI backends and data jobs outgrow a text editor once packages,
+  tests, and frameworks pile up. IntelliJ IDEA indexes the project,
+  runs a debugger and test runner, and applies safe refactors so Java
+  and Kotlin services stay navigable as they grow.
+
+use_cases:
+  - Debug a Spring or Ktor service that fronts an LLM API
+  - Refactor Java or Kotlin packages with IDE-safe rename and extract
+  - Run unit tests and inspect JVM threads while a training job client runs
+  - Build an Android or JVM client that talks to an inference backend
+  - Extend the IDE with plugins on the IntelliJ Platform

--- a/tools/dev-tools/pycharm.yaml
+++ b/tools/dev-tools/pycharm.yaml
@@ -1,0 +1,26 @@
+name: PyCharm
+description: PyCharm is JetBrains Python IDE with a debugger, test runner, scientific tools, and a Python-aware refactor engine. AI teams use it for training scripts, FastAPI services, and notebooks with inspections that catch type and import issues early.
+tagline: JetBrains Python IDE for apps, tests, and notebooks
+
+website_url: https://www.jetbrains.com/pycharm/
+docs_url: https://www.jetbrains.com/help/pycharm/
+
+install_command: brew install --cask pycharm
+
+category: Dev Tools
+tags: [python, ide, jetbrains, debugger, notebooks, editor]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Python AI work spans scripts, packages, tests, and notebooks that a
+  plain editor does not wire together. PyCharm adds a Python debugger,
+  test runner, venv and conda support, and inspections so training code
+  and API services stay navigable as the repo grows.
+
+use_cases:
+  - Debug training loops and FastAPI services with breakpoints and a Python console
+  - Run pytest and manage virtualenv or conda interpreters in one IDE
+  - Edit Jupyter notebooks next to the library code they import
+  - Refactor Python packages with rename, extract, and import inspections
+  - Jump from a call site to a model SDK definition without leaving the editor


### PR DESCRIPTION
## Add 3 tools to the catalog

IDEs and a tunnel client used in AI development workflows.

| Tool | Category | Notes |
|---|---|---|
| PyCharm | Dev Tools | JetBrains Python IDE, freemium, `brew install --cask pycharm` |
| IntelliJ IDEA | Dev Tools | JetBrains/intellij-community (~20k★), Apache-2.0, `brew install --cask intellij-idea` |
| cloudflared | Dev Tools | cloudflare/cloudflared (~16k★), Apache-2.0, `brew install cloudflared` |

Local validation passed for all three files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare Tunnel, IntelliJ IDEA, and PyCharm to the developer-tools catalog.
  * Included installation instructions, product details, documentation links, licensing and pricing information, and common use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->