### PR TITLE
Add OpenDAL, Apache Drill, Narwhals, Quilt, Robyn to catalog

### DIFF
--- a/tools/data/apache-drill.yaml
+++ b/tools/data/apache-drill.yaml
@@ -1,0 +1,30 @@
+name: Apache Drill
+description: >-
+  Apache Drill is a distributed SQL query engine for self-describing data. It
+  runs ANSI SQL over Parquet, JSON, CSV, Hive, Kafka, and NoSQL sources without
+  requiring a predefined schema, so analysts and ML teams can explore lake
+  files and nested documents in place.
+tagline: Schema-free SQL over files, Hive, and NoSQL
+
+github_url: https://github.com/apache/drill
+website_url: https://drill.apache.org
+docs_url: https://drill.apache.org/docs
+
+category: Data
+tags: [sql, parquet, json, hive, java, apache, query-engine, data-lake]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Feature engineering and exploratory analysis often stall because lake files
+  and nested JSON have no warehouse schema, and standing up Hive or Spark just
+  to run SQL is heavy. Drill lets teams query Parquet, JSON, and mixed
+  datastores with standard SQL and JDBC without an ETL step into a rigid
+  catalog.
+
+use_cases:
+  - "Run SQL over Parquet and JSON feature dumps in a data lake without registering Hive tables first"
+  - "Join nested application logs with columnar training data during dataset debugging"
+  - "Expose a JDBC SQL layer to BI and notebooks sitting on mixed NoSQL and file sources"
+  - "Prototype lakehouse queries on self-describing files before committing to a heavier Spark job"

--- a/tools/data/narwhals.yaml
+++ b/tools/data/narwhals.yaml
@@ -1,0 +1,31 @@
+name: Narwhals
+description: >-
+  Narwhals is a lightweight compatibility layer for Python dataframes. Write
+  once against a small API and run the same code on pandas, Polars, cuDF,
+  PyArrow, DuckDB, Dask, Ibis, and PySpark so dataframe libraries in ML
+  pipelines stay interchangeable.
+tagline: Write once, run on pandas, Polars, and friends
+
+github_url: https://github.com/narwhals-dev/narwhals
+website_url: https://narwhals-dev.github.io/narwhals/
+docs_url: https://narwhals-dev.github.io/narwhals/
+install_command: pip install narwhals
+
+category: Data
+tags: [python, dataframe, pandas, polars, pyarrow, duckdb, compatibility]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: >-
+  Libraries that depend on pandas lock out Polars and GPU dataframe users, while
+  shipping separate backends for each engine is expensive to maintain. Narwhals
+  lets authors express dataframe operations once and execute them on the
+  caller's engine, so ML tooling works across pandas, Polars, cuDF, and Arrow
+  without copy-paste backends.
+
+use_cases:
+  - "Ship a feature-engineering helper that runs on pandas in notebooks and Polars in production jobs"
+  - "Keep GPU cuDF and DuckDB users on the same public API as CPU pandas pipelines"
+  - "Avoid pulling pandas as a hard dependency in libraries that only need a few dataframe ops"
+  - "Migrate incremental Polars adoption without rewriting every pandas-shaped utility"

--- a/tools/data/opendal.yaml
+++ b/tools/data/opendal.yaml
@@ -1,0 +1,31 @@
+name: OpenDAL
+description: >-
+  Apache OpenDAL is a unified data access layer that talks to S3, GCS, Azure
+  Blob, HDFS, Redis, and dozens of other backends through one Rust-native API
+  with Python, Java, and Node bindings. AI pipelines can read and write
+  training data without custom storage adapters for every cloud.
+tagline: One layer for every object store and filesystem
+
+github_url: https://github.com/apache/opendal
+website_url: https://opendal.apache.org
+docs_url: https://opendal.apache.org
+install_command: pip install opendal
+
+category: Data
+tags: [storage, s3, rust, python, apache, data-access, object-store]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  ML and data teams stitch together SDKs for S3, GCS, Azure, HDFS, and local
+  disk, then rewrite retry, listing, and credential logic for each backend.
+  OpenDAL exposes one operator API across 50-plus storage services so feature
+  stores, training jobs, and agent sandboxes can move files without
+  vendor-specific code.
+
+use_cases:
+  - "Read and write training datasets on S3, GCS, or Azure Blob through a single Python Operator API"
+  - "Cache model artifacts in Redis or local disk with the same OpenDAL calls used for cloud object storage"
+  - "Build data loaders that list, stat, and stream files from HDFS or OSS without a per-cloud adapter"
+  - "Expose a consistent storage layer to agent tools that need to fetch files from mixed backends"

