### PR TITLE
Add shadcn/ui, Radix UI, Material UI, Ant Design, Elysia to catalog

### DIFF
--- a/tools/dev-tools/ant-design.yaml
+++ b/tools/dev-tools/ant-design.yaml
@@ -1,0 +1,25 @@
+name: Ant Design
+description: Enterprise-class React UI library and design language with a dense component set for data-heavy admin interfaces. Common in ML ops consoles, evaluation dashboards, and internal AI tooling that needs tables, forms, and charts at scale.
+tagline: Enterprise React UI for data-heavy apps
+
+github_url: https://github.com/ant-design/ant-design
+website_url: https://ant.design
+docs_url: https://ant.design/docs/react/introduce
+install_command: npm install antd
+
+category: Dev Tools
+tags: [react, ui, enterprise, components, typescript, admin, dashboard]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Internal AI platforms need dense tables, filters, and forms that hold up in
+  enterprise admin consoles. Building that set from scratch delays eval
+  dashboards and ops tools. Ant Design ships a battle-tested React component
+  language so teams focus on model workflows instead of UI chrome.
+
+use_cases:
+  - Build an evaluation dashboard with tables, filters, and pagination for run history
+  - Ship an internal ML ops console with forms, drawers, and notification patterns
+  - Prototype a data-labeling or dataset browser UI with enterprise-grade controls

--- a/tools/dev-tools/elysia.yaml
+++ b/tools/dev-tools/elysia.yaml
@@ -1,0 +1,25 @@
+name: Elysia
+description: Ergonomic TypeScript web framework built for Bun, with end-to-end type safety, OpenAPI, and high throughput. Teams use it to serve LLM APIs, agent webhooks, and streaming inference endpoints without a heavy Node server stack.
+tagline: Type-safe web framework for Bun
+
+github_url: https://github.com/elysiajs/elysia
+website_url: https://elysiajs.com
+docs_url: https://elysiajs.com/tutorial
+install_command: bun add elysia
+
+category: Dev Tools
+tags: [bun, typescript, web-framework, api, openapi, http, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  LLM gateways and agent webhooks need a fast TypeScript HTTP layer with
+  typed routes and OpenAPI, not a slow Express rewrite. Elysia is built for
+  Bun and infers types from the schema so teams ship inference APIs and
+  streaming endpoints with less boilerplate and fewer runtime surprises.
+
+use_cases:
+  - Serve a typed LLM or embedding HTTP API on Bun with OpenAPI docs
+  - Expose agent webhook and tool-calling endpoints with schema validation
+  - Stream inference tokens over a high-throughput Bun HTTP server

--- a/tools/dev-tools/material-ui.yaml
+++ b/tools/dev-tools/material-ui.yaml
@@ -1,0 +1,26 @@
+name: Material UI
+description: Comprehensive React component library that implements Google Material Design. Teams use it to ship production admin panels, model playgrounds, and agent dashboards with theming, data grids, and form controls out of the box.
+tagline: Production React UI with Material Design
+
+github_url: https://github.com/mui/material-ui
+website_url: https://mui.com/material-ui/
+docs_url: https://mui.com/material-ui/getting-started/
+install_command: npm install @mui/material @emotion/react @emotion/styled
+
+category: Dev Tools
+tags: [react, ui, material-design, components, typescript, theming, dashboard]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  ML and agent products need dense admin UIs fast, not a custom design system
+  before the first eval dashboard ships. Material UI provides a complete
+  Material Design component set, theming, and layout primitives so teams
+  launch model playgrounds and ops consoles without reinventing buttons and
+  tables.
+
+use_cases:
+  - Ship an ML ops admin panel with tables, dialogs, and themed navigation
+  - Build a model playground and prompt lab with Material form controls
+  - Prototype an agent dashboard that already looks production-ready

--- a/tools/dev-tools/radix-ui.yaml
+++ b/tools/dev-tools/radix-ui.yaml
@@ -1,0 +1,25 @@
+name: Radix UI
+description: Unstyled, accessible React primitives for dialogs, menus, popovers, and more, maintained by WorkOS. Teams compose them into design systems for agent consoles and LLM apps without rebuilding accessibility from scratch.
+tagline: Unstyled accessible React primitives
+
+github_url: https://github.com/radix-ui/primitives
+website_url: https://www.radix-ui.com
+docs_url: https://www.radix-ui.com/primitives/docs/overview/introduction
+install_command: npm install @radix-ui/react-dialog
+
+category: Dev Tools
+tags: [react, ui, accessibility, primitives, design-system, typescript, workos]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Custom AI product UIs need dialogs, dropdowns, and focus traps that work with
+  keyboards and screen readers. Rolling that by hand is slow and easy to get
+  wrong. Radix primitives give unstyled, WAI-ARIA-correct behavior so teams
+  style agent consoles without sacrificing accessibility.
+
+use_cases:
+  - Build an accessible command palette for switching models and agent tools
+  - Compose dialogs, popovers, and menus into a custom LLM chat interface
+  - Foundation a design system for internal ML ops dashboards without a visual theme

--- a/tools/dev-tools/shadcn-ui.yaml
+++ b/tools/dev-tools/shadcn-ui.yaml
@@ -1,0 +1,25 @@
+name: shadcn/ui
+description: Open-source React component collection and CLI that copies accessible, Tailwind-styled primitives into your repo so you own the code. Teams use it to ship AI product UIs, agent dashboards, and chat surfaces without a locked-in component library.
+tagline: Copy-paste React components you actually own
+
+github_url: https://github.com/shadcn-ui/ui
+website_url: https://ui.shadcn.com
+docs_url: https://ui.shadcn.com/docs
+install_command: npx shadcn@latest init
+
+category: Dev Tools
+tags: [react, tailwind, ui, components, typescript, accessibility, nextjs]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI product UIs stall when teams fight a black-box component library or rebuild
+  dialogs, forms, and chat panes from scratch. shadcn/ui drops accessible,
+  Tailwind-styled source into the repo so agent dashboards and LLM apps stay
+  customizable without vendor lock-in.
+
+use_cases:
+  - Scaffold a chat and agent console UI with owned Button, Dialog, and Form components
+  - Build a model playground and eval dashboard that matches your product design system
+  - Add accessible menus, sheets, and command palettes to an internal LLM ops tool


### PR DESCRIPTION
## Summary

Adds five Dev Tools catalog entries used daily in AI product UIs and inference APIs:

- **shadcn/ui** — copy-paste accessible React/Tailwind components (`shadcn-ui/ui`, MIT, 123k stars)
- **Radix UI** — unstyled accessible React primitives (`radix-ui/primitives`, MIT, 19k stars)
- **Material UI** — Material Design React component library (`mui/material-ui`, MIT, 99k stars)
- **Ant Design** — enterprise React UI library (`ant-design/ant-design`, MIT, 99k stars)
- **Elysia** — type-safe Bun web framework for LLM APIs (`elysiajs/elysia`, MIT, 19k stars)

All files passed local `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ant Design, Material UI, Radix UI, shadcn/ui, and Elysia to the developer-tools catalog.
  * Each entry includes descriptions, documentation and repository links, installation guidance, categories, tags, licensing, pricing, and relevant use cases.
  * Added use-case information highlighting dashboards, ML operations consoles, typed APIs, agent webhooks, streaming endpoints, and React-based interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->