### PR TITLE
Add rank-bm25, semchunk, Trafilatura, LayoutParser, Orbax to catalog

### DIFF
--- a/tools/data/layoutparser.yaml
+++ b/tools/data/layoutparser.yaml
@@ -1,0 +1,27 @@
+name: LayoutParser
+description: Unified Python toolkit for deep-learning document layout analysis. Detects text regions, tables, figures, and titles on page images so OCR and RAG pipelines can segment scanned PDFs before extraction.
+tagline: Deep learning layout analysis for document images
+
+github_url: https://github.com/Layout-Parser/layout-parser
+website_url: https://layout-parser.github.io/
+docs_url: https://layout-parser.readthedocs.io/
+
+category: Data
+tags: [document-layout, ocr, pdf, python, computer-vision, rag, extraction]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install layoutparser
+
+problem_solved: |
+  Scanned PDFs mix columns, tables, figures, and headers, so naive OCR dumps
+  reading order and loses structure. LayoutParser runs layout detection models
+  to find text blocks, tables, and figures first, then you OCR or extract only
+  the regions that matter for RAG and document pipelines.
+
+use_cases:
+  - Detect text, table, and figure regions on scanned PDF pages before OCR
+  - Segment multi-column scientific papers for structured RAG ingestion
+  - Extract tables from document images after layout detection
+  - Build a document understanding pipeline that preserves reading order

--- a/tools/data/trafilatura.yaml
+++ b/tools/data/trafilatura.yaml
@@ -1,0 +1,27 @@
+name: Trafilatura
+description: Python library and CLI that crawls the web and extracts main text plus metadata from HTML pages. Emits clean Markdown, JSON, CSV, XML, or TXT so RAG and dataset pipelines ingest article content instead of navigation boilerplate.
+tagline: Web text and metadata extraction for RAG and datasets
+
+github_url: https://github.com/adbar/trafilatura
+website_url: https://trafilatura.readthedocs.io
+docs_url: https://trafilatura.readthedocs.io
+
+category: Data
+tags: [web-scraping, extraction, python, rag, crawling, html, datasets]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install trafilatura
+
+problem_solved: |
+  Building a web corpus for RAG or training means stripping ads, nav, and scripts
+  from messy HTML. Trafilatura downloads pages, extracts the main body and metadata,
+  and writes clean Markdown or JSON so pipelines ingest article text instead of
+  boilerplate.
+
+use_cases:
+  - Extract main article text from news and blog URLs for a RAG knowledge base
+  - Crawl a site and export clean Markdown or JSON for dataset construction
+  - Pull titles, authors, and dates alongside body text for citation-aware retrieval
+  - Convert HTML dumps into TXT or XML for downstream NLP pipelines

--- a/tools/fine-tuning/orbax.yaml
+++ b/tools/fine-tuning/orbax.yaml
@@ -1,0 +1,27 @@
+name: Orbax
+description: Google checkpointing library for JAX that saves and restores partitioned model state with async I/O, transforms, and multi-host support. Lets large JAX training jobs resume cleanly without hand-rolled serialization.
+tagline: Checkpointing and persistence utilities for JAX training
+
+github_url: https://github.com/google/orbax
+website_url: https://orbax.readthedocs.io/
+docs_url: https://orbax.readthedocs.io/
+
+category: Fine-tuning
+tags: [jax, checkpointing, training, google, persistence, tpu, llm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install orbax-checkpoint
+
+problem_solved: |
+  JAX training on multi-host TPUs shards model state across devices, so naive
+  pickle dumps fail and restarts lose hours of work. Orbax writes and restores
+  partitioned checkpoints asynchronously, with transforms, so large JAX fine-tunes
+  can resume from the last step without custom serialization.
+
+use_cases:
+  - Save and restore sharded JAX model state during multi-host LLM training
+  - Resume a TPU fine-tune from the latest Orbax checkpoint after a preemption
+  - Apply checkpoint transforms when converting or exporting a JAX model
+  - Persist optimizer and train-state alongside weights for reproducible runs

--- a/tools/rag/rank-bm25.yaml
+++ b/tools/rag/rank-bm25.yaml
@@ -1,0 +1,26 @@
+name: rank-bm25
+description: Pure-Python BM25 library with BM25Okapi, BM25L, and BM25Plus scorers for ranking documents against a query. A tiny lexical retriever for hybrid RAG, search prototypes, and relevance ranking without Elasticsearch.
+tagline: Classic Python BM25 ranking without a search cluster
+
+github_url: https://github.com/dorianbrown/rank_bm25
+docs_url: https://github.com/dorianbrown/rank_bm25
+
+category: RAG
+tags: [bm25, retrieval, python, rag, lexical-search, ranking, hybrid-search]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install rank_bm25
+
+problem_solved: |
+  Hybrid RAG and search prototypes need a lexical scorer, but Elasticsearch
+  is heavy for in-process ranking and many BM25 ports are incomplete. rank-bm25
+  implements BM25Okapi, BM25L, and BM25Plus in a few hundred lines of Python so
+  you can score a query against a corpus without standing up a search cluster.
+
+use_cases:
+  - Rank document chunks by BM25 in a hybrid RAG pipeline beside vector search
+  - Prototype keyword retrieval for a local corpus without Elasticsearch
+  - Compare BM25Okapi, BM25L, and BM25Plus scoring on the same query set
+  - Add sparse lexical ranking to a Python search or QA service

--- a/tools/rag/semchunk.yaml
+++ b/tools/rag/semchunk.yaml
@@ -1,0 +1,26 @@
+name: semchunk
+description: Fast, lightweight Python library that splits text into semantically meaningful chunks using token counts and separator heuristics. Built for RAG pipelines that need embedding-sized windows without a heavy NLP tokenizer stack.
+tagline: Semantic text chunking for RAG without a heavy NLP stack
+
+github_url: https://github.com/isaacus-dev/semchunk
+docs_url: https://github.com/isaacus-dev/semchunk
+
+category: RAG
+tags: [chunking, rag, python, embeddings, tokenization, text-split]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install semchunk
+
+problem_solved: |
+  Naive character splits cut sentences mid-thought and hurt retrieval quality,
+  while full NLP tokenizers add latency and dependencies. semchunk splits on
+  semantic separators up to a token budget so RAG pipelines produce embedding-sized
+  chunks that stay readable and fit the model context window.
+
+use_cases:
+  - Chunk documentation and articles into embedding-sized windows for a vector index
+  - Split long transcripts or PDFs before feeding a RAG retriever
+  - Keep token-aware chunk sizes aligned to an embedding model's context limit
+  - Replace recursive character splitters with separator-aware semantic chunks


### PR DESCRIPTION
## Adds 5 tools to the catalog

- **rank-bm25** (RAG) — Pure-Python BM25Okapi/BM25L/BM25Plus ranking (`dorianbrown/rank_bm25`)
- **semchunk** (RAG) — Semantic token-aware text chunking (`isaacus-dev/semchunk`)
- **Trafilatura** (Data) — Web main-text and metadata extraction (`adbar/trafilatura`)
- **LayoutParser** (Data) — Document layout analysis for OCR/RAG (`Layout-Parser/layout-parser`)
- **Orbax** (Fine-tuning) — JAX checkpointing and persistence (`google/orbax`)

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for LayoutParser and Trafilatura, including descriptions, links, installation details, licensing, and use cases.
  * Added Orbax to the fine-tuning tools catalog with metadata covering checkpoint management for JAX workflows.
  * Added rank-bm25 and semchunk to the RAG tools catalog, including classification, installation information, and relevant use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->