### PR TITLE
Add HunyuanVideo, Mochi, Wan2.1, LTX-Video, sherpa-onnx to catalog

### DIFF
--- a/tools/other/hunyuanvideo.yaml
+++ b/tools/other/hunyuanvideo.yaml
@@ -1,0 +1,24 @@
+name: HunyuanVideo
+description: Tencent open video generation framework for large text-to-video and image-to-video models. HunyuanVideo publishes model weights, inference code, and a systematic training stack so teams can generate and fine-tune cinematic video without a closed API.
+tagline: Tencent large-scale open video generation framework
+
+github_url: https://github.com/Tencent-Hunyuan/HunyuanVideo
+website_url: https://aivideo.hunyuan.tencent.com
+docs_url: https://github.com/Tencent-Hunyuan/HunyuanVideo
+
+category: Other
+tags: [video-generation, text-to-video, tencent, diffusion, open-weights, hunyuan]
+pricing: free
+is_open_source: true
+
+problem_solved: |
+  High-quality video generation is often locked behind APIs with no weights
+  to fine-tune. HunyuanVideo open-sources a large video generation model plus
+  inference and training code so teams can run text-to-video and image-to-video
+  locally and adapt the model to their own footage.
+
+use_cases:
+  - Generate cinematic clips from text prompts with HunyuanVideo weights
+  - Run image-to-video synthesis from a still frame and a motion prompt
+  - Fine-tune an open video model on a custom visual style or product shots
+  - Compare open video generators against closed APIs on the same prompts

--- a/tools/other/ltx-video.yaml
+++ b/tools/other/ltx-video.yaml
@@ -1,0 +1,25 @@
+name: LTX-Video
+description: Open video generation model from Lightricks designed for fast, high-quality text-to-video and image-to-video. LTX-Video publishes inference code and weights so teams can generate clips locally with lower latency than typical diffusion video stacks.
+tagline: Fast open video generation from Lightricks
+
+github_url: https://github.com/Lightricks/LTX-Video
+website_url: https://ltx.io/model
+docs_url: https://github.com/Lightricks/LTX-Video
+
+category: Other
+tags: [video-generation, text-to-video, image-to-video, lightricks, diffusion, open-weights]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Diffusion video models are often too slow for interactive creative work, and
+  closed APIs hide the weights. LTX-Video is Lightricks' open model and
+  inference stack aimed at faster text-to-video and image-to-video so teams
+  can iterate locally without waiting on a vendor queue.
+
+use_cases:
+  - Generate video from text with LTX-Video at interactive-friendly latency
+  - Animate product stills into short clips with image-to-video
+  - Self-host an open video model inside a creative tooling pipeline
+  - Prototype video generation UX without a closed API dependency

--- a/tools/other/mochi.yaml
+++ b/tools/other/mochi.yaml
@@ -1,0 +1,24 @@
+name: Mochi
+description: Open-source video generation models from Genmo, including Mochi 1. The repo ships inference code and weights so builders can run high-quality text-to-video locally instead of depending on a closed video API.
+tagline: Open video generation models from Genmo
+
+github_url: https://github.com/genmoai/mochi
+docs_url: https://github.com/genmoai/mochi
+
+category: Other
+tags: [video-generation, text-to-video, genmo, diffusion, open-weights]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Most video generators are closed APIs, so you cannot inspect, self-host, or
+  fine-tune the model. Mochi from Genmo publishes open video generation weights
+  and inference code so teams can produce clips on their own GPUs and iterate
+  without a vendor lock-in.
+
+use_cases:
+  - Generate video clips from text prompts with Mochi 1 weights
+  - Self-host an open video model for internal creative pipelines
+  - Benchmark open text-to-video quality against closed APIs
+  - Adapt Genmo inference code for a custom video generation workflow

--- a/tools/other/sherpa-onnx.yaml
+++ b/tools/other/sherpa-onnx.yaml
@@ -1,0 +1,27 @@
+name: sherpa-onnx
+description: Offline speech toolkit from next-gen Kaldi using ONNX Runtime. sherpa-onnx covers speech-to-text, text-to-speech, diarization, VAD, and related tasks on servers, phones, and embedded boards without a network call.
+tagline: Offline speech AI with next-gen Kaldi and ONNX Runtime
+
+github_url: https://github.com/k2-fsa/sherpa-onnx
+website_url: https://k2-fsa.github.io/sherpa/onnx/index.html
+docs_url: https://k2-fsa.github.io/sherpa/onnx/index.html
+
+category: Other
+tags: [asr, tts, onnx, speech, offline, embedded, kaldi, vad]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install sherpa-onnx
+
+problem_solved: |
+  On-device and air-gapped apps need ASR, TTS, and VAD without sending audio
+  to a cloud API, but many speech stacks assume a server and a network.
+  sherpa-onnx runs next-gen Kaldi models through ONNX Runtime on servers,
+  phones, and boards so speech features work fully offline.
+
+use_cases:
+  - Run offline speech-to-text on a laptop, phone, or Raspberry Pi
+  - Add on-device TTS and VAD to an embedded or air-gapped application
+  - Deploy speaker diarization without sending audio to a cloud API
+  - Serve streaming ASR over websocket with sherpa-onnx on a local server

--- a/tools/other/wan2.1.yaml
+++ b/tools/other/wan2.1.yaml
@@ -1,0 +1,25 @@
+name: Wan2.1
+description: Open large-scale video generative models from Wan-Video, covering text-to-video and image-to-video. Wan2.1 publishes weights and inference code so teams can generate and extend video locally at production-oriented quality.
+tagline: Open advanced large-scale video generative models
+
+github_url: https://github.com/Wan-Video/Wan2.1
+website_url: https://wan.video
+docs_url: https://github.com/Wan-Video/Wan2.1
+
+category: Other
+tags: [video-generation, text-to-video, image-to-video, open-weights, wan]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Production video generation usually means a closed API with no weights to
+  self-host or customize. Wan2.1 open-sources large video models plus inference
+  so teams can run text-to-video and image-to-video on their own GPUs and
+  integrate generation into internal pipelines.
+
+use_cases:
+  - Generate video from text prompts with Wan2.1 open weights
+  - Animate a still image into a clip with image-to-video inference
+  - Self-host a large video model for a creative or product pipeline
+  - Compare Wan2.1 quality against other open video generators


### PR DESCRIPTION
## Adds 5 tools to the catalog

- **HunyuanVideo** (Other) — Tencent open large video generation (`Tencent-Hunyuan/HunyuanVideo`)
- **Mochi** (Other) — Genmo open video generation models (`genmoai/mochi`)
- **Wan2.1** (Other) — Open large-scale video generative models (`Wan-Video/Wan2.1`)
- **LTX-Video** (Other) — Fast open video generation from Lightricks (`Lightricks/LTX-Video`)
- **sherpa-onnx** (Other) — Offline speech with next-gen Kaldi and ONNX Runtime (`k2-fsa/sherpa-onnx`)

Local validation passed for all five YAML files.
