### PR TITLE
Add Convex, Vortex, Litestar, Falcon to catalog

### DIFF
--- a/tools/data/convex.yaml
+++ b/tools/data/convex.yaml
@@ -1,0 +1,31 @@
+name: Convex
+description: >-
+  Convex is an open-source reactive database and backend for app developers.
+  You write TypeScript queries, mutations, and actions that run with strong
+  consistency, and clients subscribe to live results so UIs and agents stay in
+  sync without custom WebSockets or cache invalidation.
+tagline: Reactive TypeScript database for live-updating apps
+
+github_url: https://github.com/get-convex/convex-backend
+website_url: https://convex.dev
+docs_url: https://docs.convex.dev
+install_command: npm install convex
+
+category: Data
+tags: [database, typescript, reactive, backend, realtime, serverless]
+pricing: freemium
+is_open_source: true
+license: FSL-1.1-Apache-2.0
+
+problem_solved: >-
+  Building live-updating apps usually means stitching a database, API layer,
+  WebSockets, and cache invalidation together, which breaks under concurrent
+  writes and is painful for agents that need consistent reads after mutations.
+  Convex stores data and server functions in one reactive backend so queries
+  stay consistent and clients receive updates automatically.
+
+use_cases:
+  - "Store chat sessions, tool traces, and user state for AI apps with TypeScript mutations and live query subscriptions"
+  - "Power collaborative dashboards that update instantly when background agents write results into Convex tables"
+  - "Self-host a reactive backend for Next.js or React Native products without standing up a separate API and WebSocket stack"
+  - "Run scheduled actions and file storage alongside transactional queries for agent workflows that need durable state"

--- a/tools/data/vortex.yaml
+++ b/tools/data/vortex.yaml
@@ -1,0 +1,31 @@
+name: Vortex
+description: >-
+  Vortex is an Apache Arrow-compatible columnar file format and compression
+  framework under LF AI and Data. It stores arrays with pluggable encodings so
+  analytics and ML pipelines can scan large datasets faster than Parquet while
+  remaining zero-copy with Arrow, DuckDB, Polars, and Spark.
+tagline: Fastest FOSS columnar format for compressed array data
+
+github_url: https://github.com/vortex-data/vortex
+website_url: https://vortex.dev
+docs_url: https://docs.vortex.dev
+install_command: pip install vortex-data
+
+category: Data
+tags: [columnar, compression, arrow, rust, python, parquet, analytics]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Training and analytics jobs spend too much time reading Parquet and similar
+  formats that were not designed for random access, nested types, or modern
+  SIMD compression. Vortex provides an extensible columnar layout with
+  state-of-the-art encodings so teams can store embeddings, tables, and
+  multimodal arrays compactly and read them at Arrow speed.
+
+use_cases:
+  - "Replace Parquet lakes with Vortex files for faster scans of feature tables and embedding dumps in Python or Rust"
+  - "Feed DuckDB, Polars, or Spark jobs from compressed Vortex datasets without copying into Arrow first"
+  - "Store nested and multimodal arrays with pluggable encodings that keep random access cheap during training"
+  - "Convert existing columnar files with the vx CLI and inspect layouts before rolling Vortex into a data pipeline"

--- a/tools/dev-tools/falcon.yaml
+++ b/tools/dev-tools/falcon.yaml
@@ -1,0 +1,31 @@
+name: Falcon
+description: >-
+  Falcon is a no-magic Python web framework for REST APIs and microservices.
+  It runs on WSGI and ASGI with a tiny core, so inference endpoints and agent
+  tool servers stay fast and predictable under load without the overhead of
+  heavier frameworks.
+tagline: No-magic Python framework for APIs and microservices
+
+github_url: https://github.com/falconry/falcon
+website_url: https://falconframework.org
+docs_url: https://falcon.readthedocs.io
+install_command: pip install falcon
+
+category: Dev Tools
+tags: [python, api, wsgi, asgi, microservices, rest, web-framework]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  High-throughput Python APIs often pay for framework magic they do not need:
+  implicit DI, bloated middleware, and slow request parsing that shows up as
+  latency on inference and webhook paths. Falcon keeps routing, media
+  handling, and hooks explicit so microservices stay small, inspectable, and
+  fast at scale.
+
+use_cases:
+  - "Serve high-QPS model scoring and embedding APIs on WSGI or ASGI with minimal per-request overhead"
+  - "Build webhook and tool-call gateways for agents where every millisecond of framework time matters"
+  - "Ship REST microservices with explicit media handlers, hooks, and responders instead of decorator-heavy frameworks"
+  - "Run Falcon behind gunicorn or uvicorn as a lean edge for Python ML services that already have their own business layer"

--- a/tools/dev-tools/litestar.yaml
+++ b/tools/dev-tools/litestar.yaml
@@ -1,0 +1,31 @@
+name: Litestar
+description: >-
+  Litestar is a high-performance Python ASGI framework for REST APIs,
+  WebSockets, and background workers. It ships OpenAPI docs, msgspec or
+  Pydantic validation, dependency injection, and production middleware without
+  locking you into a single ORM or plugin stack.
+tagline: Light, flexible ASGI framework built to scale
+
+github_url: https://github.com/litestar-org/litestar
+website_url: https://litestar.dev
+docs_url: https://docs.litestar.dev
+install_command: pip install litestar
+
+category: Dev Tools
+tags: [python, asgi, api, openapi, pydantic, async, web-framework]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: >-
+  Teams serving model inference, agent tools, and async workers need a Python
+  web framework that is fast and typed without FastAPI's tighter coupling to
+  Pydantic and Starlette internals. Litestar gives first-class OpenAPI,
+  msgspec-speed serialization, DI, and channels so API backends stay
+  maintainable as traffic and schema complexity grow.
+
+use_cases:
+  - "Expose LLM and embedding inference endpoints with automatic OpenAPI docs and msgspec-validated request bodies"
+  - "Build WebSocket or SSE token-streaming APIs for chat agents using Litestar channels and background tasks"
+  - "Stand up production microservices with dependency injection, guards, and middleware without adopting a full Django stack"
+  - "Migrate Starlite-era services to a maintained ASGI core that still supports SQLAlchemy, Redis, and task queues"


### PR DESCRIPTION
## Summary

Add four catalog entries for backend data and Python web infrastructure used in AI app stacks:

- **Convex** (Data) — open-source reactive TypeScript database and backend (`get-convex/convex-backend`, 12.5k★)
- **Vortex** (Data) — LF AI & Data columnar file format and compression framework (`vortex-data/vortex`, 3.2k★)
- **Litestar** (Dev Tools) — high-performance Python ASGI framework (`litestar-org/litestar`, 8.5k★)
- **Falcon** (Dev Tools) — no-magic Python REST/microservices framework (`falconry/falcon`, 9.8k★)

## Validation

Local `npx tsx scripts/validate-tool.ts` passed for all four files.

## Test plan

- [x] YAML schema validation
- [ ] Sync-on-merge upserts to Supabase after merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog metadata for Convex, including links, installation details, pricing, licensing, and use cases.
  - Added catalog metadata for Vortex, including links, installation details, pricing, licensing, and use cases.
  - Added catalog metadata for Falcon, highlighting API and microservice development.
  - Added catalog metadata for Litestar, including supported application patterns and migration use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->