### PR TITLE
Add Chakra UI, WebStorm, GoLand to catalog

### DIFF
--- a/tools/dev-tools/chakra-ui.yaml
+++ b/tools/dev-tools/chakra-ui.yaml
@@ -1,0 +1,25 @@
+name: Chakra UI
+description: Accessible React component system for building SaaS product UIs quickly. Teams use it to ship agent dashboards, chat surfaces, and model playgrounds with theming, dark mode, and composable primitives without a heavy design-system lift.
+tagline: Accessible React UI system for SaaS
+
+github_url: https://github.com/chakra-ui/chakra-ui
+website_url: https://chakra-ui.com
+docs_url: https://chakra-ui.com/docs
+install_command: npm install @chakra-ui/react
+
+category: Dev Tools
+tags: [react, ui, components, accessibility, typescript, theming, saas]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI product teams need a complete, accessible component system without
+  owning a design org. Chakra UI provides themed, composable React
+  primitives so chat UIs, eval dashboards, and agent consoles ship with
+  dark mode and responsive layout instead of one-off CSS.
+
+use_cases:
+  - Build an agent chat and settings UI with themed Chakra primitives
+  - Ship an eval dashboard with accessible forms, tables, and drawers
+  - Prototype a SaaS LLM product UI with dark mode and design tokens

--- a/tools/dev-tools/goland.yaml
+++ b/tools/dev-tools/goland.yaml
@@ -1,0 +1,22 @@
+name: GoLand
+description: JetBrains IDE for Go with debugging, testing, and refactoring built in. Teams use it to build LLM gateways, agent runtimes, and inference sidecars in Go with inspections that catch concurrency and type issues before they hit production.
+tagline: JetBrains IDE for Go
+
+website_url: https://www.jetbrains.com/go/
+docs_url: https://www.jetbrains.com/help/go/discover-goland.html
+
+category: Dev Tools
+tags: [ide, go, golang, jetbrains, backend, developer-tools]
+pricing: paid
+is_open_source: false
+
+problem_solved: |
+  Go services that sit in front of models need a Go-aware IDE, not a
+  generic editor with plugins. GoLand provides debugging, testing, and
+  refactoring so teams shipping LLM gateways and agent runtimes catch
+  concurrency bugs and broken interfaces before deploy.
+
+use_cases:
+  - Debug a Go LLM gateway or embedding sidecar with breakpoints and tests
+  - Refactor agent runtime packages with Go-aware rename and inspections
+  - Build and profile inference proxy services that sit in front of model APIs

--- a/tools/dev-tools/webstorm.yaml
+++ b/tools/dev-tools/webstorm.yaml
@@ -1,0 +1,22 @@
+name: WebStorm
+description: JetBrains IDE for JavaScript and TypeScript with first-class React, Node, and frontend tooling. Teams use it to build AI product UIs, agent dashboards, and LLM apps with refactoring, debugging, and framework-aware completions.
+tagline: JetBrains IDE for JavaScript and TypeScript
+
+website_url: https://www.jetbrains.com/webstorm/
+docs_url: https://www.jetbrains.com/help/webstorm/getting-started-with-webstorm.html
+
+category: Dev Tools
+tags: [ide, javascript, typescript, react, jetbrains, frontend, developer-tools]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Frontend AI products mix React, TypeScript, and Node services that generic
+  editors underserve. WebStorm gives framework-aware refactoring, debugging,
+  and inspections so teams shipping agent UIs and LLM consoles spend less
+  time chasing type errors and broken imports.
+
+use_cases:
+  - Debug a TypeScript agent dashboard and chat frontend in a dedicated JS IDE
+  - Refactor React LLM playground code with framework-aware inspections
+  - Work across Node API and frontend code for an inference console in one IDE


### PR DESCRIPTION
## Summary

Adds three Dev Tools catalog entries:

- **Chakra UI** — accessible React component system (`chakra-ui/chakra-ui`, MIT, 40k stars)
- **WebStorm** — JetBrains JavaScript/TypeScript IDE (commercial, free for non-commercial use)
- **GoLand** — JetBrains Go IDE (commercial)

All files passed local `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Chakra UI, GoLand, and WebStorm to the developer tools catalog.
  - Added descriptions, links, pricing and licensing details, categories, tags, and practical use cases for each tool.
  - Highlighted Chakra UI for accessible React interfaces, GoLand for Go development, and WebStorm for TypeScript, React, and Node.js workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->