### PR TITLE
Add Flowbite, PrimeReact, Quasar, Element Plus, Naive UI to catalog

### DIFF
--- a/tools/dev-tools/element-plus.yaml
+++ b/tools/dev-tools/element-plus.yaml
@@ -1,0 +1,25 @@
+name: Element Plus
+description: Vue 3 component library from the Element team with TypeScript, theming, and a full enterprise widget set. Used to build admin consoles, eval dashboards, and agent operations UIs with tables, forms, and navigation out of the box.
+tagline: Vue 3 enterprise component library
+
+github_url: https://github.com/element-plus/element-plus
+website_url: https://element-plus.org
+docs_url: https://element-plus.org/en-US/guide/installation.html
+install_command: npm install element-plus
+
+category: Dev Tools
+tags: [vue, ui, components, typescript, enterprise, admin, frontend]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Vue 3 admin and ops UIs need a complete, typed widget set for tables,
+  forms, and navigation. Element Plus gives AI teams an enterprise
+  component library so eval dashboards and agent consoles ship without
+  reinventing layout and form patterns.
+
+use_cases:
+  - Build a Vue 3 agent admin console with Element Plus tables and forms
+  - Theme an eval dashboard using Element Plus design tokens
+  - Ship an LLM ops UI with menus, dialogs, and pagination

--- a/tools/dev-tools/flowbite.yaml
+++ b/tools/dev-tools/flowbite.yaml
@@ -1,0 +1,25 @@
+name: Flowbite
+description: Open-source Tailwind CSS component library of interactive UI elements. Teams use it to ship agent dashboards, chat widgets, and marketing pages with dropdowns, modals, and forms without writing custom JS for every interaction.
+tagline: Interactive Tailwind CSS component library
+
+github_url: https://github.com/themesberg/flowbite
+website_url: https://flowbite.com
+docs_url: https://flowbite.com/docs/getting-started/introduction/
+install_command: npm install flowbite
+
+category: Dev Tools
+tags: [tailwind, css, ui, components, html, javascript, frontend]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Tailwind utilities alone do not give you dropdowns, modals, or date
+  pickers. Flowbite adds interactive components on top of Tailwind so AI
+  product teams can ship agent dashboards and chat surfaces without a
+  separate React design system or custom JS for every widget.
+
+use_cases:
+  - Add Tailwind dropdowns, modals, and drawers to an agent console
+  - Prototype a marketing site for an LLM product with Flowbite forms
+  - Ship a chat widget UI with Tailwind components and dark mode

--- a/tools/dev-tools/naive-ui.yaml
+++ b/tools/dev-tools/naive-ui.yaml
@@ -1,0 +1,25 @@
+name: Naive UI
+description: TypeScript-first Vue 3 component library with theme customization and a complete widget set. Teams use it to ship fast, themeable agent dashboards and LLM product UIs without fighting CSS-in-JS or incomplete type coverage.
+tagline: TypeScript Vue 3 component library
+
+github_url: https://github.com/tusen-ai/naive-ui
+website_url: https://www.naiveui.com
+docs_url: https://www.naiveui.com/en-US/os-theme/docs/installation
+install_command: npm install naive-ui
+
+category: Dev Tools
+tags: [vue, ui, components, typescript, theming, frontend]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Vue 3 AI products need typed, themeable components that stay fast.
+  Naive UI ships a complete TypeScript widget set so teams build agent
+  dashboards and LLM consoles with dark mode and custom tokens instead
+  of incomplete types or heavy CSS-in-JS.
+
+use_cases:
+  - Theme a Vue 3 agent dashboard with Naive UI design tokens
+  - Build an LLM playground UI with typed Naive UI forms and tables
+  - Ship a dark-mode eval console without a custom design system

--- a/tools/dev-tools/primereact.yaml
+++ b/tools/dev-tools/primereact.yaml
@@ -1,0 +1,25 @@
+name: PrimeReact
+description: The most complete React UI component library from PrimeTek. Ships 90-plus themed, accessible widgets so teams build agent consoles, eval dashboards, and data-heavy LLM apps without assembling a design system from scratch.
+tagline: Complete React UI component library
+
+github_url: https://github.com/primefaces/primereact
+website_url: https://primereact.org
+docs_url: https://primereact.org
+install_command: npm install primereact
+
+category: Dev Tools
+tags: [react, ui, components, typescript, datatable, theming, frontend]
+pricing: freemium
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Data-heavy AI products need tables, trees, charts, and forms that stay
+  accessible under load. PrimeReact provides a full React widget set so
+  teams ship eval dashboards and agent ops consoles without stitching
+  together five incomplete libraries.
+
+use_cases:
+  - Build an eval dashboard with PrimeReact DataTable and filters
+  - Theme an agent operations console with PrimeReact layouts
+  - Ship a model playground UI with forms, dialogs, and charts

--- a/tools/dev-tools/quasar.yaml
+++ b/tools/dev-tools/quasar.yaml
@@ -1,0 +1,25 @@
+name: Quasar
+description: Vue.js framework for building high-performance SPAs, PWAs, SSR, mobile, and desktop apps from one codebase. Teams ship agent UIs and internal LLM tools across web and Electron without maintaining separate frontends.
+tagline: Vue framework for web, mobile, and desktop
+
+github_url: https://github.com/quasarframework/quasar
+website_url: https://quasar.dev
+docs_url: https://quasar.dev/start/quick-start
+install_command: npm install quasar
+
+category: Dev Tools
+tags: [vue, ui, spa, pwa, electron, mobile, frontend]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  AI product teams often need the same agent UI on web, desktop, and
+  mobile. Quasar lets a Vue codebase target SPA, PWA, SSR, Cordova,
+  Capacitor, and Electron so LLM tools ship once instead of as three
+  separate frontends.
+
+use_cases:
+  - Ship an agent desktop app and web console from one Vue codebase
+  - Build a PWA for on-device LLM tooling with Quasar components
+  - Prototype an internal eval dashboard as SPA and Electron


### PR DESCRIPTION
## Summary

Adds five UI/frontend libraries used to ship agent dashboards, eval consoles, and LLM product UIs.

- **Flowbite** (Dev Tools) — Tailwind CSS interactive component library (9.3k★, MIT)
- **PrimeReact** (Dev Tools) — complete React UI widget set (8.3k★, MIT)
- **Quasar** (Dev Tools) — Vue framework for web, mobile, and desktop (27.2k★, MIT)
- **Element Plus** (Dev Tools) — Vue 3 enterprise component library (27.7k★, MIT)
- **Naive UI** (Dev Tools) — TypeScript-first Vue 3 component library (18.5k★, MIT)

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Element Plus, Flowbite, Naive UI, PrimeReact, and Quasar.
  - Included descriptions, documentation and repository links, installation commands, categories, tags, licensing, pricing, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->