### PR TITLE
Add PyMongo, MongoEngine, Beanie, Motor, Tortoise ORM to catalog

### DIFF
--- a/tools/data/beanie.yaml
+++ b/tools/data/beanie.yaml
@@ -1,0 +1,27 @@
+name: Beanie
+description: Async Python ODM for MongoDB built on Pydantic and Motor. Beanie lets FastAPI and asyncio services model documents with type hints, migrations, and relations without blocking the event loop.
+tagline: Async MongoDB ODM with Pydantic
+
+github_url: https://github.com/BeanieODM/beanie
+website_url: https://beanie-odm.dev
+docs_url: https://beanie-odm.dev
+
+category: Data
+tags: [python, mongodb, odm, asyncio, pydantic, fastapi]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install beanie
+
+problem_solved: |
+  Sync MongoDB ODMs block asyncio servers, and Motor alone still leaves you
+  writing untyped dicts. Beanie combines Motor with Pydantic models so FastAPI
+  and agent backends can define documents, indexes, and migrations with type
+  hints and non-blocking I/O.
+
+use_cases:
+  - Model MongoDB collections as Pydantic documents in a FastAPI app
+  - Run async queries from an agent server without blocking the event loop
+  - Apply document migrations when experiment or memory schemas change
+  - Define relations and indexes next to the Python document class

--- a/tools/data/mongoengine.yaml
+++ b/tools/data/mongoengine.yaml
@@ -1,0 +1,27 @@
+name: MongoEngine
+description: Object-document mapper for MongoDB in Python. MongoEngine maps classes to collections with schemas, validation, and query helpers so you can model documents without writing raw PyMongo dicts.
+tagline: Python ODM for MongoDB
+
+github_url: https://github.com/MongoEngine/mongoengine
+website_url: https://mongoengine-odm.readthedocs.io
+docs_url: https://mongoengine-odm.readthedocs.io
+
+category: Data
+tags: [python, mongodb, odm, orm, documents, schema]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install mongoengine
+
+problem_solved: |
+  Raw PyMongo dicts have no schema, so field names drift and nested documents
+  are easy to corrupt. MongoEngine maps Python classes to MongoDB collections
+  with types, validation, and queryset helpers, so application data around
+  models and agents stays structured without a relational ORM.
+
+use_cases:
+  - Define document schemas for user, job, and experiment records
+  - Query nested MongoDB documents with a Django-like queryset API
+  - Validate fields before writes so training metadata stays consistent
+  - Map Python classes to collections without writing raw BSON dicts

--- a/tools/data/motor.yaml
+++ b/tools/data/motor.yaml
@@ -1,0 +1,27 @@
+name: Motor
+description: Async MongoDB driver for Tornado and asyncio. Motor wraps PyMongo so FastAPI, Tornado, and agent runtimes can query MongoDB without blocking the event loop on network I/O.
+tagline: Async MongoDB driver for asyncio and Tornado
+
+github_url: https://github.com/mongodb/motor
+website_url: https://motor.readthedocs.io
+docs_url: https://motor.readthedocs.io
+
+category: Data
+tags: [python, mongodb, asyncio, tornado, driver, async]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install motor
+
+problem_solved: |
+  PyMongo is synchronous, so a MongoDB call inside an asyncio handler stalls
+  every other request. Motor is the official async wrapper around PyMongo for
+  asyncio and Tornado, so document reads and writes stay off the event loop
+  in FastAPI services and long-running agent processes.
+
+use_cases:
+  - Query MongoDB from FastAPI without blocking the event loop
+  - Use async cursors in Tornado apps that serve model results
+  - Share PyMongo-compatible APIs in asyncio worker processes
+  - Stream change feeds into an async pipeline without a thread pool

--- a/tools/data/pymongo.yaml
+++ b/tools/data/pymongo.yaml
@@ -1,0 +1,27 @@
+name: PyMongo
+description: Official MongoDB driver for Python. PyMongo is the supported client for CRUD, aggregations, GridFS, and change streams, so ML pipelines can store documents, embeddings metadata, and job state in MongoDB from CPython.
+tagline: Official MongoDB driver for Python
+
+github_url: https://github.com/mongodb/mongo-python-driver
+website_url: https://www.mongodb.com/docs/languages/python/pymongo-driver/current/
+docs_url: https://www.mongodb.com/docs/languages/python/pymongo-driver/current/
+
+category: Data
+tags: [python, mongodb, driver, nosql, documents, database]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install pymongo
+
+problem_solved: |
+  Talking to MongoDB from Python without the official driver means reimplementing
+  wire protocol, auth, and connection pooling. PyMongo is the supported client
+  for CRUD, aggregations, GridFS, and change streams, so feature stores, agent
+  memory, and job metadata can live in MongoDB with production-grade retries.
+
+use_cases:
+  - Store and query document records that back an ML feature store
+  - Stream change events to trigger retraining or cache invalidation
+  - Persist agent conversation state and tool results in MongoDB
+  - Upload large artifacts through GridFS from a Python training job

--- a/tools/data/tortoise-orm.yaml
+++ b/tools/data/tortoise-orm.yaml
@@ -1,0 +1,27 @@
+name: Tortoise ORM
+description: Async ORM for Python inspired by Django. Tortoise ORM supports relations, migrations, and multiple backends so asyncio services can persist structured data without a sync Django ORM or raw SQL.
+tagline: Familiar asyncio ORM for Python
+
+github_url: https://github.com/tortoise/tortoise-orm
+website_url: https://tortoise.github.io
+docs_url: https://tortoise.github.io
+
+category: Data
+tags: [python, orm, asyncio, sql, django, database]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install tortoise-orm
+
+problem_solved: |
+  Django ORM and SQLAlchemy sync sessions block asyncio apps, and writing raw
+  SQL for every relation is error-prone. Tortoise ORM gives FastAPI and agent
+  backends a Django-like model API with async I/O, relations, and migrations
+  across SQLite, PostgreSQL, and MySQL.
+
+use_cases:
+  - Persist FastAPI application data with async model queries
+  - Model relations between users, jobs, and experiment records
+  - Run schema migrations for asyncio services without Django
+  - Use SQLite in tests and PostgreSQL in production with the same models


### PR DESCRIPTION
## Summary

Adds five Python data tools for MongoDB and async ORMs:

- **PyMongo** — official MongoDB driver for Python
- **MongoEngine** — object-document mapper for MongoDB
- **Beanie** — async MongoDB ODM on Pydantic and Motor
- **Motor** — async MongoDB driver for asyncio and Tornado
- **Tortoise ORM** — Django-like asyncio ORM

All entries validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for Beanie, MongoEngine, Motor, PyMongo, and Tortoise ORM.
  * Added discoverable metadata including descriptions, categories, tags, pricing, licensing, installation commands, and links.
  * Documented practical use cases such as schema modeling, asynchronous queries, validation, migrations, change streams, and repository-based data access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->