### PR TITLE
Add Vuetify, Alpine.js, Gatsby, UnoCSS to catalog

### DIFF
--- a/tools/dev-tools/alpinejs.yaml
+++ b/tools/dev-tools/alpinejs.yaml
@@ -1,0 +1,25 @@
+name: Alpine.js
+description: Rugged, minimal JavaScript framework for composing behavior in your markup. Teams use it to add interactivity to agent landing pages, docs, and lightweight dashboards without a full React or Vue bundle.
+tagline: Minimal JS framework in your markup
+
+github_url: https://github.com/alpinejs/alpine
+website_url: https://alpinejs.dev
+docs_url: https://alpinejs.dev/start-here
+install_command: npm install alpinejs
+
+category: Dev Tools
+tags: [javascript, frontend, lightweight, html, sprinkles, developer-tools]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Marketing pages and internal tools for AI products often need dropdowns,
+  tabs, and toggles without a SPA framework. Alpine.js puts reactive
+  behavior in HTML attributes so teams ship interactive docs and agent
+  landing pages without React or Vue overhead.
+
+use_cases:
+  - Add interactive tabs and accordions to an LLM product docs site
+  - Prototype a lightweight agent status page without a SPA framework
+  - Sprinkle dropdowns and modals onto a static Tailwind marketing page

--- a/tools/dev-tools/gatsby.yaml
+++ b/tools/dev-tools/gatsby.yaml
@@ -1,0 +1,25 @@
+name: Gatsby
+description: React-based static site framework with performance, scalability, and a GraphQL data layer. Teams use it to ship docs, blogs, and marketing sites for AI products with fast page loads and content sourced from CMSs or Markdown.
+tagline: React static site framework with GraphQL data
+
+github_url: https://github.com/gatsbyjs/gatsby
+website_url: https://www.gatsbyjs.com
+docs_url: https://www.gatsbyjs.com/docs
+install_command: npm install gatsby
+
+category: Dev Tools
+tags: [react, static-site, graphql, jamstack, docs, frontend]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI product docs and marketing sites need fast static pages with content
+  from Markdown, CMSs, and APIs. Gatsby compiles React into a GraphQL-backed
+  static site so teams ship documentation and landing pages without a
+  slow client-rendered app.
+
+use_cases:
+  - Generate a fast docs site for an LLM API from Markdown and GraphQL
+  - Ship a marketing site for an agent product with CMS-sourced content
+  - Build a blog and changelog for an AI platform with React templates

--- a/tools/dev-tools/unocss.yaml
+++ b/tools/dev-tools/unocss.yaml
@@ -1,0 +1,25 @@
+name: UnoCSS
+description: Instant on-demand atomic CSS engine. Teams use it as a faster, more flexible alternative to Tailwind for styling agent dashboards, LLM consoles, and docs with custom presets and icons.
+tagline: On-demand atomic CSS engine
+
+github_url: https://github.com/unocss/unocss
+website_url: https://unocss.dev
+docs_url: https://unocss.dev/guide/
+install_command: npm install unocss
+
+category: Dev Tools
+tags: [css, atomic-css, tailwind, vite, frontend, styling]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Utility CSS for AI UIs should stay fast as presets and icon sets grow.
+  UnoCSS generates atomic classes on demand with customizable presets so
+  teams style agent dashboards and docs without shipping a huge CSS
+  runtime or being locked to one Tailwind config.
+
+use_cases:
+  - Style a Vite agent dashboard with on-demand atomic CSS and icon presets
+  - Replace a slow Tailwind pipeline in an LLM console with UnoCSS
+  - Share custom utility presets across docs and product UI for an AI platform

--- a/tools/dev-tools/vuetify.yaml
+++ b/tools/dev-tools/vuetify.yaml
@@ -1,0 +1,25 @@
+name: Vuetify
+description: Vue component framework that implements Material Design. Teams use it to ship agent dashboards, eval consoles, and internal LLM tools on Vue without assembling a design system from scratch.
+tagline: Material Design component framework for Vue
+
+github_url: https://github.com/vuetifyjs/vuetify
+website_url: https://vuetifyjs.com
+docs_url: https://vuetifyjs.com/en/getting-started/installation/
+install_command: npm install vuetify
+
+category: Dev Tools
+tags: [vue, ui, material-design, components, typescript, dashboard]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Vue AI products still need a dense, themed component set for admin UIs.
+  Vuetify provides Material Design components, layout, and theming so teams
+  launch model playgrounds and agent consoles on Vue without rebuilding
+  tables, dialogs, and navigation.
+
+use_cases:
+  - Build a Vue ML ops dashboard with Vuetify tables, dialogs, and navigation
+  - Ship a Vue model playground with Material form controls and themes
+  - Prototype an internal agent console on Vue that already looks production-ready


### PR DESCRIPTION
## Summary

Adds four Dev Tools catalog entries:

- **Vuetify** — Vue Material Design component framework (`vuetifyjs/vuetify`, MIT, 41k stars)
- **Alpine.js** — minimal JS framework in markup (`alpinejs/alpine`, MIT, 31k stars)
- **Gatsby** — React static site framework (`gatsbyjs/gatsby`, MIT, 55k stars)
- **UnoCSS** — on-demand atomic CSS engine (`unocss/unocss`, MIT, 18k stars)

All files passed local `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Alpine.js, Gatsby, UnoCSS, and Vuetify to the developer tools catalog.
  * Catalog entries now include descriptions, installation commands, project links, licensing, pricing, tags, and representative use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->