### PR TITLE
Add PentAGI, Ruflo, AlpacaEval, Grafana Alloy, Arena-Hard to catalog

### DIFF
--- a/tools/agent-frameworks/pentagi.yaml
+++ b/tools/agent-frameworks/pentagi.yaml
@@ -1,0 +1,25 @@
+name: PentAGI
+description: "Fully autonomous multi-agent platform for penetration testing. Specialist agents plan, recon, exploit, and write reports inside sandboxed Docker, with a web UI, REST and GraphQL APIs, and support for OpenAI, Anthropic, Gemini, and local models."
+tagline: "Autonomous AI agents that run real penetration tests"
+
+github_url: https://github.com/vxcontrol/pentagi
+website_url: https://pentagi.com
+docs_url: https://github.com/vxcontrol/pentagi
+
+category: Agents
+tags: [agents, penetration-testing, security, autonomous, docker, multi-agent, golang]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Manual pentests are slow, expensive, and hard to repeat. PentAGI runs a crew of specialist
+  agents that decompose a target, gather intel, attempt exploits in isolated containers, and
+  produce a report, so security teams can automate offensive testing without handing agents
+  the host machine.
+
+use_cases:
+  - Run an autonomous pentest against a staging environment and get a written vulnerability report
+  - Give security agents Docker-isolated Kali tooling without exposing the host
+  - Automate recon, exploitation, and reporting as a repeatable CI-style security workflow
+  - Connect OpenAI, Anthropic, Gemini, or local models to a self-hosted offensive-security agent stack

--- a/tools/agent-frameworks/ruflo.yaml
+++ b/tools/agent-frameworks/ruflo.yaml
@@ -1,0 +1,26 @@
+name: Ruflo
+description: "Agent meta-harness for Claude Code and Codex that adds coordinated swarms, persistent memory, federation across machines, and 60-plus specialized agents. Install once and agents plan, remember, test, and improve instead of running as isolated one-shot sessions."
+tagline: "The original agent meta-harness for Claude Code and Codex"
+
+github_url: https://github.com/ruvnet/ruflo
+website_url: https://cognitum.one
+docs_url: https://github.com/ruvnet/ruflo/blob/main/docs/ruflo-explained.md
+install_command: npm install -g ruflo
+
+category: Agents
+tags: [agents, swarm, claude-code, mcp, typescript, orchestration, multi-agent, memory]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Coding agents forget context, cannot coordinate, and restart from scratch each session.
+  Ruflo wraps Claude Code and Codex with a harness: specialized agents, swarm orchestration,
+  vector memory, hooks, and optional federation so work persists and teams of agents can
+  collaborate without leaking data.
+
+use_cases:
+  - Scaffold a Claude Code workspace with swarm agents, memory, hooks, and an MCP server
+  - Coordinate specialized agents for planning, coding, testing, and review in one loop
+  - Federate agents across machines so teams share tasks without sharing private data
+  - Add persistent memory and self-learning so agents improve across sessions

--- a/tools/monitoring/alpaca-eval.yaml
+++ b/tools/monitoring/alpaca-eval.yaml
@@ -1,0 +1,26 @@
+name: AlpacaEval
+description: "Automatic evaluator for instruction-following language models from Stanford tatsu-lab. Computes cheap, fast, human-validated win rates against a reference model, including length-controlled scores that reduce GPT-4 judge length bias."
+tagline: "Cheap, fast, human-validated LLM instruction-following eval"
+
+github_url: https://github.com/tatsu-lab/alpaca_eval
+website_url: https://tatsu-lab.github.io/alpaca_eval/
+docs_url: https://github.com/tatsu-lab/alpaca_eval
+install_command: pip install alpaca-eval
+
+category: Monitoring
+tags: [evaluation, llm-eval, instruction-following, leaderboard, benchmarking, python]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Human eval of instruction-following models is slow and expensive, while static accuracy
+  suites miss open-ended quality. AlpacaEval uses an LLM judge on the AlpacaFarm set to
+  produce win rates that correlate with humans, with length control to stop models from
+  winning just by being verbose.
+
+use_cases:
+  - Rank instruction-tuned models with automatic win rates against a GPT-4 baseline
+  - Report length-controlled scores that reduce verbosity bias in LLM-as-judge evals
+  - Iterate on prompts or fine-tunes with a cheap eval before running human studies
+  - Publish results on the public AlpacaEval leaderboard for instruction-following quality

