### PR TITLE
Add argon2-cffi, limits, python-multipart, cuVS, PyNNDescent to catalog

### DIFF
--- a/tools/dev-tools/argon2-cffi.yaml
+++ b/tools/dev-tools/argon2-cffi.yaml
@@ -1,0 +1,28 @@
+name: argon2-cffi
+description: Python CFFI bindings for Argon2, the Password Hashing Competition winner. argon2-cffi hashes and verifies secrets with PHC strings so agent APIs can store credentials without a custom key-derivation stack.
+tagline: Argon2 password hashing for Python
+
+github_url: https://github.com/hynek/argon2-cffi
+website_url: https://argon2-cffi.readthedocs.io/
+docs_url: https://argon2-cffi.readthedocs.io/
+
+category: Dev Tools
+tags: [python, cryptography, password-hashing, argon2, security, authentication]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install argon2-cffi
+
+problem_solved: |
+  Agent dashboards, API keys, and user accounts need a slow, memory-hard hash so stolen
+  password databases are expensive to crack. MD5, SHA-1, and even unsalted SHA-256 are
+  too fast on GPUs. argon2-cffi wraps the Argon2 winner with a small Python API, PHC
+  string encoding, and verified CFFI bindings so you can hash, verify, and rehash
+  credentials without shipping a hand-rolled KDF.
+
+use_cases:
+  - Hash and verify user passwords for agent product dashboards and admin consoles
+  - Store API-token secrets with Argon2id so a leaked database is costly to brute-force
+  - Rehash credentials on login when Argon2 parameters (time, memory, parallelism) are raised
+  - Replace deprecated hashlib.pbkdf2_hmac stacks with a PHC-string compatible Argon2 API

--- a/tools/dev-tools/limits.yaml
+++ b/tools/dev-tools/limits.yaml
@@ -1,0 +1,27 @@
+name: limits
+description: Rate limiting for Python with sliding window, fixed window, and token bucket strategies. limits backs Flask-Limiter and SlowAPI so public agent APIs can throttle abuse across Redis, Memcached, MongoDB, or in-memory storage.
+tagline: Rate limiting strategies and storage backends for Python
+
+github_url: https://github.com/alisaifee/limits
+website_url: https://limits.readthedocs.org
+docs_url: https://limits.readthedocs.org
+
+category: Dev Tools
+tags: [python, rate-limiting, redis, memcached, api, throttling]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install limits
+
+problem_solved: |
+  Public LLM and agent endpoints get flooded by retries, scrapers, and runaway clients.
+  Rolling your own counters is error-prone across processes and restarts. limits provides
+  battle-tested window and bucket algorithms plus pluggable storage (Redis, Memcached,
+  MongoDB, memory) so you can enforce per-key quotas without writing a custom limiter.
+
+use_cases:
+  - Cap requests per API key on a FastAPI or Flask agent inference endpoint
+  - Share rate-limit state across workers with Redis or Memcached backends
+  - Apply sliding-window or token-bucket policies to webhook and tool-call traffic
+  - Power Flask-Limiter or SlowAPI with a storage-agnostic rate-limit core

--- a/tools/dev-tools/python-multipart.yaml
+++ b/tools/dev-tools/python-multipart.yaml
@@ -1,0 +1,27 @@
+name: python-multipart
+description: Streaming multipart/form-data parser for Python. python-multipart is the parser Starlette and FastAPI use to decode file uploads and form fields without loading entire request bodies into memory.
+tagline: Streaming multipart parser used by Starlette and FastAPI
+
+github_url: https://github.com/Kludex/python-multipart
+website_url: https://multipart.fastapiexpert.com/
+docs_url: https://multipart.fastapiexpert.com/
+
+category: Dev Tools
+tags: [python, multipart, form-data, file-upload, starlette, fastapi, http]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install python-multipart
+
+problem_solved: |
+  Agent apps accept file uploads, dataset CSVs, and form posts that can be larger than
+  RAM. Naive parsers buffer the whole body and blow memory. python-multipart streams
+  multipart/form-data as it arrives, which is why Starlette and FastAPI depend on it
+  for UploadFile and form parsing without loading entire requests into memory.
+
+use_cases:
+  - Parse file uploads on FastAPI endpoints that ingest PDFs, images, or training data
+  - Stream multipart form fields in Starlette apps without buffering the full body
+  - Decode mixed JSON-plus-file tool payloads sent as multipart/form-data
+  - Replace ad-hoc cgi.FieldStorage parsing with a maintained streaming parser

