### PR TITLE
Add Crush, exo, Quanto, GritLM, GOT-OCR to catalog

### DIFF
--- a/tools/agent-frameworks/crush.yaml
+++ b/tools/agent-frameworks/crush.yaml
@@ -1,0 +1,31 @@
+name: Crush
+description: A terminal-native agentic coding assistant from Charm that wires your local tools, code, and workflows into the LLM of your choice. It supports many models, mid-session switching, LSP-aware context, MCP extensions, and runs on macOS, Linux, Windows, Android, and BSD.
+tagline: Glamorous agentic coding in your terminal
+
+github_url: https://github.com/charmbracelet/crush
+website_url: https://github.com/charmbracelet/crush
+docs_url: https://github.com/charmbracelet/crush
+
+install_command: |
+  brew install charmbracelet/tap/crush
+  npm install -g @charmland/crush
+
+category: Agents
+tags: [go, agents, coding-assistant, terminal, mcp, lsp, llm]
+pricing: free
+is_open_source: true
+license: FSL-1.1-MIT
+
+problem_solved: |
+  Most coding agents live in an IDE or a browser tab, so terminal-first developers lose their
+  existing CLI, LSP, and script workflows when they ask a model for help. Crush runs as a
+  Charm TUI in any terminal, keeps multiple project sessions, talks to OpenAI- and
+  Anthropic-compatible APIs, and pulls extra context from language servers and MCP servers.
+  You stay in the shell while the agent edits code with the same tools you already use.
+
+use_cases:
+  - Pair with a local or cloud LLM from the terminal to edit a repo using LSP diagnostics as extra context
+  - Switch models mid-session without dropping conversation history when one provider rate-limits
+  - Extend the agent with HTTP, stdio, or SSE MCP servers for tickets, docs, and internal APIs
+  - Keep separate Crush sessions per project so coding contexts do not bleed across workstreams
+  - Run the same agentic coding workflow on macOS, Linux, Windows, WSL, Android, and BSD

--- a/tools/data/got-ocr.yaml
+++ b/tools/data/got-ocr.yaml
@@ -1,0 +1,27 @@
+name: GOT-OCR
+description: A unified end-to-end OCR-2.0 model that reads plain text, formatted documents, formulas, tables, charts, and sheet music into structured output. GOT-OCR replaces a stack of specialist engines with one vision-language model, with weights on Hugging Face and Transformers inference support.
+tagline: One end-to-end model for documents, formulas, tables, and charts
+
+github_url: https://github.com/Ucas-HaoranWei/GOT-OCR2.0
+website_url: https://huggingface.co/stepfun-ai/GOT-OCR-2.0-hf
+docs_url: https://arxiv.org/abs/2409.01704
+
+category: Data
+tags: [ocr, vision-language, documents, pdf, tables, formulas, transformers]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Production document pipelines stitch together scene-text detectors, layout parsers,
+  formula recognizers, and table extractors, each with its own errors and GPU graph.
+  GOT-OCR 2.0 treats OCR as a single sequence-generation problem, so one model transcribes
+  pages, equations, tables, and charts into text or structured markup. Teams ingest messy
+  PDFs and screenshots without maintaining a zoo of specialist OCR services.
+
+use_cases:
+  - Transcribe scanned research PDFs including formulas and tables into machine-readable text
+  - Extract chart and sheet-music content that classic OCR engines skip or garble
+  - Run batched GOT-OCR inference through Hugging Face Transformers in a document pipeline
+  - Fine-tune GOT-OCR on domain forms so a single model replaces several vendor OCR APIs
+  - Convert screenshot-heavy internal wikis into searchable text for RAG without layout heuristics

--- a/tools/fine-tuning/quanto.yaml
+++ b/tools/fine-tuning/quanto.yaml
@@ -1,0 +1,29 @@
+name: Quanto
+description: Hugging Face Optimum's PyTorch quantization backend. Quanto quantizes weights and activations to int2, int4, int8, or float8 in eager mode, runs on CUDA and MPS, inserts quantized modules automatically, and serializes with PyTorch or safetensors for smaller LLM footprints.
+tagline: Eager-mode PyTorch quantization for LLM weights and activations
+
+github_url: https://github.com/huggingface/optimum-quanto
+website_url: https://github.com/huggingface/optimum-quanto
+docs_url: https://huggingface.co/docs/optimum-quanto
+
+install_command: pip install optimum-quanto
+
+category: Fine-tuning
+tags: [python, pytorch, quantization, llm, huggingface, inference-optimization]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Post-training quantization often requires tracing the model into a compiler graph, which
+  breaks custom modules and eager-mode training loops. Quanto stays in vanilla PyTorch, so
+  non-traceable models still quantize, can move between CUDA and Apple MPS, and export with
+  safetensors. Teams shrink memory with int4 or float8 weights without rewriting the model
+  for a separate inference compiler.
+
+use_cases:
+  - Quantize a Hugging Face Transformers checkpoint to int8 or float8 weights before local serving
+  - Cut GPU or MPS memory for an LLM while keeping an eager PyTorch training or eval loop
+  - Serialize a quantized model with safetensors and reload it in Optimum or vanilla PyTorch
+  - Compare int4 weight-only versus float8 activation quantization on the same architecture
+  - Prototype quantization on Apple Silicon MPS before moving the same recipe to CUDA servers

