### PR TITLE
Add colorama, MarkupSafe, aiosqlite to catalog

### DIFF
--- a/tools/data/aiosqlite.yaml
+++ b/tools/data/aiosqlite.yaml
@@ -1,0 +1,26 @@
+name: aiosqlite
+description: Asyncio bridge to Python's sqlite3 module that runs SQLite operations on a background thread so FastAPI and asyncio apps can query local databases without blocking the event loop.
+tagline: Async SQLite access for Python asyncio applications
+
+github_url: https://github.com/omnilib/aiosqlite
+website_url: https://aiosqlite.omnilib.dev
+docs_url: https://aiosqlite.omnilib.dev
+install_command: pip install aiosqlite
+
+category: Data
+tags: [python, sqlite, asyncio, async, database, fastapi]
+pricing: free
+is_open_source: true
+license: MIT
+
+problem_solved: |
+  The stdlib sqlite3 API is synchronous, so calling it from asyncio blocks the
+  event loop. aiosqlite wraps sqlite3 on a worker thread and exposes awaitable
+  connections, cursors, and transactions so FastAPI and other async apps can
+  use a local SQLite file without stalling concurrent requests.
+
+use_cases:
+  - Query a local SQLite database from FastAPI without blocking the event loop
+  - Store agent memory or job state in SQLite inside an asyncio worker
+  - Run migrations and transactions with async context managers
+  - Prototype an async data layer before moving to a networked SQL backend

--- a/tools/dev-tools/colorama.yaml
+++ b/tools/dev-tools/colorama.yaml
@@ -1,0 +1,25 @@
+name: colorama
+description: Cross-platform Python library that makes ANSI color and style codes work on Windows terminals as well as Unix, used by CLIs, test runners, and logging tools.
+tagline: Colored terminal text that works on Windows and Unix
+
+github_url: https://github.com/tartley/colorama
+website_url: https://pypi.org/project/colorama/
+install_command: pip install colorama
+
+category: Dev Tools
+tags: [python, cli, terminal, color, windows, logging]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  ANSI color codes work on Unix terminals but are ignored or printed as garbage
+  on Windows consoles. colorama wraps stdout and stderr so the same color and
+  style sequences work across platforms, which is why so many Python CLIs and
+  test tools depend on it for readable terminal output.
+
+use_cases:
+  - Colorize CLI status, errors, and progress on Windows and Unix
+  - Add ANSI styles to logging output in a cross-platform Python tool
+  - Keep test-runner failure output readable in cmd.exe and PowerShell
+  - Wrap stdout in a library so downstream CLIs get color without OS checks

--- a/tools/dev-tools/markupsafe.yaml
+++ b/tools/dev-tools/markupsafe.yaml
@@ -1,0 +1,26 @@
+name: MarkupSafe
+description: Pallets library that escapes untrusted strings for HTML and XML and implements a Markup type so Jinja2 and Flask can mix safe markup with autoescaped text.
+tagline: Safe HTML and XML escaping for Python web templates
+
+github_url: https://github.com/pallets/markupsafe
+website_url: https://markupsafe.palletsprojects.com
+docs_url: https://markupsafe.palletsprojects.com
+install_command: pip install MarkupSafe
+
+category: Dev Tools
+tags: [python, html, xml, escaping, jinja2, flask, security]
+pricing: free
+is_open_source: true
+license: BSD-3-Clause
+
+problem_solved: |
+  Injecting user text into HTML or XML without escaping causes XSS. MarkupSafe
+  provides a fast C-accelerated escape function and a Markup type so Jinja2,
+  Flask, and other Python web stacks can mark trusted fragments as safe while
+  autoescaping everything else.
+
+use_cases:
+  - Escape user-supplied strings before inserting them into HTML templates
+  - Mark trusted HTML fragments as safe Markup in a Jinja2 template
+  - Power Flask and Jinja2 autoescaping without a slower pure-Python escape
+  - Sanitize XML text nodes in a Python reporting or feed generator


### PR DESCRIPTION
## Add 3 tools to the catalog

- **colorama** (Dev Tools) — cross-platform colored terminal text. https://github.com/tartley/colorama
- **MarkupSafe** (Dev Tools) — HTML/XML escaping used by Jinja2 and Flask. https://github.com/pallets/markupsafe
- **aiosqlite** (Data) — asyncio bridge to sqlite3. https://github.com/omnilib/aiosqlite

Remainder batch after the previous 5-tool PR. Distinct from existing SQLite and sqlite-vec entries.

Local validation: all 3 YAML files passed `scripts/validate-tool.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog entries for `aiosqlite`, including async SQLite access, installation details, licensing, and practical use cases.
  - Added `colorama` metadata covering cross-platform terminal color support, setup information, and example uses.
  - Added `MarkupSafe` metadata describing safe HTML/XML escaping, installation details, licensing, and integration use cases.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->