### PR TITLE
Add LMCache, Moonshot AI, MiniMax, LMOps, AgentScope to catalog

### DIFF
--- a/tools/agent-frameworks/agentscope.yaml
+++ b/tools/agent-frameworks/agentscope.yaml
@@ -1,0 +1,25 @@
+name: AgentScope
+description: Framework for building and running agents you can see, understand, and trust. Teams design multi-agent workflows with visible traces so production agent apps stay debuggable instead of opaque LLM loops.
+tagline: Transparent multi-agent framework
+
+github_url: https://github.com/agentscope-ai/agentscope
+website_url: https://docs.agentscope.io/
+docs_url: https://docs.agentscope.io/
+install_command: pip install agentscope
+
+category: Agents
+tags: [python, agents, multi-agent, observability, llm, orchestration]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Multi-agent apps fail silently when you cannot see why an agent chose
+  a tool or a message. AgentScope makes agent runs visible and
+  trustworthy so teams debug, evaluate, and ship multi-agent workflows
+  instead of opaque prompt chains.
+
+use_cases:
+  - Build a multi-agent research crew with visible message traces
+  - Debug tool-calling agents with AgentScope runtime views
+  - Orchestrate production agents with typed message passing

--- a/tools/llm/lmcache.yaml
+++ b/tools/llm/lmcache.yaml
@@ -1,0 +1,24 @@
+name: LMCache
+description: KV cache layer that supercharges LLM serving by reusing prefix and retrieved caches across requests. Teams cut time-to-first-token and GPU spend on RAG and multi-turn agent workloads without changing the model.
+tagline: Fastest KV cache layer for LLM serving
+
+github_url: https://github.com/LMCache/LMCache
+website_url: https://lmcache.ai/
+docs_url: https://docs.lmcache.ai/
+install_command: pip install lmcache
+
+category: LLM
+tags: [python, kv-cache, inference, vllm, rag, serving]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  RAG and multi-turn agents recompute the same KV cache on every request.
+  LMCache stores and reuses prefix and retrieval caches so LLM serving
+  spends less GPU time on repeated context and returns tokens faster.
+
+use_cases:
+  - Cache RAG prefixes across vLLM requests to cut TTFT
+  - Reuse KV cache for multi-turn agent conversations
+  - Share cache across serving replicas for high-QPS chat

--- a/tools/llm/lmops.yaml
+++ b/tools/llm/lmops.yaml
@@ -1,0 +1,24 @@
+name: LMOps
+description: Microsoft research toolkit for enabling AI capabilities with LLMs and multimodal models. Collects methods for prompting, compression, and grounding so teams can study and apply LLMOps techniques from one repo.
+tagline: Microsoft research toolkit for LLMOps
+
+github_url: https://github.com/microsoft/LMOps
+website_url: https://aka.ms/GeneralAI
+docs_url: https://github.com/microsoft/LMOps
+
+category: LLM
+tags: [llm, research, microsoft, prompting, compression, multimodal]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  LLMOps research is scattered across papers and one-off repos.
+  LMOps gathers Microsoft methods for prompting, compression, and
+  multimodal grounding so teams can evaluate and apply those techniques
+  without hunting each project separately.
+
+use_cases:
+  - Study prompt and compression methods from Microsoft LLMOps research
+  - Prototype multimodal grounding using LMOps example code
+  - Compare LLMOps techniques before adopting them in production

--- a/tools/llm/minimax.yaml
+++ b/tools/llm/minimax.yaml
@@ -1,0 +1,23 @@
+name: MiniMax
+description: AI platform for text, vision, speech, and video models with hosted APIs and open weights. Teams build agents and multimodal apps on MiniMax without assembling a separate model vendor for each modality.
+tagline: Multimodal models and APIs from MiniMax
+
+github_url: https://github.com/MiniMax-AI/MiniMax-01
+website_url: https://www.minimax.io/
+docs_url: https://platform.minimax.io/
+
+category: LLM
+tags: [llm, api, multimodal, speech, video, agents]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Multimodal products often juggle one vendor for text, another for
+  speech, and another for video. MiniMax ships text, vision, speech, and
+  video models plus APIs so teams build agents and media apps from one
+  platform.
+
+use_cases:
+  - Call MiniMax text models for chat and agent tool use
+  - Generate speech or video from the MiniMax API
+  - Experiment with MiniMax open-weight text and VL models

--- a/tools/llm/moonshot-ai.yaml
+++ b/tools/llm/moonshot-ai.yaml
@@ -1,0 +1,23 @@
+name: Moonshot AI
+description: AI lab behind the Kimi model family and an OpenAI-compatible API for chat, coding, and long-context agents. Teams call Kimi from existing SDKs to ship assistants without standing up their own training stack.
+tagline: Kimi models and API from Moonshot AI
+
+github_url: https://github.com/MoonshotAI/Kimi-K2
+website_url: https://www.moonshot.ai
+docs_url: https://platform.moonshot.ai/docs
+
+category: LLM
+tags: [llm, api, kimi, long-context, agents, china]
+pricing: freemium
+is_open_source: false
+
+problem_solved: |
+  Teams that want long-context Kimi models need a hosted API, not only
+  open weights. Moonshot AI provides the Kimi family and an
+  OpenAI-compatible platform so products can call Kimi for chat, coding,
+  and agents without training or self-hosting.
+
+use_cases:
+  - Call Kimi via an OpenAI-compatible API for chat and coding
+  - Run long-context document agents on Moonshot's platform
+  - Prototype assistants with Kimi K2 open weights or the hosted API


### PR DESCRIPTION
## Summary

Adds five catalog entries for LLM serving, model platforms, and agents.

- **LMCache** (LLM) — KV cache layer for LLM serving (11.7k★, Apache-2.0)
- **Moonshot AI** (LLM) — Kimi models and OpenAI-compatible API
- **MiniMax** (LLM) — multimodal models and APIs
- **LMOps** (LLM) — Microsoft LLMOps research toolkit (4.5k★, MIT)
- **AgentScope** (Agents) — transparent multi-agent framework (31.2k★, Apache-2.0)

Skipped from the tracker batch: fairseq (archived) and text-generation-webui (already cataloged as Oobabooga).

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added listings for the AgentScope agent framework and LMCache, LMOps, MiniMax, and Moonshot AI platforms.
  - Included descriptions, tags, pricing and licensing details, installation information, and links to relevant resources.
  - Added practical use cases covering multi-agent workflows, observability, model applications, tool-calling, and production orchestration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->