### PR TITLE
Add Tailwind CSS, Laravel, Ruby on Rails, Bootstrap to catalog

### DIFF
--- a/tools/dev-tools/bootstrap.yaml
+++ b/tools/dev-tools/bootstrap.yaml
@@ -1,0 +1,28 @@
+name: Bootstrap
+description: Bootstrap is a CSS and JS toolkit with a responsive grid, components, and utilities. Teams use it to ship admin consoles, docs, and internal AI tools quickly when they need familiar buttons, nav, and forms without a custom design system.
+tagline: Responsive CSS and JS toolkit for common UI components
+
+github_url: https://github.com/twbs/bootstrap
+website_url: https://getbootstrap.com
+docs_url: https://getbootstrap.com/docs/
+
+install_command: npm install bootstrap
+
+category: Dev Tools
+tags: [css, frontend, ui, javascript, components, responsive]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Internal AI tools need a usable admin UI before a design system
+  exists. Bootstrap provides a grid, forms, and components so a
+  team can ship a settings page or eval dashboard that works on
+  mobile without writing CSS from scratch.
+
+use_cases:
+  - Scaffold an internal eval dashboard with Bootstrap grid and tables
+  - Add responsive nav and forms to a docs or admin site
+  - Ship a settings UI for an agent product before a custom design system exists
+  - Drop Bootstrap CSS into a Rails or Laravel app for a familiar look
+  - Prototype a chat admin page with buttons, modals, and alerts

--- a/tools/dev-tools/laravel.yaml
+++ b/tools/dev-tools/laravel.yaml
@@ -1,0 +1,28 @@
+name: Laravel
+description: Laravel is a PHP web framework with routing, Eloquent ORM, queues, and first-party auth. Teams use it to ship AI product backends, admin panels, and job workers that call model APIs without assembling a custom PHP stack.
+tagline: PHP framework for web apps, APIs, and queues
+
+github_url: https://github.com/laravel/framework
+website_url: https://laravel.com
+docs_url: https://laravel.com/docs
+
+install_command: composer create-project laravel/laravel
+
+category: Dev Tools
+tags: [php, backend, framework, orm, queues, fullstack]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  PHP backends for AI products still need auth, queues, and an ORM
+  besides a raw script that calls an LLM. Laravel provides those
+  pieces so a team can run inference jobs, store results, and expose
+  an HTTP API without assembling a custom stack.
+
+use_cases:
+  - Build a PHP API that proxies LLM calls and stores results in Eloquent
+  - Queue embedding or eval jobs with Laravel queues and workers
+  - Ship an admin panel for prompts, users, and usage with first-party auth
+  - Schedule retraining or digest emails with Laravel's scheduler
+  - Serve a Blade or Inertia UI in front of a model backend

--- a/tools/dev-tools/ruby-on-rails.yaml
+++ b/tools/dev-tools/ruby-on-rails.yaml
@@ -1,0 +1,28 @@
+name: Ruby on Rails
+description: Ruby on Rails is a full-stack web framework that favors convention over configuration for models, controllers, and views. Teams use it to ship AI product APIs, admin apps, and background jobs with Active Record and a batteries-included Ruby stack.
+tagline: Convention-over-configuration web framework in Ruby
+
+github_url: https://github.com/rails/rails
+website_url: https://rubyonrails.org
+docs_url: https://guides.rubyonrails.org
+
+install_command: gem install rails
+
+category: Dev Tools
+tags: [ruby, backend, framework, orm, fullstack, web]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Building an AI product backend from Rack and gems means reinventing
+  routing, persistence, and jobs. Rails gives Active Record, Active
+  Job, and a conventional app structure so a small team can ship an
+  API and admin UI in front of a model service.
+
+use_cases:
+  - Build a Rails API that stores prompts, users, and model outputs
+  - Run embedding or eval work in Active Job workers
+  - Ship an admin interface with Hotwire for an internal AI tool
+  - Use Active Record migrations to version the product database
+  - Scaffold a full-stack app that calls an LLM from a controller or job

--- a/tools/dev-tools/tailwind-css.yaml
+++ b/tools/dev-tools/tailwind-css.yaml
@@ -1,0 +1,28 @@
+name: Tailwind CSS
+description: Tailwind CSS is a utility-first CSS framework that styles UIs from class names instead of handwritten stylesheets. AI product teams use it to ship agent consoles, docs, and marketing pages quickly with a consistent design system.
+tagline: Utility-first CSS for fast, consistent product UIs
+
+github_url: https://github.com/tailwindlabs/tailwindcss
+website_url: https://tailwindcss.com
+docs_url: https://tailwindcss.com/docs
+
+install_command: npm install tailwindcss
+
+category: Dev Tools
+tags: [css, frontend, design-system, javascript, ui]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Custom CSS for agent dashboards and docs sites drifts and slows
+  every UI change. Tailwind maps spacing, color, and layout to
+  utility classes so teams ship consistent interfaces without
+  maintaining a growing stylesheet.
+
+use_cases:
+  - Style an agent console or chat UI without writing a custom stylesheet
+  - Keep docs and marketing pages on the same spacing and color scale
+  - Prototype a playground layout with utility classes in HTML or JSX
+  - Pair Tailwind with Next.js, SvelteKit, or Vue for production AI frontends
+  - Constrain a design system with a shared Tailwind theme config


### PR DESCRIPTION
## Add 4 tools to the catalog

CSS toolkits and full-stack web frameworks used to ship AI product UIs and backends.

| Tool | Category | Notes |
|---|---|---|
| Tailwind CSS | Dev Tools | tailwindlabs/tailwindcss (~97k★), MIT, `npm install tailwindcss` |
| Laravel | Dev Tools | laravel/framework (~35k★), MIT, `composer create-project laravel/laravel` |
| Ruby on Rails | Dev Tools | rails/rails (~59k★), MIT, `gem install rails` |
| Bootstrap | Dev Tools | twbs/bootstrap (~175k★), MIT, `npm install bootstrap` |

Local validation passed for all four files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Bootstrap, Laravel, Ruby on Rails, and Tailwind CSS to the developer tools catalog.
  - Each entry includes descriptions, installation guidance, links to official resources, category and tag information, pricing and licensing details, and practical use cases.
  - Added coverage for common development scenarios including responsive interfaces, APIs, databases, background jobs, admin tools, and design systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->