### PR TITLE
Add Connexion, BlackSheep, Pyramid to catalog

### DIFF
--- a/tools/dev-tools/blacksheep.yaml
+++ b/tools/dev-tools/blacksheep.yaml
@@ -1,0 +1,30 @@
+name: BlackSheep
+description: >-
+  BlackSheep is a fast ASGI web framework for Python with built-in OpenAPI
+  docs, dependency injection, and a high-performance HTTP stack. It is aimed
+  at APIs and microservices that need Flask-like simplicity with ASGI speed
+  for model serving and agent backends.
+tagline: Fast ASGI web framework for Python APIs
+
+github_url: https://github.com/Neoteroi/BlackSheep
+website_url: https://www.neoteroi.dev/blacksheep/
+docs_url: https://www.neoteroi.dev/blacksheep/
+install_command: pip install blacksheep
+
+category: Dev Tools
+tags: [python, asgi, api, openapi, web-framework, async, microservices]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: >-
+  Teams that find FastAPI too opinionated or Starlette too low-level still
+  need a fast async Python HTTP layer with OpenAPI and DI for inference
+  services. BlackSheep fills that gap with a small ASGI core, automatic docs,
+  and explicit dependency injection without requiring Pydantic everywhere.
+
+use_cases:
+  - "Serve async model inference endpoints with automatic OpenAPI generation and typed handlers"
+  - "Build microservice gateways for agent tools using BlackSheep DI and middleware"
+  - "Replace slower WSGI APIs on hot paths while keeping Python request handlers"
+  - "Prototype ASGI services that need WebSocket or SSE streaming without a heavy framework"

--- a/tools/dev-tools/connexion.yaml
+++ b/tools/dev-tools/connexion.yaml
@@ -1,0 +1,30 @@
+name: Connexion
+description: >-
+  Connexion is a Python framework for spec-first APIs. You write an OpenAPI
+  contract, then Connexion routes requests, validates payloads, and serves
+  Swagger UI so inference and agent tool servers stay aligned with the
+  published schema instead of drifting from handwritten routes.
+tagline: Spec-first Python APIs from an OpenAPI contract
+
+github_url: https://github.com/spec-first/connexion
+website_url: https://connexion.readthedocs.io
+docs_url: https://connexion.readthedocs.io
+install_command: pip install connexion
+
+category: Dev Tools
+tags: [python, openapi, api, swagger, spec-first, flask, asgi]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: >-
+  Hand-rolled FastAPI or Flask routes often drift from the OpenAPI file that
+  clients and LLM tool-calling layers depend on, causing validation bugs in
+  production. Connexion generates the HTTP layer from the spec so request
+  validation, routing, and docs cannot silently diverge from the contract.
+
+use_cases:
+  - "Stand up an OpenAPI-first inference API where the spec is the source of truth for routes and validation"
+  - "Expose agent tool servers whose JSON schemas stay identical to the published OpenAPI document"
+  - "Generate Swagger UI automatically so partner teams can try ML endpoints without extra doc sites"
+  - "Migrate Flask or ASGI services to contract-driven routing without rewriting business handlers"

--- a/tools/dev-tools/pyramid.yaml
+++ b/tools/dev-tools/pyramid.yaml
@@ -1,0 +1,31 @@
+name: Pyramid
+description: >-
+  Pyramid is a flexible Python web framework that scales from a single-file
+  app to a large service without imposing an ORM or template stack. Teams use
+  it for APIs and internal tools where routing, auth, and traversal need to
+  stay explicit rather than framework-magic.
+tagline: Start small, finish big Python web framework
+
+github_url: https://github.com/Pylons/pyramid
+website_url: https://trypyramid.com
+docs_url: https://docs.pylonsproject.org/projects/pyramid/en/latest/
+install_command: pip install pyramid
+
+category: Dev Tools
+tags: [python, web-framework, wsgi, api, pylons, routing]
+pricing: free
+is_open_source: true
+license: BSD-derived
+
+problem_solved: >-
+  Full-stack frameworks force an ORM, templating, and plugin model that ML
+  internal tools rarely need, while microframeworks outgrow a single module
+  without a clear extension story. Pyramid lets teams start with a tiny WSGI
+  app and add auth, traversal, and config as agent dashboards and APIs get
+  more complex.
+
+use_cases:
+  - "Build internal ML ops dashboards that start as a small WSGI app and grow without a rewrite"
+  - "Expose versioned JSON APIs with explicit Pyramid routing and authentication policies"
+  - "Host annotation or evaluation UIs next to Python training code without adopting Django"
+  - "Wrap existing Python libraries as HTTP services using Pyramid's unopinionated view configuration"


### PR DESCRIPTION
## Summary

Add three Python web frameworks used for APIs and internal ML services:

- **Connexion** (Dev Tools) — spec-first OpenAPI framework (`spec-first/connexion`, 4.6k★)
- **BlackSheep** (Dev Tools) — fast ASGI framework (`Neoteroi/BlackSheep`, 2.4k★)
- **Pyramid** (Dev Tools) — unopinionated Pylons web framework (`Pylons/pyramid`, 4.1k★)

## Validation

Local `npx tsx scripts/validate-tool.ts` passed for all three files.

## Test plan

- [x] YAML schema validation
- [ ] Sync-on-merge upserts to Supabase after merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added developer-tool catalog entries for BlackSheep, Connexion, and Pyramid.
  * Included framework descriptions, documentation and project links, installation commands, licensing, pricing, categories, tags, and common use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->