### PR TITLE
Add Angular, Vue, SolidJS, Qwik, Preact to catalog

### DIFF
--- a/tools/dev-tools/angular.yaml
+++ b/tools/dev-tools/angular.yaml
@@ -1,0 +1,28 @@
+name: Angular
+description: Angular is a TypeScript framework for building large client apps with components, dependency injection, and a first-party CLI. AI product teams use it for enterprise dashboards, admin consoles, and typed UIs in front of model APIs.
+tagline: TypeScript framework for large-scale web apps
+
+github_url: https://github.com/angular/angular
+website_url: https://angular.dev
+docs_url: https://angular.dev/overview
+
+install_command: npm install @angular/core
+
+category: Dev Tools
+tags: [typescript, javascript, frontend, framework, spa, google]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Large product UIs need structure, typing, and a standard way to
+  organize routing, forms, and HTTP. Angular provides components,
+  dependency injection, and a CLI so teams can ship an agent console
+  or admin app without inventing a framework around React.
+
+use_cases:
+  - Build an enterprise agent dashboard with typed components and routing
+  - Generate a new Angular app and libraries with the official CLI
+  - Call model APIs from Angular services without putting keys in templates
+  - Share UI kits across multiple internal AI tools in one workspace
+  - Ship a large TypeScript SPA with first-party forms and HTTP clients

--- a/tools/dev-tools/preact.yaml
+++ b/tools/dev-tools/preact.yaml
@@ -1,0 +1,27 @@
+name: Preact
+description: Preact is a 3kb React-compatible UI library with the same component and hooks model. Teams drop it in when a chat widget or embed must stay tiny but still use a React-like API and the existing JSX ecosystem.
+tagline: 3kb React-compatible UI library for small bundles
+
+github_url: https://github.com/preactjs/preact
+website_url: https://preactjs.com
+docs_url: https://preactjs.com/guide/v10/getting-started
+
+install_command: npm install preact
+
+category: Dev Tools
+tags: [javascript, typescript, frontend, react, performance, spa]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Embeddable agent widgets cannot afford a full React runtime on every
+  host page. Preact keeps the familiar component and hooks API at about
+  3kb so a chat embed or toolbar ships without dragging React along.
+
+use_cases:
+  - Embed a chat widget on a docs site without shipping full React
+  - Alias React to Preact in a Vite app to shrink an AI playground bundle
+  - Build a JSX UI with hooks when the host page already has tight size limits
+  - Replace React in a support chatbot overlay that loads on every page
+  - Keep a familiar component API while cutting client JavaScript

--- a/tools/dev-tools/qwik.yaml
+++ b/tools/dev-tools/qwik.yaml
@@ -1,0 +1,28 @@
+name: Qwik
+description: Qwik is a web framework that ships HTML first and lazy-loads code on interaction, aiming for instant load on slow networks. Teams use it for public AI marketing sites and playgrounds where first-load JS would otherwise stall the page.
+tagline: Resumable web framework with instant HTML-first loads
+
+github_url: https://github.com/QwikDev/qwik
+website_url: https://qwik.dev
+docs_url: https://qwik.dev/docs/
+
+install_command: npm install @builder.io/qwik
+
+category: Dev Tools
+tags: [javascript, typescript, frontend, ssr, performance, framework]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Public AI product pages hydrate megabytes of JS before a playground
+  is usable. Qwik resumes on the server-rendered HTML and downloads
+  code only when a control is used, so first paint stays fast even
+  when the app later loads a model widget.
+
+use_cases:
+  - Ship a public AI playground that is interactive before hydrating a SPA
+  - Lazy-load model-widget code only after the user clicks Run
+  - Host a marketing site and a docs demo on the same Qwik app
+  - Keep first-load JS small for users on slow mobile networks
+  - Resume server-rendered HTML instead of rehydrating a full client tree

--- a/tools/dev-tools/solidjs.yaml
+++ b/tools/dev-tools/solidjs.yaml
@@ -1,0 +1,28 @@
+name: SolidJS
+description: SolidJS is a declarative JavaScript UI library that compiles reactivity to fine-grained DOM updates with no virtual DOM. Teams use it when an agent console or streaming token UI needs React-like DX with smaller runtime cost.
+tagline: Fine-grained reactive UI library without a virtual DOM
+
+github_url: https://github.com/solidjs/solid
+website_url: https://www.solidjs.com
+docs_url: https://www.solidjs.com/docs/latest
+
+install_command: npm install solid-js
+
+category: Dev Tools
+tags: [javascript, typescript, frontend, reactive, spa, performance]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Streaming agent UIs update the DOM constantly, and a virtual DOM
+  can add overhead and extra client JS. SolidJS compiles signals to
+  precise updates so chat tokens, traces, and dashboards stay fast
+  without a React-sized runtime.
+
+use_cases:
+  - Render a streaming token view with fine-grained reactive updates
+  - Build a small agent console that stays fast on modest devices
+  - Port a React-like component model without shipping a virtual DOM
+  - Pair SolidJS with Vite for a lightweight AI playground
+  - Update traces and metrics in the DOM without rerendering whole trees

--- a/tools/dev-tools/vue.yaml
+++ b/tools/dev-tools/vue.yaml
@@ -1,0 +1,28 @@
+name: Vue
+description: Vue is a progressive JavaScript framework for building UIs with a template syntax and a reactive composition API. Teams use it for agent dashboards, docs widgets, and SPAs that stay approachable as they grow from a widget to a full app.
+tagline: Progressive JavaScript framework for web UIs
+
+github_url: https://github.com/vuejs/core
+website_url: https://vuejs.org
+docs_url: https://vuejs.org/guide/introduction.html
+
+install_command: npm install vue
+
+category: Dev Tools
+tags: [javascript, typescript, frontend, framework, spa, reactive]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Teams want a reactive UI library that can start as a single widget
+  and grow into a full SPA without a steep React-or-Angular choice.
+  Vue's templates and composition API let AI product UIs scale from
+  a chat embed to a dashboard with the same mental model.
+
+use_cases:
+  - Build a Vue agent console or chat widget with the composition API
+  - Drop Vue into an existing page to add an interactive model playground
+  - Grow a prototype into a routed SPA without rewriting the UI layer
+  - Pair Vue with Nuxt when SSR and server routes become necessary
+  - Teach frontend newcomers a template-based UI for internal AI tools


### PR DESCRIPTION
## Add 5 tools to the catalog

Frontend UI libraries and frameworks used to ship AI product interfaces.

| Tool | Category | Notes |
|---|---|---|
| Angular | Dev Tools | angular/angular (~101k★), MIT, `npm install @angular/core` |
| Vue | Dev Tools | vuejs/core (~54k★), MIT, `npm install vue` |
| SolidJS | Dev Tools | solidjs/solid (~36k★), MIT, `npm install solid-js` |
| Qwik | Dev Tools | QwikDev/qwik (~22k★), MIT, `npm install @builder.io/qwik` |
| Preact | Dev Tools | preactjs/preact (~39k★), MIT, `npm install preact` |

Local validation passed for all five files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Angular, Preact, Qwik, SolidJS, and Vue to the developer-tools catalog.
  * Included descriptions, documentation links, installation commands, categories, tags, licensing details, and pricing information for each framework.
  * Added problem statements and practical use cases to help users evaluate each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->