--- a/tools/vector-databases/cuvs.yaml
+++ b/tools/vector-databases/cuvs.yaml
@@ -1,0 +1,27 @@
+name: cuVS
+description: GPU library for vector search and clustering from NVIDIA RAPIDS. cuVS implements IVF, CAGRA, and other ANN indexes on CUDA so embedding retrieval and RAG pipelines can search millions of vectors on GPU.
+tagline: GPU-accelerated vector search and clustering from NVIDIA
+
+github_url: https://github.com/NVIDIA/cuvs
+website_url: https://docs.nvidia.com/cuvs/
+docs_url: https://docs.nvidia.com/cuvs/
+
+category: Vector DB
+tags: [vector-search, gpu, cuda, ann, embeddings, nvidia, rapids, clustering]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install cuvs-cu12
+
+problem_solved: |
+  CPU ANN indexes struggle when embedding collections grow into the tens of millions
+  and RAG latency budgets are tight. cuVS (formerly RAFT ANN) runs IVF-PQ, CAGRA, and
+  clustering kernels on NVIDIA GPUs so nearest-neighbor search, graph construction, and
+  vector clustering stay in device memory instead of bouncing through host-side indexes.
+
+use_cases:
+  - Build GPU ANN indexes (CAGRA, IVF-PQ) for low-latency embedding retrieval
+  - Accelerate RAG and semantic search over millions of vectors on CUDA hardware
+  - Cluster embedding collections on GPU for dataset dedup and exploration
+  - Integrate RAPIDS vector search into Python pipelines with the cuVS API

--- a/tools/vector-databases/pynndescent.yaml
+++ b/tools/vector-databases/pynndescent.yaml
@@ -1,0 +1,26 @@
+name: PyNNDescent
+description: Python nearest-neighbor descent for approximate k-NN graphs. PyNNDescent builds fast ANN indexes used by UMAP and clustering pipelines when exact nearest-neighbor search is too slow for large embedding sets.
+tagline: Approximate nearest neighbors via nearest-neighbor descent
+
+github_url: https://github.com/lmcinnes/pynndescent
+docs_url: https://github.com/lmcinnes/pynndescent
+
+category: Vector DB
+tags: [python, ann, nearest-neighbors, umap, embeddings, knn, clustering]
+pricing: free
+is_open_source: true
+license: BSD-2-Clause
+
+install_command: pip install pynndescent
+
+problem_solved: |
+  Exact k-NN over large embedding sets is O(n^2) and too slow for UMAP, HDBSCAN, and
+  custom retrieval. PyNNDescent implements nearest-neighbor descent to build approximate
+  k-NN graphs and query indexes in Python, which is why UMAP uses it as its default
+  neighbor backend for high-dimensional data.
+
+use_cases:
+  - Build approximate k-NN graphs for UMAP, clustering, and embedding visualization
+  - Query nearest neighbors over custom distance metrics beyond Euclidean cosine
+  - Index embedding collections in pure Python without a separate vector database
+  - Speed up neighbor search in scikit-learn-style ML pipelines on CPU


### PR DESCRIPTION
## Summary

Adds five catalog entries used in Python agent APIs, FastAPI stacks, and GPU/CPU nearest-neighbor search:

- **argon2-cffi** (Dev Tools) — Argon2 password hashing via CFFI (`hynek/argon2-cffi`, MIT, 731★)
- **limits** (Dev Tools) — Rate-limit strategies and storage backends (`alisaifee/limits`, MIT, 644★)
- **python-multipart** (Dev Tools) — Streaming multipart parser used by Starlette/FastAPI (`Kludex/python-multipart`, Apache-2.0, 532★)
- **cuVS** (Vector DB) — NVIDIA RAPIDS GPU vector search and clustering (`NVIDIA/cuvs`, Apache-2.0, 849★)
- **PyNNDescent** (Vector DB) — Approximate k-NN via nearest-neighbor descent (`lmcinnes/pynndescent`, BSD-2-Clause, 969★)

All five validated locally with `npx tsx scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added five tools to the catalog:
    - Argon2-CFFI for password hashing
    - Limits for rate limiting
    - Python-Multipart for multipart form-data parsing
    - cuVS for GPU-accelerated vector search and clustering
    - PyNNDescent for approximate nearest-neighbor search
  - Each entry includes installation details, project links, licensing, pricing, categories, tags, and practical use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->