### PR TITLE
Add Tevatron, SmoothQuant, HQQ, MMEngine, FlagGems to catalog

### DIFF
--- a/tools/fine-tuning/flaggems.yaml
+++ b/tools/fine-tuning/flaggems.yaml
@@ -1,0 +1,24 @@
+name: FlagGems
+description: Operator library for large language models written in Triton. Drops in as PyTorch-compatible kernels so teams speed up LLM training and inference without rewriting models in CUDA C++.
+tagline: Triton operator library for LLMs
+
+github_url: https://github.com/flagos-ai/FlagGems
+docs_url: https://github.com/flagos-ai/FlagGems
+install_command: pip install flag_gems
+
+category: Fine-tuning
+tags: [triton, gpu, kernels, llm, pytorch, inference, training]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  LLM training and serving spend time in attention and fused ops that
+  stock PyTorch does not always optimize. FlagGems provides Triton
+  kernels that replace those operators so teams get faster GPU execution
+  without writing custom CUDA.
+
+use_cases:
+  - Speed up LLM inference with Triton replacement kernels
+  - Fuse operators in a training loop without custom CUDA
+  - Benchmark FlagGems kernels against native PyTorch ops

--- a/tools/fine-tuning/hqq.yaml
+++ b/tools/fine-tuning/hqq.yaml
@@ -1,0 +1,25 @@
+name: HQQ
+description: Half-Quadratic Quantization for fast, calibration-light compression of large language models. Teams drop models to 2-bit through 8-bit weights for inference and QLoRA-style fine-tuning with a simple PyTorch API.
+tagline: Half-Quadratic Quantization for LLMs
+
+github_url: https://github.com/dropbox/hqq
+website_url: https://dropbox.github.io/hqq_blog/
+docs_url: https://github.com/dropbox/hqq
+install_command: pip install hqq
+
+category: Fine-tuning
+tags: [quantization, llm, pytorch, qlora, inference, python]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Many quantizers need long calibration and still lose quality at 2-bit
+  and 4-bit. HQQ uses half-quadratic optimization so teams compress LLMs
+  quickly and run low-bit inference or QLoRA without a heavy calibration
+  pipeline.
+
+use_cases:
+  - Quantize an LLM to 4-bit for local inference with HQQ
+  - Fine-tune a quantized model with QLoRA-style training
+  - Compare 2-bit versus 4-bit quality on a chat model

--- a/tools/fine-tuning/mmengine.yaml
+++ b/tools/fine-tuning/mmengine.yaml
@@ -1,0 +1,25 @@
+name: MMEngine
+description: OpenMMLab foundational library for training deep learning models. Provides a runner, hooks, logging, and config system so vision and multimodal teams share training infrastructure instead of rewriting loops for every project.
+tagline: OpenMMLab training foundation library
+
+github_url: https://github.com/open-mmlab/mmengine
+website_url: https://mmengine.readthedocs.io/
+docs_url: https://mmengine.readthedocs.io/en/latest/
+install_command: pip install mmengine
+
+category: Fine-tuning
+tags: [python, pytorch, training, openmmlab, config, vision]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Vision and multimodal training stacks rewrite runners, hooks, and
+  logging for every repo. MMEngine is the OpenMMLab training foundation
+  so teams share configs, distributed training, and experiment logging
+  across MMDetection, MMYOLO, and custom models.
+
+use_cases:
+  - Train an OpenMMLab vision model with a shared runner and hooks
+  - Configure distributed fine-tuning from YAML-style configs
+  - Log and checkpoint multimodal experiments with one training loop

--- a/tools/fine-tuning/smoothquant.yaml
+++ b/tools/fine-tuning/smoothquant.yaml
@@ -1,0 +1,24 @@
+name: SmoothQuant
+description: Post-training quantization method for large language models that smooths activation outliers so INT8 inference stays accurate. Teams use it to cut LLM memory and latency without a full retraining pass.
+tagline: Accurate INT8 post-training quantization for LLMs
+
+github_url: https://github.com/mit-han-lab/smoothquant
+website_url: https://arxiv.org/abs/2211.10438
+docs_url: https://github.com/mit-han-lab/smoothquant
+
+category: Fine-tuning
+tags: [quantization, llm, pytorch, int8, inference, post-training]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  LLM activations have outliers that break naive INT8 quantization.
+  SmoothQuant migrates quantization difficulty from activations to
+  weights so models run accurate INT8 inference without retraining,
+  cutting memory and latency for serving.
+
+use_cases:
+  - Quantize a Hugging Face LLM to INT8 for cheaper inference
+  - Reduce GPU memory for serving a 7B-plus model
+  - Compare SmoothQuant INT8 quality against FP16 baselines

--- a/tools/rag/tevatron.yaml
+++ b/tools/rag/tevatron.yaml
@@ -1,0 +1,25 @@
+name: Tevatron
+description: Unified document retrieval toolkit across scale, language, and modality. Teams train dense retrievers and run RAG search with a shared training and inference stack instead of one-off scripts for each embedding model.
+tagline: Unified toolkit for neural document retrieval
+
+github_url: https://github.com/texttron/tevatron
+website_url: http://tevatron.ai
+docs_url: https://github.com/texttron/tevatron
+install_command: pip install tevatron
+
+category: RAG
+tags: [python, retrieval, dense-retrieval, rag, embeddings, information-retrieval]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Dense retriever training is fragmented across papers and one-off
+  scripts. Tevatron unifies training and inference for neural document
+  retrieval so RAG teams can train, evaluate, and serve retrievers
+  across scale, language, and modality from one toolkit.
+
+use_cases:
+  - Train a dense retriever for a multilingual RAG pipeline
+  - Evaluate retrieval models on standard IR benchmarks
+  - Serve neural document search for an agent knowledge base


### PR DESCRIPTION
## Summary

Adds five catalog entries for retrieval, quantization, and training infrastructure.

- **Tevatron** (RAG) — unified neural document retrieval toolkit (750★, Apache-2.0)
- **SmoothQuant** (Fine-tuning) — accurate INT8 post-training quantization (1.7k★, MIT)
- **HQQ** (Fine-tuning) — Half-Quadratic Quantization (958★, Apache-2.0)
- **MMEngine** (Fine-tuning) — OpenMMLab training foundation (1.5k★, Apache-2.0)
- **FlagGems** (Fine-tuning) — Triton operator library for LLMs (1.1k★, Apache-2.0)

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for five AI/ML tools: FlagGems, HQQ, MMEngine, SmoothQuant, and Tevatron.
  * Included user-facing descriptions, categories, tags, licensing and pricing details, installation instructions, links, and example use cases.
  * Added coverage for fine-tuning, quantization, model optimization, vision infrastructure, and retrieval-augmented generation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->