--- a/tools/monitoring/arena-hard.yaml
+++ b/tools/monitoring/arena-hard.yaml
@@ -1,0 +1,24 @@
+name: Arena-Hard
+description: "Automatic LLM benchmark from LMArena that scores models on hard, real-user prompts using LLM-as-judge win rates. Higher correlation with Chatbot Arena than many static suites, with style control to reduce verbosity bias."
+tagline: "Hard-prompt LLM benchmark that tracks Chatbot Arena"
+
+github_url: https://github.com/lmarena/arena-hard-auto
+website_url: https://github.com/lmarena/arena-hard-auto
+docs_url: https://github.com/lmarena/arena-hard-auto
+
+category: Monitoring
+tags: [evaluation, llm-eval, benchmarking, chatbot-arena, llm-as-judge, python]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Static academic benchmarks saturate and poorly predict live Chatbot Arena rank. Arena-Hard
+  samples hard prompts from real user battles, judges model answers with an LLM, and reports
+  win rates with style control so labs can estimate Arena standing without a full live eval.
+
+use_cases:
+  - Score a new model on hard user prompts before submitting it to live Chatbot Arena
+  - Compare instruction-tuned checkpoints with GPT-4.1-as-judge win rates and confidence intervals
+  - Apply style control so longer or markdown-heavy answers do not inflate scores
+  - Reproduce published Arena-Hard leaderboards with the official auto-eval toolkit

--- a/tools/monitoring/grafana-alloy.yaml
+++ b/tools/monitoring/grafana-alloy.yaml
@@ -1,0 +1,26 @@
+name: Grafana Alloy
+description: "Grafana Labs distribution of the OpenTelemetry Collector with programmable pipelines for metrics, logs, traces, and profiles. Natively speaks Prometheus and OTLP, pulls config from Git or S3, and replaces Grafana Agent as the unified telemetry collector."
+tagline: "OpenTelemetry collector with Prometheus pipelines"
+
+github_url: https://github.com/grafana/alloy
+website_url: https://grafana.com/oss/alloy
+docs_url: https://grafana.com/docs/alloy/latest/
+install_command: brew install grafana-alloy
+
+category: Monitoring
+tags: [opentelemetry, prometheus, observability, collector, metrics, logs, traces, grafana]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Teams stitching Prometheus, OTel Collector, and Grafana Agent end up with overlapping
+  collectors and brittle config. Grafana Alloy is one programmable collector for metrics,
+  logs, traces, and profiles, with clustering, Vault support, and remote config so you
+  can ship telemetry to Grafana, Mimir, Loki, Tempo, or any OTLP backend.
+
+use_cases:
+  - Replace Grafana Agent with a single collector for Prometheus and OpenTelemetry pipelines
+  - Scrape metrics, tail logs, and receive traces, then remote-write to Mimir, Loki, and Tempo
+  - Pull Alloy config from GitHub, S3, or HTTP so fleets of collectors stay in sync
+  - Cluster Alloy instances for high-availability telemetry at the edge of ML inference stacks


### PR DESCRIPTION
## Summary

Add 5 tools to the Agentic AI For Good catalog:

- **PentAGI** (Agents) — autonomous multi-agent penetration testing platform (`vxcontrol/pentagi`)
- **Ruflo** (Agents) — agent meta-harness for Claude Code and Codex, formerly Claude Flow (`ruvnet/ruflo`)
- **AlpacaEval** (Monitoring) — Stanford tatsu-lab automatic instruction-following evaluator (`tatsu-lab/alpaca_eval`)
- **Grafana Alloy** (Monitoring) — OpenTelemetry Collector distribution with Prometheus pipelines (`grafana/alloy`)
- **Arena-Hard** (Monitoring) — LMArena hard-prompt automatic LLM benchmark (`lmarena/arena-hard-auto`)

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PentAGI and Ruflo to the agent frameworks catalog, highlighting autonomous security testing, coding-agent coordination, workspace setup, and federation capabilities.
  * Added AlpacaEval and Arena-Hard to the monitoring catalog for automated model evaluation, scoring, checkpoint comparison, and leaderboard analysis.
  * Added Grafana Alloy as a monitoring catalog entry for unified OpenTelemetry-based telemetry collection.
  * Included installation details, documentation links, licensing, pricing, tags, and practical use cases for each tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->