### PR TITLE
Add vcrpy, Daphne, Mangum, CherryPy to catalog

### DIFF
--- a/tools/dev-tools/cherrypy.yaml
+++ b/tools/dev-tools/cherrypy.yaml
@@ -1,0 +1,28 @@
+name: CherryPy
+description: Minimalist object-oriented HTTP framework for Python. CherryPy maps URL paths to Python objects so you can serve model endpoints and admin tools without a large framework, while still getting a production-ready WSGI server.
+tagline: Pythonic object-oriented HTTP framework
+
+github_url: https://github.com/cherrypy/cherrypy
+website_url: https://cherrypy.org
+docs_url: https://docs.cherrypy.dev
+
+category: Dev Tools
+tags: [python, http, web-framework, wsgi, server]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install cherrypy
+
+problem_solved: |
+  Serving a small HTTP API in Python often means pulling in a large framework
+  or writing a raw WSGI server. CherryPy is a compact object-oriented HTTP
+  framework with a built-in production server, so model endpoints, health
+  checks, and internal tools can be classes with methods instead of a full
+  Django or Flask stack.
+
+use_cases:
+  - Expose a small inference or health-check HTTP API as Python objects
+  - Embed a production-ready HTTP server inside a long-running ML process
+  - Mount WSGI apps and static files for internal admin tools
+  - Run a lightweight Python web service without a large framework

--- a/tools/dev-tools/daphne.yaml
+++ b/tools/dev-tools/daphne.yaml
@@ -1,0 +1,26 @@
+name: Daphne
+description: HTTP and WebSocket ASGI server for Django Channels. Daphne runs async Django apps so chat, streaming inference, and long-lived agent connections can use WebSockets instead of request-response only.
+tagline: ASGI server for Django Channels and WebSockets
+
+github_url: https://github.com/django/daphne
+docs_url: https://github.com/django/daphne
+
+category: Dev Tools
+tags: [python, asgi, django, websocket, http, server]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+install_command: pip install daphne
+
+problem_solved: |
+  Django's default WSGI server cannot speak WebSockets or HTTP/2, so chat
+  UIs, streaming model output, and live agent sessions need a separate ASGI
+  stack. Daphne is the reference ASGI server for Django Channels, handling
+  HTTP and WebSocket connections so those apps can run under one process.
+
+use_cases:
+  - Serve Django Channels apps with HTTP and WebSocket in one process
+  - Stream token-by-token model output to a browser over WebSockets
+  - Run long-lived agent sessions that push events to a Django frontend
+  - Terminate TLS and proxy ASGI traffic in development and production

--- a/tools/dev-tools/mangum.yaml
+++ b/tools/dev-tools/mangum.yaml
@@ -1,0 +1,27 @@
+name: Mangum
+description: Adapter that runs ASGI apps on AWS Lambda. Mangum wraps FastAPI, Starlette, and Django ASGI so you can deploy agent APIs and model endpoints as Lambda functions behind API Gateway.
+tagline: Run ASGI apps on AWS Lambda
+
+github_url: https://github.com/Kludex/mangum
+website_url: https://mangum.fastapiexpert.com
+docs_url: https://mangum.fastapiexpert.com
+
+category: Dev Tools
+tags: [python, asgi, aws, lambda, fastapi, serverless]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install mangum
+
+problem_solved: |
+  FastAPI and Starlette apps expect a long-lived ASGI server, but AWS Lambda
+  is a per-request function runtime. Mangum translates API Gateway and
+  Function URL events into ASGI scope and back, so the same agent or model
+  API can deploy as a Lambda without rewriting handlers.
+
+use_cases:
+  - Deploy a FastAPI agent API on Lambda behind API Gateway
+  - Run Starlette or Django ASGI apps as serverless functions
+  - Handle HTTP, WebSocket, and lifespan events from Lambda event sources
+  - Keep a single ASGI codebase for local uvicorn and production Lambda

--- a/tools/dev-tools/vcrpy.yaml
+++ b/tools/dev-tools/vcrpy.yaml
@@ -1,0 +1,26 @@
+name: vcrpy
+description: HTTP recording library for Python tests. vcrpy intercepts requests and httpx calls, then replays cassettes so CI can mock model APIs, webhooks, and third-party HTTP without hitting the network.
+tagline: Record and replay HTTP in Python tests
+
+github_url: https://github.com/kevin1024/vcrpy
+docs_url: https://vcrpy.readthedocs.io
+
+category: Dev Tools
+tags: [python, testing, http, mock, cassettes, ci]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install vcrpy
+
+problem_solved: |
+  Tests that call live HTTP APIs are slow, flaky, and can burn paid tokens
+  on every CI run. vcrpy records requests into cassettes and replays them
+  on later runs, so agent tools, model clients, and webhook handlers can
+  be tested offline with the same request and response bodies.
+
+use_cases:
+  - Record OpenAI or other model HTTP calls once and replay them in CI
+  - Fixture third-party webhooks without standing up a mock server
+  - Keep pytest suites offline while still asserting real response shapes
+  - Filter secrets from cassettes before committing HTTP fixtures


### PR DESCRIPTION
## Summary

Adds four Python developer tools used in testing, ASGI serving, and HTTP APIs:

- **vcrpy** — record and replay HTTP interactions in tests
- **Daphne** — HTTP/WebSocket ASGI server for Django Channels
- **Mangum** — run FastAPI/Starlette ASGI apps on AWS Lambda
- **CherryPy** — minimalist object-oriented HTTP framework

All entries validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CherryPy, Daphne, Mangum, and vcrpy to the Dev Tools catalog.
  - Included descriptions, tags, licensing and pricing details, installation commands, and links to project resources.
  - Added use cases covering lightweight Python web services, ASGI and WebSocket applications, serverless deployments, and HTTP recording for tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->