### PR TITLE
Add Boto3, Moto, Twisted, Freezegun, aiofiles to catalog

### DIFF
--- a/tools/dev-tools/aiofiles.yaml
+++ b/tools/dev-tools/aiofiles.yaml
@@ -1,0 +1,26 @@
+name: aiofiles
+description: Async file I/O for asyncio. aiofiles wraps standard file operations in a thread pool so FastAPI, Starlette, and agent runtimes can read and write files without blocking the event loop.
+tagline: Async file I/O for asyncio
+
+github_url: https://github.com/Tinche/aiofiles
+docs_url: https://github.com/Tinche/aiofiles
+
+category: Dev Tools
+tags: [python, asyncio, files, async, fastapi, io]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install aiofiles
+
+problem_solved: |
+  Standard open() and Path.read_text() block the asyncio event loop, stalling
+  concurrent request handling in FastAPI apps and agent servers. aiofiles
+  offloads file reads, writes, and tempfile work to a thread pool with an
+  async API, so upload handlers and local artifact code stay non-blocking.
+
+use_cases:
+  - Read and write uploaded files in FastAPI without blocking the event loop
+  - Stream local model or prompt files from an asyncio agent runtime
+  - Use async tempfile helpers when tests or jobs need scratch files
+  - Serve static artifacts from an asyncio server without sync disk I/O

--- a/tools/dev-tools/boto3.yaml
+++ b/tools/dev-tools/boto3.yaml
@@ -1,0 +1,28 @@
+name: Boto3
+description: AWS SDK for Python. Boto3 is the official client for S3, SageMaker, Bedrock, Lambda, and the rest of AWS, so ML pipelines can provision data, train jobs, and call models from Python without raw HTTP.
+tagline: Official AWS SDK for Python
+
+github_url: https://github.com/boto/boto3
+website_url: https://aws.amazon.com/sdk-for-python/
+docs_url: https://boto3.amazonaws.com/v1/documentation/api/latest/index.html
+
+category: Dev Tools
+tags: [python, aws, sdk, s3, sagemaker, bedrock, cloud]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install boto3
+
+problem_solved: |
+  Calling AWS from Python without a generated client means signing requests,
+  paging results, and tracking service APIs by hand. Boto3 wraps every AWS
+  service in resource and client APIs so training jobs, feature stores, and
+  agent tools can talk to S3, SageMaker, Bedrock, and Lambda with the same
+  credentials and retry behavior as the rest of the AWS CLI.
+
+use_cases:
+  - Upload training datasets and model artifacts to S3 from a Python job
+  - Launch SageMaker training and inference jobs from a pipeline script
+  - Call Amazon Bedrock models from an agent without a custom HTTP client
+  - Provision Lambda, IAM, and SQS resources that back an ML service

--- a/tools/dev-tools/freezegun.yaml
+++ b/tools/dev-tools/freezegun.yaml
@@ -1,0 +1,27 @@
+name: Freezegun
+description: Library that freezes datetime in Python tests. Freezegun patches datetime, date, and time so time-dependent code, cron logic, and token expiry can be tested at a fixed clock without sleeping or waiting for real time.
+tagline: Freeze time in Python tests
+
+github_url: https://github.com/spulec/freezegun
+docs_url: https://github.com/spulec/freezegun
+
+category: Dev Tools
+tags: [python, testing, datetime, pytest, mock]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install freezegun
+
+problem_solved: |
+  Code that depends on the system clock is hard to test. Sleeps make CI slow,
+  and real midnight or expiry boundaries are nearly impossible to hit. Freezegun
+  patches datetime, date, and time so you can freeze, tick, or travel to a
+  specific instant and assert cron jobs, token TTL, and scheduling logic
+  deterministically.
+
+use_cases:
+  - Freeze the clock while testing JWT or API key expiry
+  - Travel to a future date to assert scheduled job and cron behavior
+  - Tick time in small steps to cover retry backoff without sleeping
+  - Make datetime-dependent feature flags and rate limits deterministic in CI

--- a/tools/dev-tools/moto.yaml
+++ b/tools/dev-tools/moto.yaml
@@ -1,0 +1,27 @@
+name: Moto
+description: Library that mocks AWS services in Python tests. Moto intercepts boto3 calls so you can exercise S3, SageMaker, Lambda, and IAM code locally without hitting real AWS or paying for fixtures.
+tagline: Mock AWS services in Python tests
+
+github_url: https://github.com/getmoto/moto
+website_url: https://docs.getmoto.org
+docs_url: https://docs.getmoto.org/en/latest/
+
+category: Dev Tools
+tags: [python, aws, testing, mock, boto3, ci]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install moto
+
+problem_solved: |
+  Tests that hit live AWS are slow, flaky, and expensive, and stubbing every
+  boto3 client by hand drifts from real APIs. Moto intercepts AWS calls in
+  process so S3, IAM, Lambda, and SageMaker code can run against an in-memory
+  mock that matches service behavior, keeping CI offline and deterministic.
+
+use_cases:
+  - Unit-test S3 upload and download helpers without a real bucket
+  - Exercise IAM and STS credential flows in CI with no AWS account
+  - Mock Lambda invoke and SageMaker APIs while testing ML pipeline code
+  - Run decorator or server-mode AWS mocks alongside pytest fixtures

--- a/tools/dev-tools/twisted.yaml
+++ b/tools/dev-tools/twisted.yaml
@@ -1,0 +1,28 @@
+name: Twisted
+description: Event-driven networking engine for Python. Twisted provides async TCP, TLS, HTTP, SSH, and protocol helpers so long-running services can handle many connections without threads or a separate event loop library.
+tagline: Event-driven networking engine for Python
+
+github_url: https://github.com/twisted/twisted
+website_url: https://twisted.org
+docs_url: https://docs.twisted.org
+
+category: Dev Tools
+tags: [python, async, networking, http, tcp, event-loop]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install Twisted
+
+problem_solved: |
+  Building network services in Python with blocking sockets or ad-hoc threads
+  does not scale to many concurrent connections. Twisted is an event-driven
+  engine with reactors, deferreds, and protocol implementations for TCP, TLS,
+  HTTP, and SSH, so model-serving daemons and data ingest services can stay
+  async without rewriting the transport layer.
+
+use_cases:
+  - Run an async TCP or TLS server that streams inference results to clients
+  - Build a custom protocol handler for internal ML service communication
+  - Serve HTTP endpoints from a Twisted reactor alongside existing services
+  - Integrate SSH, SMTP, or DNS clients into a long-running Python daemon


### PR DESCRIPTION
## Summary

Adds five Python developer tools used daily in ML and agent stacks:

- **Boto3** — official AWS SDK for Python (S3, SageMaker, Bedrock, Lambda)
- **Moto** — in-process mock of AWS services for boto3 tests
- **Twisted** — event-driven networking engine for Python
- **Freezegun** — freeze/tick datetime in tests
- **aiofiles** — async file I/O for asyncio / FastAPI

All entries validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for five developer tools: Aiofiles, Boto3, Freezegun, Moto, and Twisted.
  * Each entry includes descriptions, categories, tags, licensing and pricing details, documentation links, installation commands, and practical use cases.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->