### PR TITLE
Add python-jose, blinker, dnspython, slowapi, mashumaro to catalog

### DIFF
--- a/tools/data/mashumaro.yaml
+++ b/tools/data/mashumaro.yaml
@@ -1,0 +1,27 @@
+name: mashumaro
+description: Fast Python serialization library for dataclasses that converts objects to JSON, YAML, MessagePack, and dicts with type-safe compile-time codegen instead of runtime reflection.
+tagline: Fast dataclass serialization for JSON, YAML, and MessagePack
+
+github_url: https://github.com/Fatal1ty/mashumaro
+website_url: https://mashumaro.io
+docs_url: https://mashumaro.io
+install_command: pip install mashumaro
+
+category: Data
+tags: [python, serialization, dataclasses, json, yaml, messagepack]
+pricing: free
+is_open_source: true
+license: Apache-2.0
+
+problem_solved: |
+  Runtime serializers that inspect types on every dump and load are slow and
+  easy to misconfigure. mashumaro generates serialization code for dataclasses
+  so JSON, YAML, MessagePack, and dict conversions stay type-safe and fast,
+  which helps data pipelines and API payloads that move lots of structured
+  records.
+
+use_cases:
+  - Serialize dataclass records to JSON in a high-throughput data pipeline
+  - Load YAML or MessagePack configs into typed Python dataclasses
+  - Replace slower runtime serializers in an ML feature or job payload path
+  - Round-trip nested dataclasses between services without a heavy ORM

--- a/tools/dev-tools/blinker.yaml
+++ b/tools/dev-tools/blinker.yaml
@@ -1,0 +1,26 @@
+name: blinker
+description: Fast in-process Python signal and event dispatching library used by Flask and other Pallets projects to connect senders to named signals without tight coupling.
+tagline: In-process Python signals for decoupled event dispatch
+
+github_url: https://github.com/pallets-eco/blinker
+website_url: https://blinker.readthedocs.io
+docs_url: https://blinker.readthedocs.io
+install_command: pip install blinker
+
+category: Dev Tools
+tags: [python, signals, events, flask, pallets, pubsub]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  Python apps often need hooks so one module can react when another does work,
+  without importing each other. blinker provides named signals with send and
+  connect so Flask, ML services, and libraries can dispatch in-process events
+  without a message broker or circular imports.
+
+use_cases:
+  - Hook request start and finish callbacks in a Flask-style web app
+  - Notify metrics or logging code when a model inference job completes
+  - Let plugins subscribe to named signals without modifying core modules
+  - Replace ad-hoc callback lists with a small, tested dispatcher

--- a/tools/dev-tools/dnspython.yaml
+++ b/tools/dev-tools/dnspython.yaml
@@ -1,0 +1,25 @@
+name: dnspython
+description: Powerful DNS toolkit for Python that queries, constructs, and serves DNS records, including async support, used for lookups, zone work, and DNS-based service discovery.
+tagline: Full-featured DNS toolkit for Python applications
+
+github_url: https://github.com/rthalley/dnspython
+website_url: https://www.dnspython.org
+docs_url: https://dnspython.readthedocs.io
+install_command: pip install dnspython
+
+category: Dev Tools
+tags: [python, dns, networking, async, service-discovery]
+pricing: free
+is_open_source: true
+
+problem_solved: |
+  Many Python services need more than a single hostname lookup: MX records,
+  TXT verification, SRV discovery, or custom resolvers. dnspython is a full DNS
+  toolkit that queries and constructs records, talks to resolvers, and supports
+  async I/O so apps can do real DNS work without shelling out to dig.
+
+use_cases:
+  - Resolve MX, TXT, and SRV records for email or service discovery
+  - Verify domain ownership via DNS TXT records in an auth or SaaS flow
+  - Build a custom resolver or stub client inside a Python network service
+  - Look up DNS records asynchronously in FastAPI or asyncio workers

--- a/tools/dev-tools/python-jose.yaml
+++ b/tools/dev-tools/python-jose.yaml
@@ -1,0 +1,26 @@
+name: python-jose
+description: Python JOSE library for JWT, JWS, JWE, and JWK that signs, encrypts, and verifies tokens with HMAC, RSA, and ECDSA backends used in API auth.
+tagline: JOSE JWT, JWS, JWE, and JWK implementation for Python
+
+github_url: https://github.com/mpdavis/python-jose
+website_url: https://python-jose.readthedocs.io
+docs_url: https://python-jose.readthedocs.io
+install_command: pip install python-jose
+
+category: Dev Tools
+tags: [python, jwt, jose, jws, jwe, authentication, security]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  API services need to sign and verify JSON Web Tokens without pulling in a full
+  identity platform. python-jose implements JOSE standards in Python so you can
+  create, encrypt, and verify JWT, JWS, JWE, and JWK payloads with HMAC, RSA, and
+  ECDSA backends in auth middleware and service-to-service calls.
+
+use_cases:
+  - Issue and verify JWT access tokens in a Python API
+  - Encrypt sensitive claims with JWE before storing or sending them
+  - Rotate signing keys using JWK sets in a multi-service auth setup
+  - Decode and validate tokens from an OAuth or OIDC identity provider

--- a/tools/dev-tools/slowapi.yaml
+++ b/tools/dev-tools/slowapi.yaml
@@ -1,0 +1,26 @@
+name: slowapi
+description: Rate limiter for Starlette and FastAPI, based on limits, that caps requests by IP, key, or route using in-memory or Redis storage to protect APIs from abuse.
+tagline: Rate limiting for FastAPI and Starlette APIs
+
+github_url: https://github.com/laurentS/slowapi
+website_url: https://pypi.org/project/slowapi/
+docs_url: https://github.com/laurentS/slowapi
+install_command: pip install slowapi
+
+category: Dev Tools
+tags: [python, fastapi, starlette, rate-limiting, redis, api]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  FastAPI and Starlette apps need request throttling but Flask-Limiter does not
+  plug in cleanly. slowapi brings limits-based rate limiting to ASGI, so you can
+  cap traffic by IP, user, or route with in-memory or Redis backends and return
+  standard 429 responses without writing custom middleware.
+
+use_cases:
+  - Limit login and signup endpoints to stop brute-force attempts
+  - Cap expensive LLM or embedding routes per API key
+  - Share rate-limit counters across workers with a Redis backend
+  - Decorate FastAPI routes with per-route request quotas


### PR DESCRIPTION
## Add 5 tools to the catalog

- **python-jose** (Dev Tools) — JOSE/JWT/JWS/JWE library. https://github.com/mpdavis/python-jose
- **blinker** (Dev Tools) — in-process Python signals. https://github.com/pallets-eco/blinker
- **dnspython** (Dev Tools) — DNS toolkit for Python. https://github.com/rthalley/dnspython
- **slowapi** (Dev Tools) — rate limiter for FastAPI/Starlette. https://github.com/laurentS/slowapi
- **mashumaro** (Data) — fast dataclass serialization. https://github.com/Fatal1ty/mashumaro

python-jose is distinct from existing PyJWT. mashumaro is distinct from existing marshmallow.

Local validation: all 5 YAML files passed `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added catalog metadata for Mashumaro, including installation details, links, licensing, tags, and use cases.
  * Added developer-tool entries for Blinker, dnspython, python-jose, and slowapi.
  * Included descriptions, categories, pricing and open-source information, setup commands, project resources, problem statements, and representative use cases for each newly documented tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->