### PR TITLE
Add Open-Sora, VideoCrafter, EasyAnimate, einops, safetensors to catalog

### DIFF
--- a/tools/dev-tools/einops.yaml
+++ b/tools/dev-tools/einops.yaml
@@ -1,0 +1,26 @@
+name: einops
+description: Tensor operation library that makes rearrange, reduce, repeat, pack, and einsum readable across NumPy, PyTorch, JAX, and other array backends with a single pattern syntax.
+tagline: Readable tensor ops for PyTorch, JAX, NumPy, and more
+
+github_url: https://github.com/arogozhnikov/einops
+website_url: https://einops.rocks
+docs_url: https://einops.rocks/
+install_command: pip install einops
+
+category: Dev Tools
+tags: [python, tensors, pytorch, jax, numpy, deep-learning, einsum]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Deep learning code is full of reshape, permute, squeeze, and concatenate calls that
+  hide axis intent and break when a tensor rank changes. einops replaces those with a
+  single pattern language so rearrange, reduce, repeat, pack, and einsum stay readable
+  and portable across NumPy, PyTorch, JAX, and other backends.
+
+use_cases:
+  - Rewrite messy PyTorch view and permute chains as a single rearrange pattern
+  - Pack tokens from mixed-rank tensors before a transformer block, then unpack them
+  - Write backend-agnostic tensor code that runs on NumPy, JAX, and PyTorch
+  - Teach or review model code where axis names are explicit in the operation

--- a/tools/dev-tools/safetensors.yaml
+++ b/tools/dev-tools/safetensors.yaml
@@ -1,0 +1,26 @@
+name: safetensors
+description: Fast, zero-copy tensor serialization format that stores model weights safely without pickle, used across Hugging Face Transformers, Diffusers, and local inference stacks.
+tagline: Safe, fast format for storing and sharing model tensors
+
+github_url: https://github.com/safetensors/safetensors
+website_url: https://huggingface.co/docs/safetensors
+docs_url: https://huggingface.co/docs/safetensors
+install_command: pip install safetensors
+
+category: Dev Tools
+tags: [python, tensors, serialization, huggingface, pytorch, security, model-weights]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Pickle-based weight files can execute arbitrary code on load, which is a supply-chain
+  risk when sharing checkpoints. safetensors is a simple tensor format that is not
+  executable, supports zero-copy loads, and has become the default way Hugging Face
+  and many inference stacks ship model weights.
+
+use_cases:
+  - Save and load PyTorch checkpoints without pickle execution risk
+  - Distribute Hugging Face model weights in the default safetensors format
+  - Memory-map large tensors and load only the slices needed on each GPU
+  - Convert legacy .bin or pickle weights to a safer sharing format

--- a/tools/other/easyanimate.yaml
+++ b/tools/other/easyanimate.yaml
@@ -1,0 +1,24 @@
+name: EasyAnimate
+description: Alibaba PAI end-to-end pipeline for high-resolution, long video generation using transformer diffusion, with training for DiT models, VAEs, LoRA, and bilingual text-to-video inference.
+tagline: Transformer pipeline for long, high-resolution AI video
+
+github_url: https://github.com/aigc-apps/EasyAnimate
+website_url: https://easyanimate.github.io/
+
+category: Other
+tags: [video-generation, text-to-video, diffusion-transformer, lora, alibaba, generative-ai]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Generating long, high-resolution video usually means stitching short clips or using
+  closed APIs with little training control. EasyAnimate is an open transformer-diffusion
+  pipeline that trains DiT generators and VAEs, supports LoRA and control signals, and
+  produces multi-second videos at multiple resolutions from Chinese or English prompts.
+
+use_cases:
+  - Generate multi-second high-resolution videos from bilingual text prompts
+  - Train a LoRA or baseline EasyAnimate model for a custom visual style
+  - Control generated video with pose, canny, trajectory, or camera signals
+  - Run EasyAnimate weights through Hugging Face Diffusers for inference

--- a/tools/other/open-sora.yaml
+++ b/tools/other/open-sora.yaml
@@ -1,0 +1,24 @@
+name: Open-Sora
+description: Open-source video generation stack from HPC-AI Tech that trains and runs high-quality text-to-video models with a public pipeline for data, training, and inference.
+tagline: Open-source pipeline for efficient high-quality video generation
+
+github_url: https://github.com/hpcaitech/Open-Sora
+website_url: https://hpcaitech.github.io/Open-Sora/
+
+category: Other
+tags: [video-generation, text-to-video, diffusion, open-source, pytorch, generative-ai]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  High-quality video generation has been locked behind closed models with no public
+  training recipes, data pipelines, or inference code. Open-Sora publishes an end-to-end
+  open stack so researchers and builders can train, fine-tune, and run video models
+  themselves instead of depending on proprietary APIs.
+
+use_cases:
+  - Generate text-to-video clips locally with published Open-Sora checkpoints
+  - Train or fine-tune a video diffusion model on a custom dataset
+  - Reproduce open video-generation research without a closed commercial API
+  - Prototype cinematic or product videos before moving to a production model

--- a/tools/other/videocrafter.yaml
+++ b/tools/other/videocrafter.yaml
@@ -1,0 +1,23 @@
+name: VideoCrafter
+description: Open-source video generation toolbox with text-to-video and image-to-video diffusion models for high-quality clips, including VideoCrafter2 for stronger motion and concept mixing.
+tagline: Open toolbox for text-to-video and image-to-video diffusion
+
+github_url: https://github.com/AILab-CVC/VideoCrafter
+website_url: https://ailab-cvc.github.io/videocrafter2/
+
+category: Other
+tags: [video-generation, text-to-video, image-to-video, diffusion, generative-ai, pytorch]
+pricing: free
+is_open_source: true
+
+problem_solved: |
+  Most video diffusion models either need huge proprietary datasets or produce weak
+  motion and poor concept combinations. VideoCrafter is an open toolbox that ships
+  text-to-video and image-to-video models, including VideoCrafter2, which improves
+  motion quality and concept mixing even when training data is limited.
+
+use_cases:
+  - Generate short videos from text prompts with open VideoCrafter checkpoints
+  - Animate a still image into a coherent video clip with the image-to-video model
+  - Combine artistic styles and subjects in generated video without a closed API
+  - Benchmark open video diffusion quality against later text-to-video systems


### PR DESCRIPTION
## Add 5 tools to the catalog

- **Open-Sora** (Other) — HPC-AI Tech open video generation stack. https://github.com/hpcaitech/Open-Sora
- **VideoCrafter** (Other) — open text-to-video and image-to-video toolbox. https://github.com/AILab-CVC/VideoCrafter
- **EasyAnimate** (Other) — Alibaba PAI transformer pipeline for long high-res video. https://github.com/aigc-apps/EasyAnimate
- **einops** (Dev Tools) — readable tensor ops across PyTorch/JAX/NumPy. https://github.com/arogozhnikov/einops
- **safetensors** (Dev Tools) — safe, zero-copy tensor serialization. https://github.com/safetensors/safetensors

Open-Sora is distinct from the existing OpenAI Sora entry.

Local validation: all 5 YAML files passed `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog listings for tensor-processing and secure model-checkpoint tools.
  * Added entries for open-source video-generation tools supporting text-to-video, image-to-video, animation, control signals, and benchmarking.
  * Included discoverability details such as descriptions, categories, tags, project links, licensing, pricing, installation guidance, and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->