### PR TITLE
Add Styled Components, Panda CSS, Ember, NucliaDB, Xapian to catalog

### DIFF
--- a/tools/data/xapian.yaml
+++ b/tools/data/xapian.yaml
@@ -1,0 +1,24 @@
+name: Xapian
+description: Open-source probabilistic search engine library with ranking, faceting, and bindings for many languages. Teams use it to add full-text retrieval to RAG pipelines and knowledge bases without standing up a separate search cluster.
+tagline: Probabilistic full-text search library
+
+github_url: https://github.com/xapian/xapian
+website_url: https://xapian.org
+docs_url: https://xapian.org/docs/
+
+category: Data
+tags: [search, full-text-search, information-retrieval, indexing, cpp, rag]
+pricing: free
+is_open_source: true
+license: GPL-2.0
+
+problem_solved: |
+  Keyword retrieval still matters in RAG and knowledge search, but
+  running Elasticsearch is heavy for embedded or on-prem tools. Xapian
+  is an embeddable search library so teams add ranked full-text retrieval
+  without operating a search cluster.
+
+use_cases:
+  - Add ranked keyword search to a local RAG knowledge base
+  - Embed full-text retrieval in an on-prem agent without Elasticsearch
+  - Combine Xapian keyword scores with vector search for hybrid RAG

--- a/tools/dev-tools/ember.yaml
+++ b/tools/dev-tools/ember.yaml
@@ -1,0 +1,25 @@
+name: Ember
+description: JavaScript framework for ambitious web applications with conventions, a router, and a mature component model. Teams use it to ship long-lived agent consoles and internal LLM tools that stay maintainable as the product grows.
+tagline: Convention-over-configuration JS framework
+
+github_url: https://github.com/emberjs/ember.js
+website_url: https://emberjs.com
+docs_url: https://guides.emberjs.com
+install_command: npm install ember-source
+
+category: Dev Tools
+tags: [javascript, framework, spa, frontend, typescript, conventions]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Large AI product UIs rot when every team invents routing, state, and
+  component patterns. Ember's conventions give agent consoles and eval
+  dashboards a stable architecture so features ship without rewriting
+  the frontend every year.
+
+use_cases:
+  - Build a long-lived agent operations console with Ember routing
+  - Maintain an internal LLM tool UI with convention-based components
+  - Ship an eval dashboard SPA that stays upgradeable across Ember versions

--- a/tools/dev-tools/panda-css.yaml
+++ b/tools/dev-tools/panda-css.yaml
@@ -1,0 +1,24 @@
+name: Panda CSS
+description: Universal, type-safe CSS-in-JS framework from the Chakra UI team. Generates atomic CSS at build time so teams ship design-system tokens for agent dashboards and LLM product UIs without a runtime style engine.
+tagline: Type-safe build-time CSS-in-JS
+
+github_url: https://github.com/chakra-ui/panda
+website_url: https://panda-css.com
+docs_url: https://panda-css.com/docs
+install_command: npm install -D @pandacss/dev
+
+category: Dev Tools
+tags: [css, design-system, typescript, react, atomic-css, frontend]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Runtime CSS-in-JS adds bundle and hydration cost to AI product UIs.
+  Panda CSS extracts atomic styles at build time with TypeScript tokens
+  so agent dashboards stay fast and type-checked without a style runtime.
+
+use_cases:
+  - Generate a typed design system for an agent console
+  - Ship atomic CSS for an LLM playground without runtime CSS-in-JS
+  - Share design tokens across React and Vue AI product frontends

--- a/tools/dev-tools/styled-components.yaml
+++ b/tools/dev-tools/styled-components.yaml
@@ -1,0 +1,25 @@
+name: Styled Components
+description: CSS-in-JS library for React with a single API for client components, server components, streaming SSR, and React Native. Teams style agent dashboards and LLM product UIs with component-scoped CSS and no class-name collisions.
+tagline: CSS-in-JS for React and React Native
+
+github_url: https://github.com/styled-components/styled-components
+website_url: https://styled-components.com
+docs_url: https://styled-components.com/docs
+install_command: npm install styled-components
+
+category: Dev Tools
+tags: [react, css-in-js, styling, ssr, typescript, frontend]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Global CSS collides and leaks across agent UI surfaces. Styled
+  Components scopes styles to React components so chat UIs, eval
+  dashboards, and model playgrounds stay themable without class-name
+  clashes or a separate stylesheet pipeline.
+
+use_cases:
+  - Style an agent chat UI with component-scoped CSS-in-JS
+  - Theme an eval dashboard without global class collisions
+  - Share styles between a React web console and React Native app

--- a/tools/vector-databases/nucliadb.yaml
+++ b/tools/vector-databases/nucliadb.yaml
@@ -1,0 +1,24 @@
+name: NucliaDB
+description: AI search database built for RAG. Indexes text, files, and embeddings so teams run semantic, keyword, and hybrid retrieval over unstructured knowledge without stitching a vector store to a separate search engine.
+tagline: AI search database for RAG
+
+github_url: https://github.com/nuclia/nucliadb
+website_url: https://nuclia.com
+docs_url: https://docs.nuclia.dev/docs/management/nucliadb/intro
+install_command: pip install nucliadb
+
+category: Vector DB
+tags: [python, rag, vector-search, hybrid-search, embeddings, knowledge-base]
+pricing: freemium
+is_open_source: true
+
+problem_solved: |
+  RAG stacks often split vectors, keyword search, and file ingestion
+  across three systems. NucliaDB stores unstructured data and embeddings
+  together so semantic, keyword, and hybrid retrieval run in one database
+  instead of a glued-together pipeline.
+
+use_cases:
+  - Index PDFs and docs for a hybrid RAG knowledge base
+  - Run semantic plus keyword search over an internal wiki
+  - Power an agent with retrieval over files, text, and embeddings


### PR DESCRIPTION
## Summary

Adds five catalog entries spanning frontend tooling, RAG search, and full-text retrieval.

- **Styled Components** (Dev Tools) — CSS-in-JS for React (41.1k★, MIT)
- **Panda CSS** (Dev Tools) — type-safe build-time CSS-in-JS (6.2k★, MIT)
- **Ember** (Dev Tools) — convention-over-configuration JS framework (22.6k★, MIT)
- **NucliaDB** (Vector DB) — AI search database for RAG (721★)
- **Xapian** (Data) — probabilistic full-text search library (875★, GPL-2.0)

Local validation passed for all five YAML files. Xapian is cataloged as Data (search library), not Vector DB.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Xapian and NucliaDB, including descriptions, links, categories, licensing, and search or RAG use cases.
  * Added metadata for Ember, Panda CSS, and Styled Components, including documentation, installation details, licensing, and example use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->