### PR TITLE
Add Mantine, Headless UI, Ariakit, Ark UI, DaisyUI to catalog

### DIFF
--- a/tools/dev-tools/ariakit.yaml
+++ b/tools/dev-tools/ariakit.yaml
@@ -1,0 +1,25 @@
+name: Ariakit
+description: Toolkit of accessible React components, styles, and examples for building web apps. Teams use it for composite widgets like comboboxes, select, and tabs in agent consoles when they need lower-level control than a full design system.
+tagline: Accessible React component toolkit
+
+github_url: https://github.com/ariakit/ariakit
+website_url: https://ariakit.com
+docs_url: https://ariakit.com/guide/getting-started
+install_command: npm install @ariakit/react
+
+category: Dev Tools
+tags: [react, accessibility, ui, components, typescript, headless]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Complex AI UIs need comboboxes, tabs, and composite widgets that stay
+  accessible under custom styling. Ariakit gives lower-level React primitives
+  so teams building agent consoles and prompt labs do not sacrifice keyboard
+  and screen-reader support for visual control.
+
+use_cases:
+  - Build an accessible model and tool combobox for an agent console
+  - Compose tabs and select widgets in a prompt lab without a full UI kit
+  - Add keyboard-friendly menus to an internal LLM ops dashboard

--- a/tools/dev-tools/ark-ui.yaml
+++ b/tools/dev-tools/ark-ui.yaml
@@ -1,0 +1,25 @@
+name: Ark UI
+description: Unstyled, accessible UI components that work in React, Vue, Solid, and Svelte. Built by the Chakra UI team. Teams use it to share one headless component model across agent dashboards targeting more than one frontend framework.
+tagline: Headless UI components for multiple frameworks
+
+github_url: https://github.com/chakra-ui/ark
+website_url: https://ark-ui.com
+docs_url: https://ark-ui.com/docs
+install_command: npm install @ark-ui/react
+
+category: Dev Tools
+tags: [react, vue, solid, svelte, accessibility, ui, headless, chakra]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Multi-framework AI products cannot share a React-only component kit.
+  Ark UI provides the same unstyled, accessible primitives across React,
+  Vue, Solid, and Svelte so agent UIs and eval dashboards stay consistent
+  without rewriting dialogs and menus per framework.
+
+use_cases:
+  - Share accessible dialog and menu primitives across React and Vue agent UIs
+  - Build a headless design system for an LLM console that may move frameworks
+  - Add date pickers and comboboxes to a Solid or Svelte model playground

--- a/tools/dev-tools/daisyui.yaml
+++ b/tools/dev-tools/daisyui.yaml
@@ -1,0 +1,25 @@
+name: DaisyUI
+description: The most popular free Tailwind CSS component library. Adds semantic class names on top of Tailwind so teams ship chat UIs, agent dashboards, and landing pages without writing custom component CSS for every button and card.
+tagline: Tailwind CSS component library
+
+github_url: https://github.com/saadeghi/daisyui
+website_url: https://daisyui.com
+docs_url: https://daisyui.com/docs/install/
+install_command: npm install daisyui
+
+category: Dev Tools
+tags: [tailwind, css, ui, components, html, themes, frontend]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Tailwind utility classes get verbose for repeated buttons, cards, and
+  navbars in AI product UIs. DaisyUI adds semantic component classes and
+  themes so teams ship agent dashboards and chat surfaces faster without
+  leaving the Tailwind workflow.
+
+use_cases:
+  - Theme a Tailwind agent dashboard with DaisyUI buttons, cards, and drawers
+  - Prototype a chat UI landing page without a React component library
+  - Apply dark and brand themes to an internal LLM console built on Tailwind

--- a/tools/dev-tools/headless-ui.yaml
+++ b/tools/dev-tools/headless-ui.yaml
@@ -1,0 +1,25 @@
+name: Headless UI
+description: Completely unstyled, fully accessible UI components from Tailwind Labs, designed to pair with Tailwind CSS. Teams use the React and Vue packages for menus, dialogs, and listboxes in agent UIs without fighting accessibility.
+tagline: Unstyled accessible UI for Tailwind
+
+github_url: https://github.com/tailwindlabs/headlessui
+website_url: https://headlessui.com
+docs_url: https://headlessui.com
+install_command: npm install @headlessui/react
+
+category: Dev Tools
+tags: [react, vue, tailwind, accessibility, ui, components, headless]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Tailwind-first AI apps still need accessible menus, dialogs, and comboboxes.
+  Headless UI provides the behavior and ARIA wiring unstyled, so agent
+  dashboards and chat surfaces keep full visual control without rebuilding
+  keyboard navigation from scratch.
+
+use_cases:
+  - Add an accessible model-picker combobox to a Tailwind LLM console
+  - Build dialogs and disclosure panels for agent tool settings
+  - Ship a command menu for switching chats and workflows in a Vue or React app

--- a/tools/dev-tools/mantine.yaml
+++ b/tools/dev-tools/mantine.yaml
@@ -1,0 +1,25 @@
+name: Mantine
+description: Fully featured React component library with hooks, forms, dates, charts, and a theming system. Teams use it to ship agent dashboards, model playgrounds, and internal LLM consoles without assembling a design system from scratch.
+tagline: Full-featured React component library
+
+github_url: https://github.com/mantinedev/mantine
+website_url: https://mantine.dev
+docs_url: https://mantine.dev/getting-started/
+install_command: npm install @mantine/core @mantine/hooks
+
+category: Dev Tools
+tags: [react, ui, components, hooks, typescript, theming, dashboard]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI product UIs need more than buttons. They need forms, dates, notifications,
+  and charts that share one theme. Mantine ships that stack as composable
+  React packages so teams build eval dashboards and agent consoles without
+  stitching five libraries together.
+
+use_cases:
+  - Build an ML ops dashboard with Mantine forms, tables, and notifications
+  - Ship a model playground UI with themed inputs and date range filters
+  - Prototype an internal agent console with dark mode and chart widgets


### PR DESCRIPTION
## Summary

Adds five Dev Tools catalog entries for frontend UI building:

- **Mantine** — full-featured React component library (`mantinedev/mantine`, MIT, 31k stars)
- **Headless UI** — unstyled accessible components from Tailwind Labs (`tailwindlabs/headlessui`, MIT, 28k stars)
- **Ariakit** — accessible React component toolkit (`ariakit/ariakit`, MIT, 8.6k stars)
- **Ark UI** — headless components for React/Vue/Solid/Svelte (`chakra-ui/ark`, MIT, 5.3k stars)
- **DaisyUI** — Tailwind CSS component library (`saadeghi/daisyui`, MIT, 42k stars)

All files passed local `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Ariakit, Ark UI, DaisyUI, Headless UI, and Mantine.
  * Included descriptions, documentation and project links, installation commands, categories, tags, pricing, licensing, and open-source details.
  * Added problem statements and practical use cases for each UI and component library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->