--- a/tools/llm/exo.yaml
+++ b/tools/llm/exo.yaml
@@ -1,0 +1,29 @@
+name: exo
+description: An open-source cluster runtime that turns everyday devices into a local AI inference mesh. exo auto-discovers peers, shards frontier models with topology-aware tensor parallelism (including RDMA over Thunderbolt), and exposes OpenAI, Claude, and Ollama-compatible APIs plus a dashboard.
+tagline: Run frontier models locally across a device cluster
+
+github_url: https://github.com/exo-explore/exo
+website_url: https://github.com/exo-explore/exo
+docs_url: https://github.com/exo-explore/exo
+
+install_command: brew install --cask exo
+
+category: LLM
+tags: [llm, local-inference, distributed, mlx, apple-silicon, cluster, open-source]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Frontier models no longer fit on a single workstation, so teams either rent datacenter GPUs
+  or downsample the model. exo pools Macs and other devices on the local network into one
+  cluster, automatically placing shards from a live topology view and speeding interconnects
+  with RDMA over Thunderbolt. Existing Chat Completions, Claude Messages, and Ollama clients
+  keep working against a localhost endpoint instead of a cloud API.
+
+use_cases:
+  - Run DeepSeek, Qwen, or Kimi-class models across several Mac Studios without a cloud GPU bill
+  - Expose a local OpenAI-compatible API so existing apps talk to a private cluster unchanged
+  - Add machines to a cluster and let exo rebalance tensor-parallel shards from device topology
+  - Chat with clustered models from the built-in dashboard at localhost while keeping data on-prem
+  - Load custom Hugging Face models onto a heterogeneous home or lab inference mesh

--- a/tools/rag/gritlm.yaml
+++ b/tools/rag/gritlm.yaml
@@ -1,0 +1,29 @@
+name: GritLM
+description: A unified large language model that performs both generation and embedding from one set of weights, switching tasks with instruction prefixes. GritLM lets RAG stacks skip a separate retriever, speeding long-document pipelines while remaining competitive on MTEB and generative benchmarks.
+tagline: One model for embedding and generation in RAG pipelines
+
+github_url: https://github.com/ContextualAI/gritlm
+website_url: https://github.com/ContextualAI/gritlm
+docs_url: https://arxiv.org/abs/2402.09906
+
+install_command: pip install gritlm
+
+category: RAG
+tags: [python, rag, embeddings, retrieval, llm, instruction-tuning, mteb]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Typical RAG systems run a dedicated embedding model to retrieve passages and a second
+  generative model to answer, doubling GPU memory, latency, and ops. GritLM trains one LLM
+  to embed or generate based on the instruction, matching single-task training quality.
+  Long-document RAG can reuse the same weights for retrieval and answering, cutting end-to-end
+  latency by more than 60 percent in the paper's setting.
+
+use_cases:
+  - Embed queries and documents with instruction prefixes, then generate answers from the same 7B or 8x7B checkpoint
+  - Replace a two-model RAG stack with GritLM to cut GPU memory and round trips on long PDFs
+  - Fine-tune GritLM-style instruction data so one model covers search and chat for an internal corpus
+  - Benchmark unified retrieval-plus-generation quality against MTEB embedding baselines
+  - Cache document embeddings from GritLM and still use the generative head for grounded answers


### PR DESCRIPTION
## Summary

Adds five tools to the Agentic AI For Good catalog:

- **Crush** (Agents) — Charm terminal-native agentic coding assistant with LSP + MCP
- **exo** (LLM) — cluster local devices to run frontier models with OpenAI/Claude/Ollama APIs
- **Quanto** (Fine-tuning) — Hugging Face Optimum eager-mode PyTorch quantization backend
- **GritLM** (RAG) — unified generation + embedding model for single-stack RAG
- **GOT-OCR** (Data) — unified OCR-2.0 vision-language model for documents, formulas, tables, and charts

Local validation passed for all five YAML files.

## Catalog

| Tool | Category | Stars | License |
|------|----------|------:|---------|
| Crush | Agents | 28k | FSL-1.1-MIT |
| exo | LLM | 47k | Apache-2.0 |
| Quanto | Fine-tuning | 1.1k | Apache-2.0 |
| GritLM | RAG | 0.7k | MIT |
| GOT-OCR | Data | 8.2k | Apache-2.0 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Tools and Resources**
  * Added listings for Crush, a terminal-native coding assistant, and exo, which combines local devices for AI inference.
  * Added GOT-OCR, a vision-language OCR model for structured document, chart, formula, and music transcription.
  * Added Quanto for PyTorch model quantization across multiple numeric formats.
  * Added GritLM for unified embedding and text-generation workflows in retrieval-augmented generation (RAG).
* **Documentation**
  * Included installation details, links, licensing, categories, tags, and practical use cases for each listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->