--- a/tools/data/quilt.yaml
+++ b/tools/data/quilt.yaml
@@ -1,0 +1,31 @@
+name: Quilt
+description: >-
+  Quilt is a scientific data management platform that packages datasets with
+  versioned manifests, metadata, and documentation on S3. Teams and AI systems
+  can find, trust, and reuse data through immutable packages instead of loose
+  buckets of untracked files.
+tagline: Versioned data packages for teams and AI
+
+github_url: https://github.com/quiltdata/quilt
+website_url: https://quilt.bio
+docs_url: https://docs.quiltdata.com
+install_command: pip install quilt3
+
+category: Data
+tags: [data-versioning, s3, python, packages, parquet, scientific-data]
+pricing: freemium
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  ML datasets on S3 drift without versions, schemas, or discoverable docs, so
+  training jobs silently read the wrong files and teams cannot reproduce a
+  run. Quilt wraps objects into versioned packages with manifests and catalog
+  metadata so datasets are immutable, searchable, and safe to share with
+  humans and agents.
+
+use_cases:
+  - "Publish versioned training packages on S3 with manifests so jobs pin a hash instead of a moving prefix"
+  - "Catalog scientific and ML datasets with metadata so agents and teammates can search before copying buckets"
+  - "Reproduce a model run by checking out the exact Quilt package revision used at training time"
+  - "Browse Parquet and images in a catalog UI instead of listing raw S3 keys"

--- a/tools/dev-tools/robyn.yaml
+++ b/tools/dev-tools/robyn.yaml
@@ -1,0 +1,31 @@
+name: Robyn
+description: >-
+  Robyn is a high-performance async Python web framework with a Rust runtime.
+  It serves HTTP and WebSockets with Python handlers while the runtime stays
+  in Rust, so inference APIs and agent tool servers can handle more
+  concurrent requests without leaving the Python ecosystem.
+tagline: Super-fast async Python web framework with a Rust runtime
+
+github_url: https://github.com/sparckles/Robyn
+website_url: https://robyn.tech
+docs_url: https://robyn.tech
+install_command: pip install robyn
+
+category: Dev Tools
+tags: [python, rust, async, web-framework, api, websocket, performance]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+problem_solved: >-
+  Pure-Python ASGI servers become the bottleneck when model endpoints and
+  agent gateways need high concurrency, but rewriting services in Rust or Go
+  loses the Python ML stack. Robyn keeps request handlers in Python while a
+  Rust runtime does the I/O, so teams get lower latency without abandoning
+  pip-installable ML code.
+
+use_cases:
+  - "Serve embedding and LLM inference HTTP APIs with Python handlers on a Rust HTTP runtime"
+  - "Stream tokens over WebSockets from a chat agent without a separate Node or Go gateway"
+  - "Replace slower pure-Python microservices on hot paths while keeping the rest of the ML codebase"
+  - "Prototype high-concurrency tool servers that still import PyTorch or sklearn in-process"


### PR DESCRIPTION
## Summary

Add five catalog entries spanning data access, lake query, dataframe interop, dataset packaging, and high-performance Python serving:

- **OpenDAL** (Data) — Apache unified storage layer (`apache/opendal`, 5.4k★)
- **Apache Drill** (Data) — schema-free distributed SQL (`apache/drill`, 2.0k★)
- **Narwhals** (Data) — dataframe compatibility layer (`narwhals-dev/narwhals`, 1.7k★)
- **Quilt** (Data) — versioned data packages on S3 (`quiltdata/quilt`, 1.4k★)
- **Robyn** (Dev Tools) — async Python web framework with a Rust runtime (`sparckles/Robyn`, 7.4k★)

## Validation

Local `npx tsx scripts/validate-tool.ts` passed for all five files.

## Test plan

- [x] YAML schema validation
- [ ] Sync-on-merge upserts to Supabase after merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Apache Drill to the data tooling catalog for schema-free SQL queries across formats such as Parquet and JSON.
  - Added Narwhals for interoperable dataframe workflows across popular data and query libraries.
  - Added OpenDAL for unified access to object stores and filesystems.
  - Added Quilt for dataset versioning, cataloging, and reproducibility.
  - Added Robyn to the developer tools catalog as a high-performance asynchronous Python web framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->