### PR TITLE
Add FireRedASR, newspaper3k, Lhotse, micrograd, Guild AI to catalog

### DIFF
--- a/tools/data/lhotse.yaml
+++ b/tools/data/lhotse.yaml
@@ -1,0 +1,27 @@
+name: Lhotse
+description: Python library for handling speech and multimodal data in ML projects. Lhotse provides manifests, cuts, and feature pipelines so ASR and audio model training can load, mix, and augment recordings without a custom dataset stack.
+tagline: Speech and multimodal data tools for ML training
+
+github_url: https://github.com/lhotse-speech/lhotse
+website_url: https://lhotse.readthedocs.io/en/latest/
+docs_url: https://lhotse.readthedocs.io/en/latest/
+
+category: Data
+tags: [speech, audio, datasets, asr, python, multimodal, training]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install lhotse
+
+problem_solved: |
+  Speech training needs manifests, cuts, features, and augmentation that
+  ad-hoc PyTorch Datasets rarely keep consistent. Lhotse standardizes audio
+  and multimodal data loading so ASR and related models can mix corpora,
+  extract features, and iterate without a one-off dataset layer.
+
+use_cases:
+  - Build Lhotse manifests and cuts for a custom ASR training corpus
+  - Mix public speech datasets with on-the-fly augmentation
+  - Feed icefall or k2 training recipes from a Lhotse data pipeline
+  - Extract audio features once and reuse them across training runs

--- a/tools/data/newspaper3k.yaml
+++ b/tools/data/newspaper3k.yaml
@@ -1,0 +1,26 @@
+name: newspaper3k
+description: Python 3 library for downloading, parsing, and extracting news articles plus metadata. newspaper3k pulls full text, authors, dates, and keywords from article URLs so RAG and dataset pipelines can ingest journalism without hand-written HTML scrapers.
+tagline: News article and metadata extraction for Python 3
+
+github_url: https://github.com/codelucas/newspaper
+docs_url: https://newspaper.readthedocs.io/
+
+category: Data
+tags: [nlp, news, extraction, python, scraping, metadata, rag]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install newspaper3k
+
+problem_solved: |
+  Building a news corpus means fetching pages and stripping chrome, authors,
+  and dates from inconsistent publisher HTML. newspaper3k downloads articles
+  and extracts full text plus metadata so RAG and NLP pipelines ingest
+  journalism instead of writing a scraper per site.
+
+use_cases:
+  - Extract full text and authors from a list of news article URLs
+  - Build a news corpus for RAG or NLP training from publisher pages
+  - Pull publish dates and keywords for citation-aware retrieval
+  - Monitor a set of news sites and parse new articles in Python

--- a/tools/fine-tuning/micrograd.yaml
+++ b/tools/fine-tuning/micrograd.yaml
@@ -1,0 +1,26 @@
+name: micrograd
+description: Tiny scalar-valued autograd engine and neural net library from Andrej Karpathy with a PyTorch-like API. micrograd is a teaching implementation of backpropagation so you can see how gradients flow before using a full framework.
+tagline: Tiny autograd engine for learning how neural nets train
+
+github_url: https://github.com/karpathy/micrograd
+docs_url: https://github.com/karpathy/micrograd
+
+category: Fine-tuning
+tags: [autograd, education, neural-nets, python, karpathy, backprop]
+pricing: free
+is_open_source: true
+license: MIT
+
+install_command: pip install micrograd
+
+problem_solved: |
+  Full frameworks hide autograd behind C++ kernels, which makes it hard to
+  learn how backprop actually updates weights. micrograd implements a scalar
+  autograd engine and a small neural net API so you can trace every gradient
+  before moving to PyTorch or JAX for real fine-tunes.
+
+use_cases:
+  - Teach backpropagation with a readable scalar autograd implementation
+  - Prototype a tiny neural net with a PyTorch-like API before scaling up
+  - Inspect gradient flow on toy losses without a full ML framework
+  - Use as a reference when debugging how a larger trainer computes grads

--- a/tools/monitoring/guild-ai.yaml
+++ b/tools/monitoring/guild-ai.yaml
@@ -1,0 +1,27 @@
+name: Guild AI
+description: Open-source experiment tracking and ML developer tools. Guild AI runs, compares, and reproduces training jobs from the command line so teams can track hyperparameters, metrics, and artifacts without a hosted MLOps SaaS.
+tagline: Experiment tracking and ML developer tools from the CLI
+
+github_url: https://github.com/guildai/guildai
+website_url: https://guild.ai
+docs_url: https://guild.ai
+
+category: Monitoring
+tags: [experiment-tracking, mlops, python, cli, reproducibility, metrics]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+install_command: pip install guildai
+
+problem_solved: |
+  Fine-tunes produce a mess of hyperparameters, metrics, and checkpoints that
+  notebooks rarely capture. Guild AI runs training as tracked experiments from
+  the CLI, compares runs, and reproduces jobs so teams keep a local history
+  without standing up a hosted tracking SaaS.
+
+use_cases:
+  - Track hyperparameters and metrics for LLM fine-tunes from the command line
+  - Compare training runs and promote the best checkpoint
+  - Reproduce an experiment by replaying a Guild AI run
+  - Keep local experiment history without a hosted MLOps dashboard

--- a/tools/other/fireredasr.yaml
+++ b/tools/other/fireredasr.yaml
@@ -1,0 +1,24 @@
+name: FireRedASR
+description: Open industrial-grade ASR models from FireRedTeam for Mandarin, Chinese dialects, and English. FireRedASR targets SOTA public Mandarin benchmarks and also handles singing lyrics, with inference code for production speech pipelines.
+tagline: Industrial open ASR for Mandarin, dialects, and English
+
+github_url: https://github.com/FireRedTeam/FireRedASR
+docs_url: https://github.com/FireRedTeam/FireRedASR
+
+category: Other
+tags: [asr, speech, mandarin, chinese, english, open-weights, lyrics]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Mandarin and dialect ASR often lags English cloud APIs, and singing lyrics
+  are even harder. FireRedASR open-sources industrial models that hit strong
+  Mandarin benchmarks and handle lyrics, so teams can run Chinese and English
+  speech-to-text without a closed vendor.
+
+use_cases:
+  - Transcribe Mandarin and Chinese dialect audio with an open ASR model
+  - Recognize English speech alongside Chinese in a bilingual pipeline
+  - Extract singing lyrics from music or karaoke audio
+  - Self-host industrial ASR instead of sending audio to a cloud API


### PR DESCRIPTION
## Adds 5 tools to the catalog

- **FireRedASR** (Other) — Industrial open ASR for Mandarin, dialects, English (`FireRedTeam/FireRedASR`)
- **newspaper3k** (Data) — News article and metadata extraction (`codelucas/newspaper`)
- **Lhotse** (Data) — Speech and multimodal data tools (`lhotse-speech/lhotse`)
- **micrograd** (Fine-tuning) — Tiny autograd engine from Karpathy (`karpathy/micrograd`)
- **Guild AI** (Monitoring) — Experiment tracking from the CLI (`guildai/guildai`)

Local validation passed for all five YAML files.
