### PR TITLE
Add Grain, Paxml, icefall, SeqIO, k2 to catalog

### DIFF
--- a/tools/fine-tuning/grain.yaml
+++ b/tools/fine-tuning/grain.yaml
@@ -1,0 +1,27 @@
+name: Grain
+description: Google library for reading and processing ML training data in JAX and PyTorch pipelines. Grain provides deterministic, parallel data loading, mixing, and transformations so large fine-tunes can iterate epochs without ad-hoc input pipelines.
+tagline: Deterministic data loading for JAX and PyTorch training
+
+github_url: https://github.com/google/grain
+website_url: https://google-grain.readthedocs.io
+docs_url: https://google-grain.readthedocs.io
+
+category: Fine-tuning
+tags: [jax, data-loading, training, google, pytorch, pipelines, llm]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install grain
+
+problem_solved: |
+  Large JAX and PyTorch fine-tunes need deterministic, restart-safe data loading
+  across hosts, but custom tf.data or PyTorch Dataset code is easy to get wrong
+  at scale. Grain reads, mixes, and transforms training data with parallel
+  workers so epochs stay reproducible when jobs preempt or shard across devices.
+
+use_cases:
+  - Build a deterministic JAX input pipeline for multi-host LLM fine-tuning
+  - Mix multiple datasets with Grain transformations before a training step
+  - Resume a preempted TPU job without reshuffling the epoch order
+  - Share a Grain data pipeline between JAX and PyTorch training code

--- a/tools/fine-tuning/icefall.yaml
+++ b/tools/fine-tuning/icefall.yaml
@@ -1,0 +1,25 @@
+name: icefall
+description: Training and decoding recipes for next-generation Kaldi speech recognition using k2, PyTorch, and Lhotse. icefall publishes end-to-end ASR, transducer, and LLM-related speech recipes that teams can adapt instead of assembling a stack from scratch.
+tagline: Next-gen Kaldi recipes for ASR training with k2 and PyTorch
+
+github_url: https://github.com/k2-fsa/icefall
+website_url: https://k2-fsa.github.io/icefall/
+docs_url: https://k2-fsa.github.io/icefall/
+
+category: Fine-tuning
+tags: [asr, speech, pytorch, k2, kaldi, training, recipes]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Training modern ASR models means wiring k2 graphs, PyTorch trainers, and
+  audio datasets together, which is slow to get right from a blank repo.
+  icefall ships ready recipes for transducers and related speech models so
+  teams can fine-tune and decode without rebuilding the Kaldi-next stack.
+
+use_cases:
+  - Fine-tune a transducer ASR model from an icefall recipe on your audio data
+  - Decode speech with k2-based graphs using published icefall checkpoints
+  - Adapt LibriSpeech or GigaSpeech recipes to a custom speech corpus
+  - Prototype LLM-related speech training without assembling k2 plumbing

--- a/tools/fine-tuning/k2.yaml
+++ b/tools/fine-tuning/k2.yaml
@@ -1,0 +1,27 @@
+name: k2
+description: Differentiable FSA and FST library with PyTorch compatibility for speech and sequence modeling. k2 implements GPU-friendly automata algorithms so ASR and decoding graphs can be trained and composed inside neural network pipelines.
+tagline: Differentiable FSA/FST algorithms with PyTorch support
+
+github_url: https://github.com/k2-fsa/k2
+website_url: https://k2-fsa.github.io/k2
+docs_url: https://k2-fsa.github.io/k2
+
+category: Fine-tuning
+tags: [fsa, fst, asr, pytorch, speech, decoding, graphs]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install k2
+
+problem_solved: |
+  Classic Kaldi FSTs sit outside the neural net, so lattice decoding and
+  graph training cannot backprop through the automaton. k2 implements
+  differentiable FSA/FST algorithms on GPU with PyTorch so ASR graphs can
+  be composed and trained as part of the model.
+
+use_cases:
+  - Train ASR models with differentiable WFST decoding graphs in PyTorch
+  - Compose FSA lattices for speech recognition without leaving the GPU
+  - Build icefall or next-gen Kaldi pipelines on k2 automata primitives
+  - Experiment with graph-based sequence losses for speech and NLP

--- a/tools/fine-tuning/paxml.yaml
+++ b/tools/fine-tuning/paxml.yaml
@@ -1,0 +1,26 @@
+name: Paxml
+description: JAX framework from Google for training large-scale models with configurable experiments and advanced parallelization. Paxml (Pax) targets high model-FLOP utilization on TPU and GPU pods for LLM pretraining and fine-tuning.
+tagline: JAX framework for large-scale model training at Google
+
+github_url: https://github.com/google/paxml
+docs_url: https://github.com/google/paxml
+
+category: Fine-tuning
+tags: [jax, llm, training, google, tpu, parallelization, pax]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install paxml
+
+problem_solved: |
+  Training LLMs on TPU or GPU pods needs partitioning, checkpointing, and
+  experiment config that ad-hoc JAX scripts rarely get right. Paxml (Pax)
+  is Google's JAX training framework with configurable experiments and
+  parallelization, aimed at high model-FLOP utilization for large runs.
+
+use_cases:
+  - Pretrain or fine-tune a large language model on TPU pods with Pax
+  - Configure multi-host parallelization without rewriting JAX sharding by hand
+  - Run ablation experiments with Paxml config instead of forked training scripts
+  - Benchmark model-FLOP utilization on GPU or TPU clusters

--- a/tools/fine-tuning/seqio.yaml
+++ b/tools/fine-tuning/seqio.yaml
@@ -1,0 +1,26 @@
+name: SeqIO
+description: Google library for task-based datasets, preprocessing, and evaluation for sequence models. SeqIO defines reusable tasks and mixtures so T5-style pretraining and fine-tuning share one pipeline for data, tokenization, and metrics.
+tagline: Task-based datasets and evaluation for sequence models
+
+github_url: https://github.com/google/seqio
+docs_url: https://github.com/google/seqio
+
+category: Fine-tuning
+tags: [seq2seq, t5, datasets, google, preprocessing, evaluation, jax]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install seqio
+
+problem_solved: |
+  Sequence-model fine-tunes need consistent tokenization, mixing, and eval
+  across tasks, but one-off tf.data scripts drift between experiments. SeqIO
+  defines tasks and mixtures with shared preprocessing and metrics so T5-style
+  training and evaluation stay comparable across runs.
+
+use_cases:
+  - Define a SeqIO task mixture for T5-style pretraining or fine-tuning
+  - Share tokenization and preprocessing across multiple sequence-model experiments
+  - Evaluate sequence models with the same SeqIO metrics used at train time
+  - Mix public and private text tasks into one deterministic training mixture


### PR DESCRIPTION
## Adds 5 tools to the catalog

- **Grain** (Fine-tuning) — Deterministic ML data loading for JAX/PyTorch (`google/grain`)
- **Paxml** (Fine-tuning) — JAX large-scale model training framework (`google/paxml`)
- **icefall** (Fine-tuning) — Next-gen Kaldi ASR recipes with k2/PyTorch (`k2-fsa/icefall`)
- **SeqIO** (Fine-tuning) — Task-based datasets and eval for sequence models (`google/seqio`)
- **k2** (Fine-tuning) — Differentiable FSA/FST library with PyTorch (`k2-fsa/k2`)

Local validation passed for all five YAML files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for Grain, icefall, k2, Paxml, and SeqIO.
  - Included descriptions, documentation and repository links, installation details, licensing, pricing, categories, and tags.
  - Added practical use cases covering data loading, speech recognition, sequence modeling, LLM training, evaluation, and experiment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->