### PR TITLE
Add ODMantic, python-socketio, colorlog to catalog

### DIFF
--- a/tools/data/odmantic.yaml
+++ b/tools/data/odmantic.yaml
@@ -1,0 +1,27 @@
+name: ODMantic
+description: Sync and async MongoDB ODM based on Python type hints. ODMantic models documents with Pydantic so FastAPI services can validate, query, and persist MongoDB data without writing untyped dicts.
+tagline: Type-hinted MongoDB ODM with Pydantic
+
+github_url: https://github.com/art049/odmantic
+website_url: https://art049.github.io/odmantic
+docs_url: https://art049.github.io/odmantic
+
+category: Data
+tags: [python, mongodb, odm, pydantic, asyncio, type-hints]
+pricing: free
+is_open_source: true
+license: ISC
+
+install_command: pip install odmantic
+
+problem_solved: |
+  MongoDB access in Python is often untyped dicts or a sync-only ODM that
+  blocks asyncio. ODMantic models collections with Pydantic type hints and
+  supports both sync and async engines, so FastAPI and agent backends get
+  validated documents without a separate schema layer.
+
+use_cases:
+  - Define MongoDB documents with Pydantic models in a FastAPI app
+  - Run async queries against MongoDB without blocking the event loop
+  - Share the same document models between sync scripts and async APIs
+  - Validate nested documents before writes using Python type hints

--- a/tools/dev-tools/colorlog.yaml
+++ b/tools/dev-tools/colorlog.yaml
@@ -1,0 +1,27 @@
+name: colorlog
+description: Colored formatter for Python logging. colorlog adds per-level colors to the standard logging module so local ML jobs, agent CLIs, and server logs are easier to scan without switching to a full logging framework.
+tagline: Colored formatter for Python logging
+
+github_url: https://github.com/borntyping/python-colorlog
+website_url: https://pypi.org/project/colorlog/
+docs_url: https://github.com/borntyping/python-colorlog
+
+category: Dev Tools
+tags: [python, logging, cli, developer-experience, color]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install colorlog
+
+problem_solved: |
+  Standard library logging dumps monochrome lines that are hard to scan in a
+  terminal, and switching to a heavy logging stack is overkill for scripts.
+  colorlog is a drop-in formatter that colors log levels, so training jobs
+  and agent CLIs stay on logging.getLogger while becoming readable locally.
+
+use_cases:
+  - Color ERROR versus INFO lines in a local training or eval job
+  - Keep stdlib logging in a CLI while making levels easy to scan
+  - Add colored logs to an agent worker without a new logging framework
+  - Share one logging config between scripts and a development server

--- a/tools/dev-tools/python-socketio.yaml
+++ b/tools/dev-tools/python-socketio.yaml
@@ -1,0 +1,26 @@
+name: python-socketio
+description: Socket.IO server and client for Python. python-socketio adds event-based WebSocket messaging on asyncio, aiohttp, FastAPI, and Flask so agent UIs and streaming inference can push events without a custom protocol.
+tagline: Socket.IO server and client for Python
+
+github_url: https://github.com/miguelgrinberg/python-socketio
+docs_url: https://python-socketio.readthedocs.io
+
+category: Dev Tools
+tags: [python, websocket, socketio, asyncio, fastapi, realtime]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install python-socketio
+
+problem_solved: |
+  Raw WebSockets need a custom event protocol, reconnect logic, and fallbacks.
+  python-socketio implements the Socket.IO protocol in Python with asyncio and
+  WSGI integrations, so chat UIs, live agent traces, and streaming inference
+  can emit named events with rooms and acknowledgements.
+
+use_cases:
+  - Push token-stream and tool-call events to a browser over Socket.IO
+  - Add realtime rooms for multi-user agent sessions on FastAPI
+  - Connect a Python client to an existing Socket.IO Node server
+  - Fall back from WebSocket to long-polling when proxies block WS


### PR DESCRIPTION
## Summary

Adds three Python tools for document modeling, realtime events, and logging:

- **ODMantic** — type-hinted MongoDB ODM with Pydantic
- **python-socketio** — Socket.IO server and client for Python
- **colorlog** — colored formatter for stdlib logging

All entries validated locally with `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Tools**
  * Added ODMantic to the tools catalog, including installation details, licensing, links, and use cases.
  * Added colorlog to the developer tools catalog with metadata, installation instructions, and use cases.
  * Added python-socketio with protocol information, integration details, licensing, and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->